### PR TITLE
Add more types to grammar deserialiser

### DIFF
--- a/autogen/binary.rs
+++ b/autogen/binary.rs
@@ -115,7 +115,7 @@ pub fn gen_operand_decode_methods(grammar: &Vec<structs::OperandKind>) -> TokenS
         let kind = as_ident(&element.kind);
         let comment = format!("Decodes and returns the next SPIR-V word as\na SPIR-V {} value.", kind);
         let function_name = as_ident(&snake_casify(&element.kind));
-        let convert = as_ident(&format!("from_{}", if element.category == "BitEnum" { "bits" } else { "u32" }));
+        let convert = as_ident(&format!("from_{}", if element.category == structs::Category::BitEnum { "bits" } else { "u32" }));
         let error_name = as_ident(&format!("{}Unknown", kind));
         quote! {
             #[doc = #comment]
@@ -171,7 +171,7 @@ fn gen_operand_param_parse_methods(grammar: &Vec<structs::OperandKind>) -> Vec<(
         let lo_kind = as_ident(&snake_casify(&element.kind));
         let function_name = as_ident(&format!("parse_{}_arguments", lo_kind));
 
-        let method = if element.category == "BitEnum" {
+        let method = if element.category == structs::Category::BitEnum {
             // For each operand kind in the BitEnum category, its
             // enumerants are bit masks. If a certain bit having associated
             // parameters is set, we also need to decode the corresponding
@@ -318,11 +318,11 @@ pub fn gen_operand_parse_methods(grammar: &Vec<structs::OperandKind>) -> TokenSt
 
 pub fn gen_disas_bit_enum_operands(grammar: &Vec<structs::OperandKind>) -> TokenStream {
     let elements = grammar.iter().filter(|op_kind| {
-        op_kind.category == "BitEnum"
+        op_kind.category == structs::Category::BitEnum
     }).map(|op_kind| {
         let kind = as_ident(&op_kind.kind);
         let checks = op_kind.enumerants.iter().filter_map(|enumerant| {
-            if enumerant.value.string == "0x0000" {
+            if enumerant.value == 0x0000 {
                 None
             } else {
                 let symbol = as_ident(&snake_casify(&enumerant.symbol).replace("na_n", "nan").to_uppercase());

--- a/autogen/header.rs
+++ b/autogen/header.rs
@@ -50,8 +50,7 @@ fn gen_bit_enum_operand_kind(grammar: &structs::OperandKind) -> TokenStream {
     let elements = grammar.enumerants.iter().map(|enumerant| {
         // Special treatment for "NaN"
         let symbol = as_ident(&snake_casify(&enumerant.symbol).replace("na_n", "nan").to_uppercase());
-        // value.string is a hex string of the form 0x12345678
-        let value = u32::from_str_radix(&enumerant.value.string[2..], 16).unwrap();
+        let value = enumerant.value;
         quote! {
             const #symbol = #value;
         }
@@ -80,7 +79,7 @@ fn gen_value_enum_operand_kind(grammar: &structs::OperandKind) -> TokenStream {
     let mut aliases = vec![];
     let mut capability_clauses = BTreeMap::new();
     for e in &grammar.enumerants {
-        if let Some(discriminator) = seen_discriminator.get(&e.value.number) {
+        if let Some(discriminator) = seen_discriminator.get(&e.value) {
             let symbol = as_ident(&e.symbol);
             aliases.push(quote! {
                 pub const #symbol: #kind = #kind::#discriminator;
@@ -96,8 +95,8 @@ fn gen_value_enum_operand_kind(grammar: &structs::OperandKind) -> TokenStream {
                 e.symbol.to_string()
             };
             let name = as_ident(&name);
-            let number = e.value.number;
-            seen_discriminator.insert(e.value.number, name.clone());
+            let number = e.value;
+            seen_discriminator.insert(e.value, name.clone());
             enumerants.push(quote! { #name = #number });
             capability_clauses.entry(&e.capabilities).or_insert_with(Vec::new).push(name);
         }
@@ -137,19 +136,18 @@ fn gen_value_enum_operand_kind(grammar: &structs::OperandKind) -> TokenStream {
 /// Returns the code defining the enum for an operand kind by parsing
 /// the given SPIR-V `grammar`.
 fn gen_operand_kind(grammar: &structs::OperandKind) -> Option<TokenStream> {
-    if grammar.category == "BitEnum" {
-        Some(gen_bit_enum_operand_kind(grammar))
-    } else if grammar.category == "ValueEnum" {
-        Some(gen_value_enum_operand_kind(grammar))
-    } else {
-        None
+    use structs::Category::*;
+    match grammar.category {
+        BitEnum => Some(gen_bit_enum_operand_kind(grammar)),
+        ValueEnum => Some(gen_value_enum_operand_kind(grammar)),
+        _ => None,
     }
 }
 
 /// Returns the generated SPIR-V header.
 pub fn gen_spirv_header(grammar: &structs::Grammar) -> TokenStream {
     // constants and types.
-    let magic_number = u32::from_str_radix(&grammar.magic_number[2..], 16).expect("Magic number not a u32");
+    let magic_number = format!("{:#010X}", grammar.magic_number).parse::<TokenStream>().unwrap();
     let major_version = grammar.major_version;
     let minor_version = grammar.minor_version;
     let revision = grammar.revision;

--- a/autogen/table.rs
+++ b/autogen/table.rs
@@ -18,13 +18,12 @@ use crate::utils::*;
 use proc_macro2::{Ident, TokenStream};
 use quote::quote;
 
-fn convert_quantifier(quantifier: &str) -> Ident {
-    as_ident(if quantifier == "" {
-        "One"
-    } else if quantifier == "?" {
-        "ZeroOrOne"
-    } else {
-        "ZeroOrMore"
+fn convert_quantifier(quantifier: structs::Quantifier) -> Ident {
+    use structs::Quantifier::*;
+    as_ident(match quantifier {
+        One => "One",
+        ZeroOrOne => "ZeroOrOne",
+        ZeroOrMore => "ZeroOrMore",
     })
 }
 
@@ -40,7 +39,7 @@ fn gen_instruction_table(grammar: &Vec<structs::Instruction>, name: &str, is_ext
         // Vector of strings for all operands.
         let operands = inst.operands.iter().map(|e| {
             let kind = as_ident(&e.kind);
-            let quantifier = convert_quantifier(&e.quantifier);
+            let quantifier = convert_quantifier(e.quantifier);
             quote! { (#kind, #quantifier) }
         });
         let caps = inst.capabilities.iter().map(|cap| as_ident(cap));

--- a/spirv/autogen_spirv.rs
+++ b/spirv/autogen_spirv.rs
@@ -17,7 +17,7 @@
 // DO NOT MODIFY!
 
 pub type Word = u32;
-pub const MAGIC_NUMBER: u32 = 119734787u32;
+pub const MAGIC_NUMBER: u32 = 0x07230203;
 pub const MAJOR_VERSION: u8 = 1u8;
 pub const MINOR_VERSION: u8 = 3u8;
 pub const REVISION: u8 = 1u8;


### PR DESCRIPTION
Fixes #45 
This adds a few enums to the deserialiser so that there is less string checking in the autogen code. It also changes the Enumerant value field to be a u32 by parsing the string form, which eliminates the weird struct-that's-actually-an-enum.