### PR TITLE
Add codegen dependency to rspirv

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,6 +239,7 @@ dependencies = [
  "clippy 0.0.302 (registry+https://github.com/rust-lang/crates.io-index)",
  "derive_more 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rspirv-codegen 0.1.0",
  "spirv_headers 1.3.4",
 ]
 

--- a/rspirv/Cargo.toml
+++ b/rspirv/Cargo.toml
@@ -22,10 +22,12 @@ num = "0.2"
 derive_more = "0.7"
 clippy = { version = "0.0", optional = true }
 
-
 [dependencies.spirv_headers]
 version = "1.3"
 path = "../spirv"
+
+[build-dependencies]
+rspirv-codegen = { path = "../codegen", version = "0.1" }
 
 [dev-dependencies]
 assert_matches = "1.1"


### PR DESCRIPTION
The problem it's trying to solve is: when `codegen` is changed, cargo still tries to build it *after* rspirv crate, so quite often another build is required for the "rspirv" to get the latest "codegen" changes. Establishing a dependency solves it.

The downside, I think, is that it requires codegen to be built by all the clients. I don't know what the best way to address this would be. cc @grovesNL 