### PR TITLE
Derive PartialEq, Debug and Clone on public types.

### DIFF
--- a/codegen/binary.rs
+++ b/codegen/binary.rs
@@ -57,7 +57,7 @@ pub fn gen_operand_decode_errors(grammar: &Vec<structs::OperandKind>)
     }).collect();
     let error_enum = format!(
         "/// Decoder Error.\n\
-         #[derive(Debug, PartialEq)]\n\
+         #[derive(Debug, PartialEq, Clone)]\n\
          pub enum Error {{\n\
          {s:4}StreamExpected(usize),\n\
          {s:4}LimitReached(usize),\n\

--- a/rspirv/binary/autogen_error.rs
+++ b/rspirv/binary/autogen_error.rs
@@ -22,7 +22,7 @@ use spirv;
 use std::{error, fmt};
 
 /// Decoder Error.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum Error {
     StreamExpected(usize),
     LimitReached(usize),

--- a/rspirv/binary/decoder.rs
+++ b/rspirv/binary/decoder.rs
@@ -75,6 +75,7 @@ const WORD_NUM_BYTES: usize = 4;
 ///     assert_eq!(Err(DecodeError::StreamExpected(12)), d.word());
 /// }
 /// ```
+#[derive(Clone, Debug, PartialEq)]
 pub struct Decoder<'a> {
     /// Raw bytes to decode
     bytes: &'a [u8],

--- a/rspirv/binary/tracker.rs
+++ b/rspirv/binary/tracker.rs
@@ -35,7 +35,7 @@ pub enum Type {
 ///
 /// If the type of an id cannot be resolved due to some reason, this will
 /// silently ignore that id instead of erroring out.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct TypeTracker {
     /// Mapping from an id to its type.
     ///
@@ -81,6 +81,7 @@ impl TypeTracker {
     }
 }
 
+#[derive(Debug, Clone)]
 enum ExtInstSet {
     GlslStd450,
     OpenCLStd100,
@@ -90,6 +91,7 @@ enum ExtInstSet {
 ///
 /// If a given extended instruction set is not supported, it will just be
 /// silently ignored.
+#[derive(Debug, Clone)]
 pub struct ExtInstSetTracker {
     sets: collections::HashMap<spirv::Word, ExtInstSet>,
 }

--- a/rspirv/mr/build/mod.rs
+++ b/rspirv/mr/build/mod.rs
@@ -100,7 +100,7 @@ type BuildResult<T> = result::Result<T, Error>;
 ///                 OpFunctionEnd");
 /// }
 /// ```
-#[derive(Default)]
+#[derive(Default, Clone, PartialEq, Debug)]
 pub struct Builder {
     module: mr::Module,
     next_id: u32,

--- a/rspirv/mr/constructs.rs
+++ b/rspirv/mr/constructs.rs
@@ -29,7 +29,7 @@ use derive_more::From;
 /// The order of its fields basically reveal the requirements in the
 /// [Logical Layout of a Module](https://goo.gl/2kVnfX) of the SPIR-V
 /// of the SPIR-V specification.
-#[derive(Debug, Default)]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct Module {
     /// The module header.
     pub header: Option<ModuleHeader>,
@@ -62,7 +62,7 @@ pub struct Module {
 }
 
 /// Data representation of a SPIR-V module header.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct ModuleHeader {
     pub magic_number: Word,
     pub version: Word,
@@ -72,7 +72,7 @@ pub struct ModuleHeader {
 }
 
 /// Data representation of a SPIR-V function.
-#[derive(Debug, Default)]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct Function {
     /// First (defining) instruction in this function.
     pub def: Option<Instruction>,
@@ -85,7 +85,7 @@ pub struct Function {
 }
 
 /// Data representation of a SPIR-V basic block.
-#[derive(Debug, Default)]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct BasicBlock {
     /// The label starting this basic block.
     pub label: Option<Instruction>,
@@ -94,7 +94,7 @@ pub struct BasicBlock {
 }
 
 /// Data representation of a SPIR-V instruction.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, )]
 pub struct Instruction {
     /// The class (grammar specification) of this instruction.
     pub class: &'static grammar::Instruction<'static>,

--- a/rspirv/mr/loader.rs
+++ b/rspirv/mr/loader.rs
@@ -21,7 +21,7 @@ use crate::binary::{ParseAction, ParseResult};
 use std::{error, fmt};
 
 /// Data representation loading errors.
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum Error {
     NestedFunction,
     UnclosedFunction,
@@ -85,7 +85,7 @@ impl fmt::Display for Error {
 ///
 /// It implements the [`Consumer`](../binary/trait.Consumer.html) trait and
 /// works with the [`Parser`](../binary/struct.Parser.html).
-#[derive(Default)]
+#[derive(Default, Clone, Debug, PartialEq)]
 pub struct Loader {
     module: mr::Module,
     function: Option<mr::Function>,

--- a/rspirv/sr/context.rs
+++ b/rspirv/sr/context.rs
@@ -76,7 +76,7 @@ impl<T> Token<T> {
 
 /// A structure holding some kind of SPIR-V entity (e.g., type, constant,
 /// instruction, etc.) that can be referenced.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Storage<T> {
     /// Values of this storage.
     data: Vec<T>,
@@ -140,7 +140,7 @@ impl<T> ops::Index<Token<T>> for Storage<T> {
 /// object to be created, which can then be used to access the real object
 /// using the context again. Tokens are indeed indices into the vectors
 /// of objects inside the context. The context serves as the memory arena.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Context {
     /// All type objects.
     pub types: Storage<Type>,


### PR DESCRIPTION
Some of them are probably unnecessary, and there's probably some I missed.  But it's convenient to be able to wrap rspirv's types in my own types and then derive Debug on 'em.