### PR TITLE
Update all crates to edition 2018

### DIFF
--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rspirv-codegen"
 version = "0.1.0"
 authors = ["Lei Zhang <antiagainst@gmail.com>"]
+edition = "2018"
 
 build = "build.rs"
 publish = false

--- a/codegen/binary.rs
+++ b/codegen/binary.rs
@@ -12,9 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use structs;
-
-use utils::*;
+use crate::structs;
+use crate::utils::*;
 
 /// Returns the name of the method for decoding the given operand `kind`
 /// in grammar.

--- a/codegen/build.rs
+++ b/codegen/build.rs
@@ -12,15 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-extern crate proc_macro2;
-#[macro_use]
-extern crate quote;
-extern crate regex;
-extern crate serde;
-#[macro_use]
-extern crate serde_derive;
-extern crate serde_json;
-
 mod binary;
 mod header;
 mod mr;

--- a/codegen/header.rs
+++ b/codegen/header.rs
@@ -12,9 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use structs;
-
-use utils::*;
+use crate::structs;
+use crate::utils::*;
 
 static VAULE_ENUM_ATTRIBUTE: &'static str = "\
 #[repr(u32)]\n#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, FromPrimitive, Hash)]";

--- a/codegen/mr.rs
+++ b/codegen/mr.rs
@@ -12,9 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use structs;
-
-use utils::*;
+use crate::structs;
+use crate::utils::*;
 
 /// Returns true if the given operand kind can potentially have additional
 /// parameters.

--- a/codegen/sr.rs
+++ b/codegen/sr.rs
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use regex;
-use structs;
-use utils::*;
+use crate::structs;
+use crate::utils::*;
 
 use proc_macro2::{Ident, Span, TokenStream};
+use quote::quote;
 
 /// Returns the corresponding Rust type used in structured representation
 /// for the given operand kind in the SPIR-V JSON grammar.
