### PR TITLE
Add assemble_bytes

### DIFF
--- a/rspirv/binary/assemble.rs
+++ b/rspirv/binary/assemble.rs
@@ -22,8 +22,7 @@ pub trait Assemble {
     fn assemble(&self) -> Vec<u32>;
     fn assemble_bytes(&self) -> Vec<u8> {
         use std::mem;
-        b.module()
-            .assemble()
+        self.assemble()
             .iter()
             .flat_map(|val| {
                 (0..mem::size_of::<u32>()).map(move |i| ((val >> (8 * i)) & 0xff) as u8)

--- a/rspirv/binary/assemble.rs
+++ b/rspirv/binary/assemble.rs
@@ -21,6 +21,7 @@ pub trait Assemble {
     /// Assembles the current object and returns the binary code.
     fn assemble(&self) -> Vec<u32>;
     fn assemble_bytes(&self) -> Vec<u8> {
+        use std::mem;
         b.module()
             .assemble()
             .iter()

--- a/rspirv/binary/assemble.rs
+++ b/rspirv/binary/assemble.rs
@@ -20,6 +20,15 @@ use utils::num::{bytes_to_u32_le, f32_to_u32};
 pub trait Assemble {
     /// Assembles the current object and returns the binary code.
     fn assemble(&self) -> Vec<u32>;
+    fn assemble_bytes(&self) -> Vec<u8> {
+        b.module()
+            .assemble()
+            .iter()
+            .flat_map(|val| {
+                (0..mem::size_of::<u32>()).map(move |i| ((val >> (8 * i)) & 0xff) as u8)
+            })
+            .collect()
+    }
 }
 
 impl Assemble for mr::ModuleHeader {


### PR DESCRIPTION
Adds

```
pub trait Assemble {
    /// Assembles the current object and returns the binary code.
    fn assemble(&self) -> Vec<u32>;
    fn assemble_bytes(&self) -> Vec<u8> {
        use std::mem;
        self.assemble()
            .iter()
            .flat_map(|val| {
                (0..mem::size_of::<u32>()).map(move |i| ((val >> (8 * i)) & 0xff) as u8)
            })
            .collect()
    }
}
```

I think it would be useful to directly output the byte code.