### PR TITLE
[sr] parse OpPhi and transform it into block arguments.

### DIFF
--- a/autogen/sr.rs
+++ b/autogen/sr.rs
@@ -94,14 +94,14 @@ impl OperandTokens {
                 None,
             ),
             "PairLiteralIntegerIdRef" => (
-                quote! { (u32, Token<BasicBlock>) },
-                quote! { (first, self.basic_blocks[&second]) },
+                quote! { (u32, Jump) },
+                quote! { (first, self.lookup_jump(second)) },
                 "LiteralInt32",
                 Some("IdRef"),
             ),
             "PairIdRefLiteralInteger" => (
-                quote! { (Token<BasicBlock>, u32) },
-                quote! { (self.basic_blocks[&first], second) },
+                quote! { (Jump, u32) },
+                quote! { (self.lookup_jump(first), second) },
                 "IdRef",
                 Some("LiteralInt32"),
             ),
@@ -375,6 +375,9 @@ pub fn gen_sr_code_from_instruction_grammar(
                     });
                 }
             }
+            _ if inst_name == "Phi" => {
+
+            }
             _ => {
                 op_variants.push(if field_names.is_empty() {
                     quote!{ #name_ident }
@@ -399,7 +402,7 @@ pub fn gen_sr_code_from_instruction_grammar(
     };
 
     let ops = quote! {
-        use crate::sr::{module::BasicBlock, storage::Token, Type};
+        use crate::sr::{module::Jump, storage::Token, Type};
 
         #[derive(Clone, Debug, Eq, PartialEq)]
         pub enum Branch {

--- a/rspirv/lift/autogen_context.rs
+++ b/rspirv/lift/autogen_context.rs
@@ -64,7 +64,7 @@ impl LiftContext {
                         (
                             Some(&dr::Operand::LiteralInt32(first)),
                             Some(&dr::Operand::IdRef(second)),
-                        ) => Some((first, self.basic_blocks[&second])),
+                        ) => Some((first, self.lookup_jump(second))),
                         (None, None) => None,
                         _ => Err(OperandError::WrongType)?,
                     } {

--- a/rspirv/sr/autogen_ops.rs
+++ b/rspirv/sr/autogen_ops.rs
@@ -2,7 +2,7 @@
 //   external/spirv.core.grammar.json.
 // DO NOT MODIFY!
 
-use crate::sr::{module::BasicBlock, storage::Token, Type};
+use crate::sr::{module::Jump, storage::Token, Type};
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Branch {
     Branch {
@@ -17,7 +17,7 @@ pub enum Branch {
     Switch {
         selector: spirv::Word,
         default: spirv::Word,
-        target: Vec<(u32, Token<BasicBlock>)>,
+        target: Vec<(u32, Jump)>,
     },
     Return,
     ReturnValue {
@@ -142,7 +142,7 @@ pub enum Op {
     },
     GroupMemberDecorate {
         decoration_group: spirv::Word,
-        targets: Vec<(Token<BasicBlock>, u32)>,
+        targets: Vec<(Jump, u32)>,
     },
     VectorExtractDynamic {
         vector: spirv::Word,
@@ -767,9 +767,6 @@ pub enum Op {
         scope: spirv::Word,
         semantics: spirv::Word,
         value: spirv::Word,
-    },
-    Phi {
-        value_label_pairs: Vec<(spirv::Word, spirv::Word)>,
     },
     LoopMerge {
         merge_block: spirv::Word,

--- a/rspirv/sr/mod.rs
+++ b/rspirv/sr/mod.rs
@@ -3,8 +3,8 @@
 pub use self::autogen_decoration::Decoration;
 pub use self::autogen_instructions as instructions;
 pub use self::autogen_ops as ops;
-pub use self::constants::{Constant};
-pub use self::types::{Type};
+pub use self::constants::Constant;
+pub use self::types::Type;
 
 mod autogen_decoration;
 pub mod autogen_instructions;

--- a/rspirv/sr/module.rs
+++ b/rspirv/sr/module.rs
@@ -18,8 +18,18 @@ pub struct EntryPoint {
 
 #[derive(Debug)]
 pub struct BasicBlock {
-   pub ops: Vec<Op>,
-   pub terminator: ops::Terminator,
+    pub arguments: Vec<Token<Type>>,
+    pub ops: Vec<Token<Op>>,
+    pub terminator: ops::Terminator,
+}
+
+/// Jump destination parameters.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Jump {
+    /// The basic block to jump to.
+    pub block: Token<BasicBlock>,
+    /// The argument values corresponding to the basic block arguments.
+    pub arguments: Vec<Token<Op>>,
 }
 
 pub struct Function {
@@ -53,4 +63,6 @@ pub struct Module {
 
     /// All functions.
     pub functions: Vec<Function>,
+    /// All operations.
+    pub ops: Storage<Op>,
 }


### PR DESCRIPTION
Fixes #102

This change represents OpPhi instructions in the structured representation
as block arguments, which are types for the destination block, and
operations for the source blocks.