### PR TITLE
codegen: separate Branch from Terminator

### DIFF
--- a/codegen/external/README.md
+++ b/codegen/external/README.md
@@ -6,3 +6,6 @@ repository, with some modifications to spirv.core.grammar.json. So there is
 a copy of it in this directory.
 
 [spirv-headers]: https://github.com/KhronosGroup/SPIRV-Headers
+
+Modifications are:
+  - "class" field

--- a/codegen/external/spirv.core.grammar.json
+++ b/codegen/external/spirv.core.grammar.json
@@ -2312,7 +2312,7 @@
       ]
     },
     {
-      "class": "Terminator",
+      "class": "Branch",
       "opname" : "OpBranch",
       "opcode" : 249,
       "operands" : [
@@ -2320,7 +2320,7 @@
       ]
     },
     {
-      "class": "Terminator",
+      "class": "Branch",
       "opname" : "OpBranchConditional",
       "opcode" : 250,
       "operands" : [
@@ -2331,7 +2331,7 @@
       ]
     },
     {
-      "class": "Terminator",
+      "class": "Branch",
       "opname" : "OpSwitch",
       "opcode" : 251,
       "operands" : [
@@ -2347,12 +2347,12 @@
       "capabilities" : [ "Shader" ]
     },
     {
-      "class": "Terminator",
+      "class": "Branch",
       "opname" : "OpReturn",
       "opcode" : 253
     },
     {
-      "class": "Terminator",
+      "class": "Branch",
       "opname" : "OpReturnValue",
       "opcode" : 254,
       "operands" : [

--- a/codegen/mr.rs
+++ b/codegen/mr.rs
@@ -315,7 +315,7 @@ pub fn gen_mr_builder_terminator(grammar: &structs::Grammar) -> String {
     let kinds = &grammar.operand_kinds;
     // Generate build methods for all types.
     let elements: Vec<String> = grammar.instructions.iter().filter(|inst| {
-        inst.class == "Terminator"
+        inst.class == "Terminator" || inst.class == "Branch"
     }).map(|inst| {
         let (params, type_generics) = get_param_list(&inst.operands, false, kinds);
         let extras = get_push_extras(&inst.operands, kinds, "inst.operands").join(";\n");


### PR DESCRIPTION
In the spec, "Terminator" defined as either a "Branch" or the other two instructions. It would be helpful for the structured representation to work with branch instructions that are terminators.