### PR TITLE
sr: Generic Storage with Tokens detached from SPIR-V references

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,6 +78,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "itoa"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -238,6 +246,7 @@ dependencies = [
  "assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clippy 0.0.302 (registry+https://github.com/rust-lang/crates.io-index)",
  "derive_more 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rspirv-codegen 0.1.0",
  "spirv_headers 1.3.4",
@@ -436,6 +445,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e"
 "checksum clippy 0.0.302 (registry+https://github.com/rust-lang/crates.io-index)" = "d911ee15579a3f50880d8c1d59ef6e79f9533127a3bd342462f5d584f5e8c294"
 "checksum derive_more 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "eb9fb0304adeff79ef58a0a22fe93718b96862addaae17d9e34aeb8653549d3e"
+"checksum fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 "checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
 "checksum lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca488b89a5657b0a2ecd45b95609b3e848cf1755da332a0da46e2b2b1cb371a7"
 "checksum libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)" = "76e3a3ef172f1a0b9a9ff0dd1491ae5e6c948b94479a3021819ba7d860c8645d"

--- a/codegen/sr.rs
+++ b/codegen/sr.rs
@@ -108,9 +108,9 @@ pub fn get_quantified_type_tokens(ty: TokenStream, quantifier: &str) -> TokenStr
 pub fn get_operand_type_ident(operand: &structs::Operand) -> TokenStream {
     let ty = if operand.kind == "IdRef" {
         if operand.name == "'Length'" {
-            quote! { ConstantToken }
+            quote! { Token<Constant> }
         } else {
-            quote! { TypeToken }
+            quote! { Token<Type> }
         }
     } else {
         get_operand_type_sr_tokens(&operand.kind)
@@ -259,14 +259,11 @@ pub fn gen_sr_type_creation(grammar: &structs::Grammar) -> String {
                 quote! { {#( #init_list ),*} }
             };
             quote! {
-                pub fn #func_name #param_list -> TypeToken {
-                    let t = Type { ty: TypeEnum::#symbol #init_list, decorations: Vec::new() };
-                    if let Some(index) = self.types.iter().position(|x| *x == t) {
-                        TypeToken::new(index)
-                    } else {
-                        self.types.push(t);
-                        TypeToken::new(self.types.len() - 1)
-                    }
+                pub fn #func_name #param_list -> Token<Type> {
+                    self.types.fetch_or_append(Type {
+                        ty: TypeEnum::#symbol #init_list,
+                        decorations: Vec::new(),
+                    })
                 }
             }
         })

--- a/rspirv/Cargo.toml
+++ b/rspirv/Cargo.toml
@@ -18,9 +18,10 @@ path = "lib.rs"
 travis-ci = { repository = "gfx-rs/rspirv" }
 
 [dependencies]
-num = "0.2"
-derive_more = "0.7"
 clippy = { version = "0.0", optional = true }
+derive_more = "0.7"
+fxhash = "0.2"
+num = "0.2"
 
 [dependencies.spirv_headers]
 version = "1.3"

--- a/rspirv/sr/autogen_type_creation.rs
+++ b/rspirv/sr/autogen_type_creation.rs
@@ -17,87 +17,55 @@
 // DO NOT MODIFY!
 
 impl Context {
-    pub fn type_void(&mut self) -> TypeToken {
-        let t = Type {
+    pub fn type_void(&mut self) -> Token<Type> {
+        self.types.fetch_or_append(Type {
             ty: TypeEnum::Void,
             decorations: Vec::new(),
-        };
-        if let Some(index) = self.types.iter().position(|x| *x == t) {
-            TypeToken::new(index)
-        } else {
-            self.types.push(t);
-            TypeToken::new(self.types.len() - 1)
-        }
+        })
     }
-    pub fn type_bool(&mut self) -> TypeToken {
-        let t = Type {
+    pub fn type_bool(&mut self) -> Token<Type> {
+        self.types.fetch_or_append(Type {
             ty: TypeEnum::Bool,
             decorations: Vec::new(),
-        };
-        if let Some(index) = self.types.iter().position(|x| *x == t) {
-            TypeToken::new(index)
-        } else {
-            self.types.push(t);
-            TypeToken::new(self.types.len() - 1)
-        }
+        })
     }
-    pub fn type_int(&mut self, width: u32, signedness: u32) -> TypeToken {
-        let t = Type {
+    pub fn type_int(&mut self, width: u32, signedness: u32) -> Token<Type> {
+        self.types.fetch_or_append(Type {
             ty: TypeEnum::Int { width, signedness },
             decorations: Vec::new(),
-        };
-        if let Some(index) = self.types.iter().position(|x| *x == t) {
-            TypeToken::new(index)
-        } else {
-            self.types.push(t);
-            TypeToken::new(self.types.len() - 1)
-        }
+        })
     }
-    pub fn type_float(&mut self, width: u32) -> TypeToken {
-        let t = Type {
+    pub fn type_float(&mut self, width: u32) -> Token<Type> {
+        self.types.fetch_or_append(Type {
             ty: TypeEnum::Float { width },
             decorations: Vec::new(),
-        };
-        if let Some(index) = self.types.iter().position(|x| *x == t) {
-            TypeToken::new(index)
-        } else {
-            self.types.push(t);
-            TypeToken::new(self.types.len() - 1)
-        }
+        })
     }
-    pub fn type_vector(&mut self, component_type: TypeToken, component_count: u32) -> TypeToken {
-        let t = Type {
+    pub fn type_vector(
+        &mut self,
+        component_type: Token<Type>,
+        component_count: u32,
+    ) -> Token<Type> {
+        self.types.fetch_or_append(Type {
             ty: TypeEnum::Vector {
                 component_type,
                 component_count,
             },
             decorations: Vec::new(),
-        };
-        if let Some(index) = self.types.iter().position(|x| *x == t) {
-            TypeToken::new(index)
-        } else {
-            self.types.push(t);
-            TypeToken::new(self.types.len() - 1)
-        }
+        })
     }
-    pub fn type_matrix(&mut self, column_type: TypeToken, column_count: u32) -> TypeToken {
-        let t = Type {
+    pub fn type_matrix(&mut self, column_type: Token<Type>, column_count: u32) -> Token<Type> {
+        self.types.fetch_or_append(Type {
             ty: TypeEnum::Matrix {
                 column_type,
                 column_count,
             },
             decorations: Vec::new(),
-        };
-        if let Some(index) = self.types.iter().position(|x| *x == t) {
-            TypeToken::new(index)
-        } else {
-            self.types.push(t);
-            TypeToken::new(self.types.len() - 1)
-        }
+        })
     }
     pub fn type_image(
         &mut self,
-        sampled_type: TypeToken,
+        sampled_type: Token<Type>,
         dim: spirv::Dim,
         depth: u32,
         arrayed: u32,
@@ -105,8 +73,8 @@ impl Context {
         sampled: u32,
         image_format: spirv::ImageFormat,
         access_qualifier: Option<spirv::AccessQualifier>,
-    ) -> TypeToken {
-        let t = Type {
+    ) -> Token<Type> {
+        self.types.fetch_or_append(Type {
             ty: TypeEnum::Image {
                 sampled_type,
                 dim,
@@ -118,209 +86,117 @@ impl Context {
                 access_qualifier,
             },
             decorations: Vec::new(),
-        };
-        if let Some(index) = self.types.iter().position(|x| *x == t) {
-            TypeToken::new(index)
-        } else {
-            self.types.push(t);
-            TypeToken::new(self.types.len() - 1)
-        }
+        })
     }
-    pub fn type_sampler(&mut self) -> TypeToken {
-        let t = Type {
+    pub fn type_sampler(&mut self) -> Token<Type> {
+        self.types.fetch_or_append(Type {
             ty: TypeEnum::Sampler,
             decorations: Vec::new(),
-        };
-        if let Some(index) = self.types.iter().position(|x| *x == t) {
-            TypeToken::new(index)
-        } else {
-            self.types.push(t);
-            TypeToken::new(self.types.len() - 1)
-        }
+        })
     }
-    pub fn type_sampled_image(&mut self, image_type: TypeToken) -> TypeToken {
-        let t = Type {
+    pub fn type_sampled_image(&mut self, image_type: Token<Type>) -> Token<Type> {
+        self.types.fetch_or_append(Type {
             ty: TypeEnum::SampledImage { image_type },
             decorations: Vec::new(),
-        };
-        if let Some(index) = self.types.iter().position(|x| *x == t) {
-            TypeToken::new(index)
-        } else {
-            self.types.push(t);
-            TypeToken::new(self.types.len() - 1)
-        }
+        })
     }
-    pub fn type_array(&mut self, element_type: TypeToken, length: ConstantToken) -> TypeToken {
-        let t = Type {
+    pub fn type_array(
+        &mut self,
+        element_type: Token<Type>,
+        length: Token<Constant>,
+    ) -> Token<Type> {
+        self.types.fetch_or_append(Type {
             ty: TypeEnum::Array {
                 element_type,
                 length,
             },
             decorations: Vec::new(),
-        };
-        if let Some(index) = self.types.iter().position(|x| *x == t) {
-            TypeToken::new(index)
-        } else {
-            self.types.push(t);
-            TypeToken::new(self.types.len() - 1)
-        }
+        })
     }
-    pub fn type_runtime_array(&mut self, element_type: TypeToken) -> TypeToken {
-        let t = Type {
+    pub fn type_runtime_array(&mut self, element_type: Token<Type>) -> Token<Type> {
+        self.types.fetch_or_append(Type {
             ty: TypeEnum::RuntimeArray { element_type },
             decorations: Vec::new(),
-        };
-        if let Some(index) = self.types.iter().position(|x| *x == t) {
-            TypeToken::new(index)
-        } else {
-            self.types.push(t);
-            TypeToken::new(self.types.len() - 1)
-        }
+        })
     }
-    pub fn type_opaque(&mut self, type_name: String) -> TypeToken {
-        let t = Type {
+    pub fn type_opaque(&mut self, type_name: String) -> Token<Type> {
+        self.types.fetch_or_append(Type {
             ty: TypeEnum::Opaque { type_name },
             decorations: Vec::new(),
-        };
-        if let Some(index) = self.types.iter().position(|x| *x == t) {
-            TypeToken::new(index)
-        } else {
-            self.types.push(t);
-            TypeToken::new(self.types.len() - 1)
-        }
+        })
     }
     pub fn type_pointer(
         &mut self,
         storage_class: spirv::StorageClass,
-        pointee_type: TypeToken,
-    ) -> TypeToken {
-        let t = Type {
+        pointee_type: Token<Type>,
+    ) -> Token<Type> {
+        self.types.fetch_or_append(Type {
             ty: TypeEnum::Pointer {
                 storage_class,
                 pointee_type,
             },
             decorations: Vec::new(),
-        };
-        if let Some(index) = self.types.iter().position(|x| *x == t) {
-            TypeToken::new(index)
-        } else {
-            self.types.push(t);
-            TypeToken::new(self.types.len() - 1)
-        }
+        })
     }
     pub fn type_function(
         &mut self,
-        return_type: TypeToken,
-        parameter_types: Vec<TypeToken>,
-    ) -> TypeToken {
-        let t = Type {
+        return_type: Token<Type>,
+        parameter_types: Vec<Token<Type>>,
+    ) -> Token<Type> {
+        self.types.fetch_or_append(Type {
             ty: TypeEnum::Function {
                 return_type,
                 parameter_types,
             },
             decorations: Vec::new(),
-        };
-        if let Some(index) = self.types.iter().position(|x| *x == t) {
-            TypeToken::new(index)
-        } else {
-            self.types.push(t);
-            TypeToken::new(self.types.len() - 1)
-        }
+        })
     }
-    pub fn type_event(&mut self) -> TypeToken {
-        let t = Type {
+    pub fn type_event(&mut self) -> Token<Type> {
+        self.types.fetch_or_append(Type {
             ty: TypeEnum::Event,
             decorations: Vec::new(),
-        };
-        if let Some(index) = self.types.iter().position(|x| *x == t) {
-            TypeToken::new(index)
-        } else {
-            self.types.push(t);
-            TypeToken::new(self.types.len() - 1)
-        }
+        })
     }
-    pub fn type_device_event(&mut self) -> TypeToken {
-        let t = Type {
+    pub fn type_device_event(&mut self) -> Token<Type> {
+        self.types.fetch_or_append(Type {
             ty: TypeEnum::DeviceEvent,
             decorations: Vec::new(),
-        };
-        if let Some(index) = self.types.iter().position(|x| *x == t) {
-            TypeToken::new(index)
-        } else {
-            self.types.push(t);
-            TypeToken::new(self.types.len() - 1)
-        }
+        })
     }
-    pub fn type_reserve_id(&mut self) -> TypeToken {
-        let t = Type {
+    pub fn type_reserve_id(&mut self) -> Token<Type> {
+        self.types.fetch_or_append(Type {
             ty: TypeEnum::ReserveId,
             decorations: Vec::new(),
-        };
-        if let Some(index) = self.types.iter().position(|x| *x == t) {
-            TypeToken::new(index)
-        } else {
-            self.types.push(t);
-            TypeToken::new(self.types.len() - 1)
-        }
+        })
     }
-    pub fn type_queue(&mut self) -> TypeToken {
-        let t = Type {
+    pub fn type_queue(&mut self) -> Token<Type> {
+        self.types.fetch_or_append(Type {
             ty: TypeEnum::Queue,
             decorations: Vec::new(),
-        };
-        if let Some(index) = self.types.iter().position(|x| *x == t) {
-            TypeToken::new(index)
-        } else {
-            self.types.push(t);
-            TypeToken::new(self.types.len() - 1)
-        }
+        })
     }
-    pub fn type_pipe(&mut self, qualifier: spirv::AccessQualifier) -> TypeToken {
-        let t = Type {
+    pub fn type_pipe(&mut self, qualifier: spirv::AccessQualifier) -> Token<Type> {
+        self.types.fetch_or_append(Type {
             ty: TypeEnum::Pipe { qualifier },
             decorations: Vec::new(),
-        };
-        if let Some(index) = self.types.iter().position(|x| *x == t) {
-            TypeToken::new(index)
-        } else {
-            self.types.push(t);
-            TypeToken::new(self.types.len() - 1)
-        }
+        })
     }
-    pub fn type_forward_pointer(&mut self, storage_class: spirv::StorageClass) -> TypeToken {
-        let t = Type {
+    pub fn type_forward_pointer(&mut self, storage_class: spirv::StorageClass) -> Token<Type> {
+        self.types.fetch_or_append(Type {
             ty: TypeEnum::ForwardPointer { storage_class },
             decorations: Vec::new(),
-        };
-        if let Some(index) = self.types.iter().position(|x| *x == t) {
-            TypeToken::new(index)
-        } else {
-            self.types.push(t);
-            TypeToken::new(self.types.len() - 1)
-        }
+        })
     }
-    pub fn type_pipe_storage(&mut self) -> TypeToken {
-        let t = Type {
+    pub fn type_pipe_storage(&mut self) -> Token<Type> {
+        self.types.fetch_or_append(Type {
             ty: TypeEnum::PipeStorage,
             decorations: Vec::new(),
-        };
-        if let Some(index) = self.types.iter().position(|x| *x == t) {
-            TypeToken::new(index)
-        } else {
-            self.types.push(t);
-            TypeToken::new(self.types.len() - 1)
-        }
+        })
     }
-    pub fn type_named_barrier(&mut self) -> TypeToken {
-        let t = Type {
+    pub fn type_named_barrier(&mut self) -> Token<Type> {
+        self.types.fetch_or_append(Type {
             ty: TypeEnum::NamedBarrier,
             decorations: Vec::new(),
-        };
-        if let Some(index) = self.types.iter().position(|x| *x == t) {
-            TypeToken::new(index)
-        } else {
-            self.types.push(t);
-            TypeToken::new(self.types.len() - 1)
-        }
+        })
     }
 }

--- a/rspirv/sr/autogen_type_enum_check.rs
+++ b/rspirv/sr/autogen_type_enum_check.rs
@@ -28,15 +28,15 @@ pub(in crate::sr) enum TypeEnum {
         width: u32,
     },
     Vector {
-        component_type: TypeToken,
+        component_type: Token<Type>,
         component_count: u32,
     },
     Matrix {
-        column_type: TypeToken,
+        column_type: Token<Type>,
         column_count: u32,
     },
     Image {
-        sampled_type: TypeToken,
+        sampled_type: Token<Type>,
         dim: spirv::Dim,
         depth: u32,
         arrayed: u32,
@@ -47,14 +47,14 @@ pub(in crate::sr) enum TypeEnum {
     },
     Sampler,
     SampledImage {
-        image_type: TypeToken,
+        image_type: Token<Type>,
     },
     Array {
-        element_type: TypeToken,
-        length: ConstantToken,
+        element_type: Token<Type>,
+        length: Token<Constant>,
     },
     RuntimeArray {
-        element_type: TypeToken,
+        element_type: Token<Type>,
     },
     Struct {
         field_types: Vec<StructMember>,
@@ -64,11 +64,11 @@ pub(in crate::sr) enum TypeEnum {
     },
     Pointer {
         storage_class: spirv::StorageClass,
-        pointee_type: TypeToken,
+        pointee_type: Token<Type>,
     },
     Function {
-        return_type: TypeToken,
-        parameter_types: Vec<TypeToken>,
+        return_type: Token<Type>,
+        parameter_types: Vec<Token<Type>>,
     },
     Event,
     DeviceEvent,

--- a/rspirv/sr/constants.rs
+++ b/rspirv/sr/constants.rs
@@ -14,7 +14,7 @@
 
 use crate::spirv;
 
-use crate::sr::TypeToken;
+use super::{Token, Type};
 
 /// The class to represent a SPIR-V constant.
 #[derive(Clone, Debug, PartialEq)]
@@ -28,21 +28,15 @@ pub(in crate::sr) enum ConstantEnum {
     I32(i32),
     U32(u32),
     F32(f32),
-    Composite(Vec<ConstantToken>),
-    Null(TypeToken),
+    Composite(Vec<Token<Constant>>),
+    Null(Token<Type>),
     Sampler(spirv::SamplerAddressingMode, u32, spirv::SamplerFilterMode),
     SpecBool(bool),
     SpecI32(i32),
     SpecU32(u32),
     SpecF32(f32),
-    SpecComposite(Vec<ConstantToken>),
-    SpecOp(spirv::Op, Vec<ConstantToken>),
-}
-
-/// A token for representing a SPIR-V constant.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub struct ConstantToken {
-    index: usize,
+    SpecComposite(Vec<Token<Constant>>),
+    SpecOp(spirv::Op, Vec<Token<Constant>>),
 }
 
 impl Constant {
@@ -117,15 +111,5 @@ impl Constant {
             ConstantEnum::SpecOp { .. } => true,
             _ => false,
         }
-    }
-}
-
-impl ConstantToken {
-    pub(in crate::sr) fn new(index: usize) -> ConstantToken {
-        ConstantToken { index: index }
-    }
-
-    pub(in crate::sr) fn get(&self) -> usize {
-        self.index
     }
 }

--- a/rspirv/sr/context.rs
+++ b/rspirv/sr/context.rs
@@ -12,11 +12,101 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::spirv;
+use std::{
+    collections::HashMap,
+    hash::BuildHasherDefault,
+    marker::PhantomData,
+};
 
-use super::{Type, TypeToken, Constant, ConstantToken};
-use crate::sr::constants::ConstantEnum;
-use crate::sr::types::{StructMember, TypeEnum};
+use fxhash::FxHasher;
+
+use crate::{
+    spirv,
+    sr::constants::{Constant, ConstantEnum},
+    sr::types::{StructMember, TypeEnum, Type},
+};
+
+type FastHashMap<K, V> = HashMap<K, V, BuildHasherDefault<FxHasher>>;
+/// An index corresponding to `Id` in SPIR-V.
+type Index = u32;
+
+/// A strongly typed reference to a SPIR-V element.
+#[derive(Debug)]
+pub struct Token<T> {
+    index: Index,
+    marker: PhantomData<T>,
+}
+
+impl<T> Clone for Token<T> {
+    fn clone(&self) -> Self {
+        Token {
+            index: self.index,
+            marker: self.marker,
+        }
+    }
+}
+impl<T> Copy for Token<T> {}
+impl<T> PartialEq for Token<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.index == other.index
+    }
+}
+impl<T> Eq for Token<T> {}
+
+impl<T> Token<T> {
+    pub(in crate::sr) fn new(index: Index) -> Self {
+        Token {
+            index,
+            marker: PhantomData,
+        }
+    }
+}
+
+/// A structure holding some kind of SPIR-V entity (e.g., type, constant,
+/// instruction, etc.) that can be referenced.
+#[derive(Debug)]
+pub struct Storage<T> {
+    map: FastHashMap<Index, T>,
+    next_id: Index,
+}
+
+impl<T> Storage<T> {
+    fn new() -> Self {
+        Storage {
+            map: FastHashMap::default(),
+            next_id: 0,
+        }
+    }
+
+    /// Associate a value with a given index, returning a typed token.
+    ///
+    /// This is useful when processing a module in the data representation,
+    /// where the indices are known.
+    pub fn assign(&mut self, index: Index, value: T) -> Token<T> {
+        self.next_id = self.next_id.max(index + 1);
+        let old = self.map.insert(index, value);
+        assert!(old.is_none());
+        Token::new(index)
+    }
+
+    /// Add a new value to the storage, returning a typed token.
+    pub fn append(&mut self, value: T) -> Token<T> {
+        self.assign(self.next_id, value)
+    }
+
+    /// Add a value with a check for uniqueness: returns a token pointing to
+    /// an existing element if its value matches the given one, or adds a new
+    /// element otherwise.
+    pub fn fetch_or_append(&mut self, value: T) -> Token<T> where T: PartialEq {
+        if let Some((&index, _)) = self.map.iter().find(|(_, v)| v == &&value) {
+            Token::new(index)
+        } else {
+            self.append(value)
+        }
+    }
+}
+
+
 
 /// The context class for SPIR-V structured representation.
 ///
@@ -29,15 +119,15 @@ use crate::sr::types::{StructMember, TypeEnum};
 #[derive(Debug)]
 pub struct Context {
     /// All type objects.
-    types: Vec<Type>,
-    constants: Vec<Constant>,
+    types: Storage<Type>,
+    constants: Storage<Constant>,
 }
 
 impl Context {
     pub fn new() -> Self {
         Context {
-            types: vec![],
-            constants: vec![],
+            types: Storage::new(),
+            constants: Storage::new(),
         }
     }
 }
@@ -45,8 +135,8 @@ impl Context {
 include!("autogen_type_creation.rs");
 
 impl Context {
-    pub fn type_struct<T: AsRef<[TypeToken]>>(&mut self, field_types: T) -> TypeToken {
-        self.types.push(Type {
+    pub fn type_struct<T: AsRef<[Token<Type>]>>(&mut self, field_types: T) -> Token<Type> {
+        self.types.append(Type {
             ty: TypeEnum::Struct {
                 field_types: field_types
                     .as_ref()
@@ -55,57 +145,45 @@ impl Context {
                     .collect(),
             },
             decorations: Vec::new(),
-        });
-        TypeToken::new(self.types.len() - 1)
+        })
     }
 
     /// Returns the reference to the real type represented by the given token.
-    pub fn get_type(&self, token: TypeToken) -> &Type {
+    pub fn get_type(&self, token: Token<Type>) -> &Type {
         // Note: we assume the vector doesn't shrink so we always have a valid index.
-        &self.types[token.get()]
-    }
-}
-
-macro_rules! fetch_or_append {
-    ($container: expr, $val: expr) => {
-        if let Some(index) = $container.iter().position(|x| *x == $val) {
-            ConstantToken::new(index)
-        } else {
-            $container.push($val);
-            ConstantToken::new($container.len() - 1)
-        }
+        &self.types.map[&token.index]
     }
 }
 
 impl Context {
-    pub fn constant_bool(&mut self, val: bool) -> ConstantToken {
+    pub fn constant_bool(&mut self, val: bool) -> Token<Constant> {
         let v = Constant { c: ConstantEnum::Bool(val) };
-        fetch_or_append!(self.constants, v)
+        self.constants.fetch_or_append(v)
     }
 
-    pub fn constant_i32(&mut self, val: i32) -> ConstantToken {
+    pub fn constant_i32(&mut self, val: i32) -> Token<Constant> {
         let v = Constant { c: ConstantEnum::I32(val) };
-        fetch_or_append!(self.constants, v)
+        self.constants.fetch_or_append(v)
     }
 
-    pub fn constant_u32(&mut self, val: u32) -> ConstantToken {
+    pub fn constant_u32(&mut self, val: u32) -> Token<Constant> {
         let v = Constant { c: ConstantEnum::U32(val) };
-        fetch_or_append!(self.constants, v)
+        self.constants.fetch_or_append(v)
     }
 
-    pub fn constant_f32(&mut self, val: f32) -> ConstantToken {
+    pub fn constant_f32(&mut self, val: f32) -> Token<Constant> {
         let v = Constant { c: ConstantEnum::F32(val) };
-        fetch_or_append!(self.constants, v)
+        self.constants.fetch_or_append(v)
     }
 
-    pub fn constant_composite<T: AsRef<[ConstantToken]>>(&mut self, val: T) -> ConstantToken {
+    pub fn constant_composite<T: AsRef<[Token<Constant>]>>(&mut self, val: T) -> Token<Constant> {
         let v = Constant { c: ConstantEnum::Composite(val.as_ref().to_vec()) };
-        fetch_or_append!(self.constants, v)
+        self.constants.fetch_or_append(v)
     }
 
-    pub fn constant_null(&mut self, val: TypeToken) -> ConstantToken {
+    pub fn constant_null(&mut self, val: Token<Type>) -> Token<Constant> {
         let v = Constant { c: ConstantEnum::Null(val) };
-        fetch_or_append!(self.constants, v)
+        self.constants.fetch_or_append(v)
     }
 
     pub fn constant_sampler(
@@ -113,56 +191,56 @@ impl Context {
         addressing_mode: spirv::SamplerAddressingMode,
         param: u32,
         filter_mode: spirv::SamplerFilterMode,
-    ) -> ConstantToken {
+    ) -> Token<Constant> {
         let v = Constant { c: ConstantEnum::Sampler(addressing_mode, param, filter_mode) };
-        fetch_or_append!(self.constants, v)
+        self.constants.fetch_or_append(v)
     }
 
-    pub fn spec_constant_bool(&mut self, val: bool) -> ConstantToken {
+    pub fn spec_constant_bool(&mut self, val: bool) -> Token<Constant> {
         let v = Constant { c: ConstantEnum::SpecBool(val) };
-        fetch_or_append!(self.constants, v)
+        self.constants.fetch_or_append(v)
     }
 
-    pub fn spec_constant_i32(&mut self, val: i32) -> ConstantToken {
+    pub fn spec_constant_i32(&mut self, val: i32) -> Token<Constant> {
         let v = Constant { c: ConstantEnum::SpecI32(val) };
-        fetch_or_append!(self.constants, v)
+        self.constants.fetch_or_append(v)
     }
 
-    pub fn spec_constant_u32(&mut self, val: u32) -> ConstantToken {
+    pub fn spec_constant_u32(&mut self, val: u32) -> Token<Constant> {
         let v = Constant { c: ConstantEnum::SpecU32(val) };
-        fetch_or_append!(self.constants, v)
+        self.constants.fetch_or_append(v)
     }
 
-    pub fn spec_constant_f32(&mut self, val: f32) -> ConstantToken {
+    pub fn spec_constant_f32(&mut self, val: f32) -> Token<Constant> {
         let v = Constant { c: ConstantEnum::SpecF32(val) };
-        fetch_or_append!(self.constants, v)
+        self.constants.fetch_or_append(v)
     }
 
-    pub fn spec_constant_composite<T: AsRef<[ConstantToken]>>(&mut self, val: T) -> ConstantToken {
+    pub fn spec_constant_composite<T: AsRef<[Token<Constant>]>>(&mut self, val: T) -> Token<Constant> {
         let v = Constant { c: ConstantEnum::SpecComposite(val.as_ref().to_vec()) };
-        fetch_or_append!(self.constants, v)
+        self.constants.fetch_or_append(v)
     }
 
-    pub fn spec_constant_op<T: AsRef<[ConstantToken]>>(
+    pub fn spec_constant_op<T: AsRef<[Token<Constant>]>>(
         &mut self,
         op: spirv::Op,
         operands: T,
-    ) -> ConstantToken {
+    ) -> Token<Constant> {
         let v = Constant { c: ConstantEnum::SpecOp(op, operands.as_ref().to_vec()) };
-        fetch_or_append!(self.constants, v)
+        self.constants.fetch_or_append(v)
     }
 
     /// Returns the reference to the real constant represented by the given token.
-    pub fn get_constant(&self, token: ConstantToken) -> &Constant {
+    pub fn get_constant(&self, token: Token<Constant>) -> &Constant {
         // Note: we assume the vector doesn't shrink so we always have a valid index.
-        &self.constants[token.get()]
+        &self.constants.map[&token.index]
     }
 }
 
 #[cfg(test)]
 mod tests {
     use crate::spirv;
-    use crate::sr::{Context, TypeToken};
+    use crate::sr::{Context, Token};
 
     #[test]
     fn test_get_type() {
@@ -205,13 +283,13 @@ mod tests {
     #[test]
     fn test_vector_type_uniqueness() {
         let mut c = Context::new();
-        let token = TypeToken::new(0);
+        let token = Token::new(0);
         let t1 = c.type_vector(token, 4);
         let t2 = c.type_vector(token, 4);
         assert_eq!(t1, t2);
         let t3 = c.type_vector(token, 3);
         assert!(t1 != t3);
-        let token = TypeToken::new(1);
+        let token = Token::new(1);
         let t4 = c.type_vector(token, 3);
         assert!(t3 != t4);
         assert!(t2 != t3);
@@ -220,13 +298,13 @@ mod tests {
     #[test]
     fn test_matrix_type_uniqueness() {
         let mut c = Context::new();
-        let token = TypeToken::new(0);
+        let token = Token::new(0);
         let t1 = c.type_matrix(token, 4);
         let t2 = c.type_matrix(token, 4);
         assert_eq!(t1, t2);
         let t3 = c.type_matrix(token, 3);
         assert!(t1 != t3);
-        let token = TypeToken::new(1);
+        let token = Token::new(1);
         let t4 = c.type_matrix(token, 3);
         assert!(t3 != t4);
         assert!(t2 != t3);
@@ -235,7 +313,7 @@ mod tests {
     #[test]
     fn test_struct_type_non_uniqueness() {
         let mut c = Context::new();
-        let token = TypeToken::new(0);
+        let token = Token::new(0);
         let t1 = c.type_struct(&vec![token]);
         let t2 = c.type_struct(&vec![token]);
         assert!(t1 != t2);

--- a/rspirv/sr/mod.rs
+++ b/rspirv/sr/mod.rs
@@ -14,10 +14,10 @@
 
 //! **S**tructured **r**epresentation of various SPIR-V language constructs.
 
-pub use self::constants::{Constant, ConstantToken};
-pub use self::context::Context;
+pub use self::constants::{Constant};
+pub use self::context::{Context, Token};
 pub use self::autogen_decoration::Decoration;
-pub use self::types::{Type, TypeToken};
+pub use self::types::{Type};
 
 mod constants;
 mod context;

--- a/rspirv/sr/types.rs
+++ b/rspirv/sr/types.rs
@@ -14,7 +14,7 @@
 
 use crate::spirv;
 
-use super::{ConstantToken, Decoration};
+use super::{Constant, Decoration, Token};
 
 /// The class to represent a SPIR-V type.
 ///
@@ -28,20 +28,14 @@ pub struct Type {
     pub(in crate::sr) decorations: Vec<Decoration>,
 }
 
-/// A token for representing a SPIR-V type.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub struct TypeToken {
-    index: usize,
-}
-
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(in crate::sr) struct StructMember {
-    pub(in crate::sr) token: TypeToken,
+    pub(in crate::sr) token: Token<Type>,
     pub(in crate::sr) decorations: Vec<Decoration>,
 }
 
 impl StructMember {
-    pub(in crate::sr) fn new(token: TypeToken) -> Self {
+    pub(in crate::sr) fn new(token: Token<Type>) -> Self {
         StructMember {
             token,
             decorations: Vec::new(),
@@ -69,19 +63,9 @@ impl Type {
     }
 }
 
-impl TypeToken {
-    pub(in crate::sr) fn new(index: usize) -> Self {
-        TypeToken { index: index }
-    }
-
-    pub(in crate::sr) fn get(&self) -> usize {
-        self.index
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use crate::sr::{Context, ConstantToken};
+    use crate::sr::{Context, Token};
 
     #[test]
     fn test_void_type_is_only_void_type() {
@@ -221,7 +205,7 @@ mod tests {
             let t = c.get_type(structt);
             assert!(t.is_aggregate_type());
         }
-        let arrt = c.type_array(i32t, ConstantToken::new(16));
+        let arrt = c.type_array(i32t, Token::new(16));
         {
             let t = c.get_type(arrt);
             assert!(t.is_aggregate_type());
@@ -271,7 +255,7 @@ mod tests {
             let t = c.get_type(structt);
             assert!(t.is_composite_type());
         }
-        let arrt = c.type_array(i32t, ConstantToken::new(16));
+        let arrt = c.type_array(i32t, Token::new(16));
         {
             let t = c.get_type(arrt);
             assert!(t.is_composite_type());

--- a/rspirv/sr/types.rs
+++ b/rspirv/sr/types.rs
@@ -71,7 +71,7 @@ mod tests {
     fn test_void_type_is_only_void_type() {
         let mut c = Context::new();
         let voidt = c.type_void();
-        let t = c.get_type(voidt);
+        let t = &c.types[voidt];
         assert!(t.is_void_type());
         assert!(!t.is_bool_type());
         assert!(!t.is_int_type());
@@ -101,7 +101,7 @@ mod tests {
     fn test_int_type_is_only_int_type() {
         let mut c = Context::new();
         let u32t = c.type_int(32, 0);
-        let t = c.get_type(u32t);
+        let t = &c.types[u32t];
         assert!(!t.is_void_type());
         assert!(!t.is_bool_type());
         assert!(t.is_int_type());
@@ -132,22 +132,22 @@ mod tests {
         let mut c = Context::new();
         let voidt = c.type_void();
         {
-            let t = c.get_type(voidt);
+            let t = &c.types[voidt];
             assert!(!t.is_numerical_type());
         }
         let i32t = c.type_int(32, 1);
         {
-            let t = c.get_type(i32t);
+            let t = &c.types[i32t];
             assert!(t.is_numerical_type());
         }
         let f64t = c.type_float(64);
         {
-            let t = c.get_type(f64t);
+            let t = &c.types[f64t];
             assert!(t.is_numerical_type());
         }
         let boolt = c.type_bool();
         {
-            let t = c.get_type(boolt);
+            let t = &c.types[boolt];
             assert!(!t.is_numerical_type());
         }
     }
@@ -157,22 +157,22 @@ mod tests {
         let mut c = Context::new();
         let voidt = c.type_void();
         {
-            let t = c.get_type(voidt);
+            let t = &c.types[voidt];
             assert!(!t.is_scalar_type());
         }
         let i32t = c.type_int(32, 1);
         {
-            let t = c.get_type(i32t);
+            let t = &c.types[i32t];
             assert!(t.is_scalar_type());
         }
         let f64t = c.type_float(64);
         {
-            let t = c.get_type(f64t);
+            let t = &c.types[f64t];
             assert!(t.is_scalar_type());
         }
         let boolt = c.type_bool();
         {
-            let t = c.get_type(boolt);
+            let t = &c.types[boolt];
             assert!(t.is_scalar_type());
         }
     }
@@ -182,47 +182,47 @@ mod tests {
         let mut c = Context::new();
         let voidt = c.type_void();
         {
-            let t = c.get_type(voidt);
+            let t = &c.types[voidt];
             assert!(!t.is_aggregate_type());
         }
         let i32t = c.type_int(32, 1);
         {
-            let t = c.get_type(i32t);
+            let t = &c.types[i32t];
             assert!(!t.is_aggregate_type());
         }
         let f64t = c.type_float(64);
         {
-            let t = c.get_type(f64t);
+            let t = &c.types[f64t];
             assert!(!t.is_aggregate_type());
         }
         let boolt = c.type_bool();
         {
-            let t = c.get_type(boolt);
+            let t = &c.types[boolt];
             assert!(!t.is_aggregate_type());
         }
         let structt = c.type_struct(&vec![i32t, i32t, i32t]);
         {
-            let t = c.get_type(structt);
+            let t = &c.types[structt];
             assert!(t.is_aggregate_type());
         }
-        let arrt = c.type_array(i32t, Token::new(16));
+        let arrt = c.type_array(i32t, Token::DUMMY);
         {
-            let t = c.get_type(arrt);
+            let t = &c.types[arrt];
             assert!(t.is_aggregate_type());
         }
         let rtarrt = c.type_runtime_array(i32t);
         {
-            let t = c.get_type(rtarrt);
+            let t = &c.types[rtarrt];
             assert!(t.is_aggregate_type());
         }
         let v4i32t = c.type_vector(i32t, 4);
         {
-            let t = c.get_type(v4i32t);
+            let t = &c.types[v4i32t];
             assert!(!t.is_aggregate_type());
         }
         let matt = c.type_matrix(v4i32t, 4);
         {
-            let t = c.get_type(matt);
+            let t = &c.types[matt];
             assert!(!t.is_aggregate_type());
         }
     }
@@ -232,47 +232,47 @@ mod tests {
         let mut c = Context::new();
         let voidt = c.type_void();
         {
-            let t = c.get_type(voidt);
+            let t = &c.types[voidt];
             assert!(!t.is_composite_type());
         }
         let i32t = c.type_int(32, 1);
         {
-            let t = c.get_type(i32t);
+            let t = &c.types[i32t];
             assert!(!t.is_composite_type());
         }
         let f64t = c.type_float(64);
         {
-            let t = c.get_type(f64t);
+            let t = &c.types[f64t];
             assert!(!t.is_composite_type());
         }
         let boolt = c.type_bool();
         {
-            let t = c.get_type(boolt);
+            let t = &c.types[boolt];
             assert!(!t.is_composite_type());
         }
         let structt = c.type_struct(&vec![i32t, i32t, i32t]);
         {
-            let t = c.get_type(structt);
+            let t = &c.types[structt];
             assert!(t.is_composite_type());
         }
-        let arrt = c.type_array(i32t, Token::new(16));
+        let arrt = c.type_array(i32t, Token::DUMMY);
         {
-            let t = c.get_type(arrt);
+            let t = &c.types[arrt];
             assert!(t.is_composite_type());
         }
         let rtarrt = c.type_runtime_array(i32t);
         {
-            let t = c.get_type(rtarrt);
+            let t = &c.types[rtarrt];
             assert!(t.is_composite_type());
         }
         let v4i32t = c.type_vector(i32t, 4);
         {
-            let t = c.get_type(v4i32t);
+            let t = &c.types[v4i32t];
             assert!(t.is_composite_type());
         }
         let matt = c.type_matrix(v4i32t, 4);
         {
-            let t = c.get_type(matt);
+            let t = &c.types[matt];
             assert!(t.is_composite_type());
         }
     }


### PR DESCRIPTION
This is an alternative to #49 that implements `Token` in a way that is independent from SPIR-V references. There is still a bidirectional link in place to allow lookups upon building the structured representation.

Overall, this approach feels cleaner to me, but I do anticipate the structured processing to be more difficult with it, since we aren't able to use any tokens that we haven't processed yet at any point.

cc @AIOOB feedback is welcome!