@@ -84,6 +84,7 @@ pub fn gen_sr_decoration(grammar: &structs::Grammar) -> String {
         })
         .collect();
     let tokens = quote! {
+        use derive_more::From;
         use spirv;
 
         /// SPIR-V decorations.
@@ -197,7 +198,7 @@ pub fn gen_sr_type_check(grammar: &structs::Grammar) -> String {
         .collect();
     let tokens = quote! {
         #[derive(Clone, Debug, PartialEq, Eq)]
-        pub (in sr) enum TypeEnum {
+        pub (in crate::sr) enum TypeEnum {
             #( #types ),*
         }
 

--- a/codegen/structs.rs
+++ b/codegen/structs.rs
@@ -15,6 +15,7 @@
 /// Rust structs for deserializing the SPIR-V JSON grammar.
 
 use serde::de;
+use serde_derive::*;
 use std::{fmt, result, str};
 
 #[derive(Debug, Deserialize)]

--- a/codegen/table.rs
+++ b/codegen/table.rs
@@ -12,9 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use structs;
-
-use utils::*;
+use crate::structs;
+use crate::utils::*;
 
 fn convert_quantifier(quantifier: &str) -> &str {
     if quantifier == "" {

--- a/codegen/utils.rs
+++ b/codegen/utils.rs
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use regex;
-use structs;
+use crate::structs;
 
 use std::fs;
 use std::io::Write;

--- a/dis/Cargo.toml
+++ b/dis/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rspirv-dis"
 version = "0.1.0"
 authors = ["Lei Zhang <antiagainst@gmail.com>"]
+edition = "2018"
 
 description = "SPIR-V module disassembler"
 repository = "https://github.com/gfx-rs/rspirv"

--- a/dis/main.rs
+++ b/dis/main.rs
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-extern crate clap;
-extern crate rspirv;
-
 use std::fs;
 use std::io::Read;
 

--- a/rspirv/Cargo.toml
+++ b/rspirv/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rspirv"
 version = "0.5.4"
 authors = ["Lei Zhang <antiagainst@gmail.com>"]
+edition = "2018"
 
 description = "Rust library APIs for SPIR-V module manipulation"
 documentation = "https://docs.rs/rspirv"

--- a/rspirv/binary/assemble.rs
+++ b/rspirv/binary/assemble.rs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use mr;
+use crate::mr;
 
-use utils::num::{bytes_to_u32_le, f32_to_u32};
+use crate::utils::num::{bytes_to_u32_le, f32_to_u32};
 
 /// Trait for assembling functionalities.
 pub trait Assemble {
@@ -152,10 +152,10 @@ impl Assemble for mr::Module {
 
 #[cfg(test)]
 mod tests {
-    use mr;
-    use spirv;
+    use crate::mr;
+    use crate::spirv;
 
-    use binary::Assemble;
+    use crate::binary::Assemble;
     use super::{assemble_str, bytes_to_u32_le};
 
     #[test]

--- a/rspirv/binary/decoder.rs
+++ b/rspirv/binary/decoder.rs
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use spirv;
+use crate::spirv;
 
 use std::{mem, result};
 use super::DecodeError as Error;
 
-use utils::num::u32_to_bytes;
+use crate::utils::num::u32_to_bytes;
 
 pub type Result<T> = result::Result<T, Error>;
 
@@ -232,13 +232,13 @@ include!("autogen_decode_operand.rs");
 
 #[cfg(test)]
 mod tests {
-    use spirv;
+    use crate::spirv;
 
     use super::Decoder;
-    use binary::DecodeError as Error;
+    use crate::binary::DecodeError as Error;
 
-    use utils::num::f32_to_bytes;
-    use utils::num::f64_to_bytes;
+    use crate::utils::num::f32_to_bytes;
+    use crate::utils::num::f64_to_bytes;
 
     #[test]
     fn test_decoding_word_from_one_bytes() {

--- a/rspirv/binary/disassemble.rs
+++ b/rspirv/binary/disassemble.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use mr;
-use spirv;
+use crate::mr;
+use crate::spirv;
 
 use super::tracker;
 
@@ -205,10 +205,10 @@ fn disas_ext_inst(inst: &mr::Instruction,
 
 #[cfg(test)]
 mod tests {
-    use mr;
-    use spirv;
+    use crate::mr;
+    use crate::spirv;
 
-    use binary::Disassemble;
+    use crate::binary::Disassemble;
 
     #[test]
     fn test_disassemble_operand_function_control() {

--- a/rspirv/binary/parser.rs
+++ b/rspirv/binary/parser.rs
@@ -310,7 +310,7 @@ impl<'c, 'd> Parser<'c, 'd> {
                         return Err(State::HeaderIncorrect);
                     }
                 }
-                
+
                 let mut header = mr::ModuleHeader::new(words[3]);
                 let (major, minor) = version::create_version_from_word(words[1]);
                 header.set_version(major, minor);
@@ -451,6 +451,8 @@ include!("autogen_parse_operand.rs");
 
 #[cfg(test)]
 mod tests {
+    use assert_matches::assert_matches;
+
     use crate::mr;
     use crate::spirv;
 

--- a/rspirv/binary/tracker.rs
+++ b/rspirv/binary/tracker.rs
@@ -12,14 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use mr;
-use grammar;
-use spirv;
+use crate::mr;
+use crate::grammar;
+use crate::spirv;
 
 use std::collections;
 
-use grammar::GlslStd450InstructionTable as GGlInstTable;
-use grammar::OpenCLStd100InstructionTable as GClInstTable;
+use crate::grammar::GlslStd450InstructionTable as GGlInstTable;
+use crate::grammar::OpenCLStd100InstructionTable as GClInstTable;
 
 type GExtInstRef = &'static grammar::ExtendedInstruction<'static>;
 

--- a/rspirv/grammar/reflect.rs
+++ b/rspirv/grammar/reflect.rs
@@ -14,7 +14,7 @@
 
 //! Reflect functions for SPIR-V instructions.
 
-use spirv;
+use crate::spirv;
 
 /// Returns true if the given opcode is for a location debug instruction.
 pub fn is_location_debug(opcode: spirv::Op) -> bool {

--- a/rspirv/grammar/syntax.rs
+++ b/rspirv/grammar/syntax.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use spirv;
+use crate::spirv;
 
 /// Grammar for a SPIR-V instruction.
 #[derive(Debug, PartialEq, Eq, Hash)]

--- a/rspirv/lib.rs
+++ b/rspirv/lib.rs
@@ -97,12 +97,6 @@
 #![cfg_attr(feature = "clippy", feature(plugin))]
 #![cfg_attr(feature = "clippy", plugin(clippy))]
 
-#[cfg(test)]
-#[macro_use]
-extern crate assert_matches;
-#[macro_use]
-extern crate derive_more;
-extern crate num;
 extern crate spirv_headers as spirv;
 
 pub mod binary;

--- a/rspirv/mr/build/mod.rs
+++ b/rspirv/mr/build/mod.rs
@@ -14,8 +14,8 @@
 
 #![cfg_attr(feature = "clippy", allow(too_many_arguments))]
 
-use mr;
-use spirv;
+use crate::mr;
+use crate::spirv;
 
 use std::result;
 use super::Error;
@@ -550,13 +550,13 @@ include!("autogen_norm_insts.rs");
 
 #[cfg(test)]
 mod tests {
-    use mr;
-    use spirv;
+    use crate::mr;
+    use crate::spirv;
 
     use std::f32;
     use super::Builder;
 
-    use binary::Disassemble;
+    use crate::binary::Disassemble;
 
     fn has_only_one_global_inst(module: &mr::Module) -> bool {
         if !module.functions.is_empty() {

--- a/rspirv/mr/constructs.rs
+++ b/rspirv/mr/constructs.rs
@@ -19,6 +19,8 @@ use crate::spirv::Word;
 use crate::utils::version;
 use std::{convert, fmt};
 
+use derive_more::From;
+
 /// Data representation of a SPIR-V module.
 ///
 /// Most of the fields are just vectors of `Instruction`s, but some fields

--- a/rspirv/mr/constructs.rs
+++ b/rspirv/mr/constructs.rs
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use grammar;
-use spirv;
+use crate::grammar;
+use crate::spirv;
 
-use spirv::Word;
-use utils::version;
+use crate::spirv::Word;
+use crate::utils::version;
 use std::{convert, fmt};
 
 /// Data representation of a SPIR-V module.
@@ -245,8 +245,8 @@ impl convert::From<u32> for Operand {
 
 #[cfg(test)]
 mod tests {
-    use mr;
-    use spirv;
+    use crate::mr;
+    use crate::spirv;
 
     #[test]
     fn test_convert_from_string() {

--- a/rspirv/mr/loader.rs
+++ b/rspirv/mr/loader.rs
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use binary;
-use mr;
-use spirv;
-use grammar;
+use crate::binary;
+use crate::mr;
+use crate::spirv;
+use crate::grammar;
 
-use binary::{ParseAction, ParseResult};
+use crate::binary::{ParseAction, ParseResult};
 use std::{error, fmt};
 
 /// Data representation loading errors.
@@ -274,8 +274,8 @@ pub fn load_words<T: AsRef<[u32]>>(binary: T) -> ParseResult<mr::Module> {
 
 #[cfg(test)]
 mod tests {
-    use mr;
-    use spirv;
+    use crate::mr;
+    use crate::spirv;
 
     #[test]
     fn test_load_variable() {

--- a/rspirv/sr/autogen_decoration.rs
+++ b/rspirv/sr/autogen_decoration.rs
@@ -16,6 +16,7 @@
 //   external/spirv.core.grammar.json.
 // DO NOT MODIFY!
 
+use derive_more::From;
 use spirv;
 #[doc = r" SPIR-V decorations."]
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord, From)]

--- a/rspirv/sr/autogen_type_enum_check.rs
+++ b/rspirv/sr/autogen_type_enum_check.rs
@@ -17,7 +17,7 @@
 // DO NOT MODIFY!
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub(in sr) enum TypeEnum {
+pub(in crate::sr) enum TypeEnum {
     Void,
     Bool,
     Int {

--- a/rspirv/sr/constants.rs
+++ b/rspirv/sr/constants.rs
@@ -12,18 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use spirv;
+use crate::spirv;
 
-use sr::TypeToken;
+use crate::sr::TypeToken;
 
 /// The class to represent a SPIR-V constant.
 #[derive(Clone, Debug, PartialEq)]
 pub struct Constant {
-    pub(in sr) c: ConstantEnum,
+    pub(in crate::sr) c: ConstantEnum,
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub(in sr) enum ConstantEnum {
+pub(in crate::sr) enum ConstantEnum {
     Bool(bool),
     I32(i32),
     U32(u32),
@@ -121,11 +121,11 @@ impl Constant {
 }
 
 impl ConstantToken {
-    pub(in sr) fn new(index: usize) -> ConstantToken {
+    pub(in crate::sr) fn new(index: usize) -> ConstantToken {
         ConstantToken { index: index }
     }
 
-    pub(in sr) fn get(&self) -> usize {
+    pub(in crate::sr) fn get(&self) -> usize {
         self.index
     }
 }

--- a/rspirv/sr/context.rs
+++ b/rspirv/sr/context.rs
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use spirv;
+use crate::spirv;
 
 use super::{Type, TypeToken, Constant, ConstantToken};
-use sr::constants::ConstantEnum;
-use sr::types::{StructMember, TypeEnum};
+use crate::sr::constants::ConstantEnum;
+use crate::sr::types::{StructMember, TypeEnum};
 
 /// The context class for SPIR-V structured representation.
 ///
@@ -161,8 +161,8 @@ impl Context {
 
 #[cfg(test)]
 mod tests {
-    use spirv;
-    use sr::{Context, TypeToken};
+    use crate::spirv;
+    use crate::sr::{Context, TypeToken};
 
     #[test]
     fn test_get_type() {

--- a/rspirv/sr/types.rs
+++ b/rspirv/sr/types.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use spirv;
+use crate::spirv;
 
 use super::{ConstantToken, Decoration};
 
@@ -23,9 +23,9 @@ use super::{ConstantToken, Decoration};
 /// of labelling explicit lifetimes or back references.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Type {
-    pub(in sr) ty: TypeEnum,
+    pub(in crate::sr) ty: TypeEnum,
     /// Sets of decorations.
-    pub(in sr) decorations: Vec<Decoration>,
+    pub(in crate::sr) decorations: Vec<Decoration>,
 }
 
 /// A token for representing a SPIR-V type.
@@ -35,13 +35,13 @@ pub struct TypeToken {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub(in sr) struct StructMember {
-    pub(in sr) token: TypeToken,
-    pub(in sr) decorations: Vec<Decoration>,
+pub(in crate::sr) struct StructMember {
+    pub(in crate::sr) token: TypeToken,
+    pub(in crate::sr) decorations: Vec<Decoration>,
 }
 
 impl StructMember {
-    pub(in sr) fn new(token: TypeToken) -> Self {
+    pub(in crate::sr) fn new(token: TypeToken) -> Self {
         StructMember {
             token,
             decorations: Vec::new(),
@@ -70,18 +70,18 @@ impl Type {
 }
 
 impl TypeToken {
-    pub(in sr) fn new(index: usize) -> Self {
+    pub(in crate::sr) fn new(index: usize) -> Self {
         TypeToken { index: index }
     }
 
-    pub(in sr) fn get(&self) -> usize {
+    pub(in crate::sr) fn get(&self) -> usize {
         self.index
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use sr::{Context, ConstantToken};
+    use crate::sr::{Context, ConstantToken};
 
     #[test]
     fn test_void_type_is_only_void_type() {

--- a/rspirv/utils/version.rs
+++ b/rspirv/utils/version.rs
@@ -1,4 +1,4 @@
-use spirv::Word;
+use crate::spirv::Word;
 
 pub fn create_version_from_word(version: Word) -> (u8, u8) {
     (((version & 0xff0000) >> 16) as u8, ((version & 0xff00) >> 8) as u8)

--- a/spirv/Cargo.toml
+++ b/spirv/Cargo.toml
@@ -2,6 +2,7 @@
 name = "spirv_headers"
 version = "1.3.4"
 authors = ["Lei Zhang <antiagainst@gmail.com>"]
+edition = "2018"
 
 description = "Rust definition of SPIR-V structs and enums"
 documentation = "https://docs.rs/spirv_headers"

--- a/spirv/lib.rs
+++ b/spirv/lib.rs
@@ -24,11 +24,7 @@
 #![allow(non_camel_case_types)]
 #![cfg_attr(rustfmt, rustfmt_skip)]
 
-#[macro_use]
-extern crate bitflags;
-extern crate num;
-extern crate num_traits;
-#[macro_use]
-extern crate num_derive;
+use bitflags::bitflags;
+use num_derive::FromPrimitive;
 
 include!("autogen_spirv.rs");


### PR DESCRIPTION
This PR changes all the crates to use the 2018 edition of Rust. Fixes #48.