### PR TITLE
Add support for 64-bit constants

### DIFF
--- a/rspirv/binary/assemble.rs
+++ b/rspirv/binary/assemble.rs
@@ -62,9 +62,9 @@ impl Assemble for dr::Operand {
             dr::Operand::IdRef(v) |
             dr::Operand::LiteralInt32(v) |
             dr::Operand::LiteralExtInstInteger(v) => vec![v],
-            dr::Operand::LiteralInt64(_) => unimplemented!(),
+            dr::Operand::LiteralInt64(v) => vec![v as u32, (v >> 32) as u32],
             dr::Operand::LiteralFloat32(v) => vec![v.to_bits()],
-            dr::Operand::LiteralFloat64(_) => unimplemented!(),
+            dr::Operand::LiteralFloat64(v) => vec![v.to_bits() as u32, (v.to_bits() >> 32) as u32],
             dr::Operand::LiteralSpecConstantOpInteger(v) => vec![v as u32],
             dr::Operand::LiteralString(ref v) => assemble_str(v),
         }

--- a/rspirv/dr/build/mod.rs
+++ b/rspirv/dr/build/mod.rs
@@ -445,6 +445,19 @@ impl Builder {
         id
     }
 
+    /// Appends an OpConstant instruction with the given 64-bit float `value`.
+    pub fn constant_f64(&mut self, result_type: spirv::Word, value: f64) -> spirv::Word {
+        let id = self.id();
+        let inst = dr::Instruction::new(
+            spirv::Op::Constant,
+            Some(result_type),
+            Some(id),
+            vec![dr::Operand::LiteralFloat64(value)],
+        );
+        self.module.types_global_values.push(inst);
+        id
+    }
+
     /// Appends an OpConstant instruction with the given 32-bit integer `value`.
     /// or the module if no block is under construction.
     pub fn constant_u32(&mut self, result_type: spirv::Word, value: u32) -> spirv::Word {
@@ -454,6 +467,19 @@ impl Builder {
             Some(result_type),
             Some(id),
             vec![dr::Operand::LiteralInt32(value)],
+        );
+        self.module.types_global_values.push(inst);
+        id
+    }
+
+    /// Appends an OpConstant instruction with the given 64-bit integer `value`.
+    pub fn constant_u64(&mut self, result_type: spirv::Word, value: u64) -> spirv::Word {
+        let id = self.id();
+        let inst = dr::Instruction::new(
+            spirv::Op::Constant,
+            Some(result_type),
+            Some(id),
+            vec![dr::Operand::LiteralInt64(value)],
         );
         self.module.types_global_values.push(inst);
         id
@@ -473,6 +499,19 @@ impl Builder {
         id
     }
 
+    /// Appends an OpSpecConstant instruction with the given 64-bit float `value`.
+    pub fn spec_constant_f64(&mut self, result_type: spirv::Word, value: f64) -> spirv::Word {
+        let id = self.id();
+        let inst = dr::Instruction::new(
+            spirv::Op::SpecConstant,
+            Some(result_type),
+            Some(id),
+            vec![dr::Operand::LiteralFloat64(value)],
+        );
+        self.module.types_global_values.push(inst);
+        id
+    }
+
     /// Appends an OpSpecConstant instruction with the given 32-bit integer `value`.
     /// or the module if no block is under construction.
     pub fn spec_constant_u32(&mut self, result_type: spirv::Word, value: u32) -> spirv::Word {
@@ -482,6 +521,19 @@ impl Builder {
             Some(result_type),
             Some(id),
             vec![dr::Operand::LiteralInt32(value)],
+        );
+        self.module.types_global_values.push(inst);
+        id
+    }
+
+    /// Appends an OpSpecConstant instruction with the given 32-bit integer `value`.
+    pub fn spec_constant_u64(&mut self, result_type: spirv::Word, value: u64) -> spirv::Word {
+        let id = self.id();
+        let inst = dr::Instruction::new(
+            spirv::Op::SpecConstant,
+            Some(result_type),
+            Some(id),
+            vec![dr::Operand::LiteralInt64(value)],
         );
         self.module.types_global_values.push(inst);
         id


### PR DESCRIPTION
Adds four additional functions to Builder, namely constant_f64,
constant_u64, spec_constant_f64, spec_constant_u64. These are mostly copies
of their 32-bit equivalents, except that they use different types.

Additionally implements two branches in the impl Assemble for Operand
for variants LiteralInt64 and LiteralFloat64 according to section 2.2.1
of the spec (v1.5).