### PR TITLE
Install and run rustfmt only on stable Rust

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ jobs:
       rust: nightly 
       script: # rustfmt is not always available on nightly
         - cargo check --verbose
-        - git diff --exit-code
         - cargo test --verbose
     - os: osx
       rust: stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,36 +10,21 @@ before_script:
 
 jobs:
   include:
-    - stage: install_rustfmt
-      os: linux
+    - os: linux
       rust: stable
-      script: rustup component add rustfmt
-    - stage: install_rustfmt
-      os: osx
-      rust: stable
-      script: rustup component add rustfmt
-    - stage: install_rustfmt
-      os: windows
-      rust: stable
-      script: rustup component add rustfmt
-    - stage: test
-      os: linux
-      rust: stable
-    - stage: test
-      os: linux
+    - os: linux
       rust: nightly 
-    - stage: test
-      os: osx
+      script: # rustfmt is not always available on nightly
+        - cargo check --verbose
+        - git diff --exit-code
+        - cargo test --verbose
+    - os: osx
       rust: stable
-    - stage: test
-      os: windows
+    - os: windows
       rust: stable
 
 script:
+  - rustup component add rustfmt
   - cargo check --verbose
   - git diff --exit-code
   - cargo test --verbose
-
-stages:
-  - install_rustfmt
-  - test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,6 @@
 language: rust
 
 sudo: false
-matrix:
-  fast_finish: true
-  include:
-    - os: linux
-      rust: stable
-    - os: linux
-      rust: nightly
-    - os: osx
-      rust: stable
-    - os: windows
-      rust: stable
-
 branches:
   except:
     - staging.tmp
@@ -23,14 +11,35 @@ before_script:
 jobs:
   include:
     - stage: install_rustfmt
+      os: linux
+      rust: stable
+      script: rustup component add rustfmt
+    - stage: install_rustfmt
+      os: osx
+      rust: stable
+      script: rustup component add rustfmt
+    - stage: install_rustfmt
+      os: windows
+      rust: stable
       script: rustup component add rustfmt
     - stage: test
-      script:
-        - cargo check --verbose
-        - git diff --exit-code
-        - cargo test --verbose
+      os: linux
+      rust: stable
+    - stage: test
+      os: linux
+      rust: nightly 
+    - stage: test
+      os: osx
+      rust: stable
+    - stage: test
+      os: windows
+      rust: stable
+
+script:
+  - cargo check --verbose
+  - git diff --exit-code
+  - cargo test --verbose
 
 stages:
-  - name: install_rustfmt
-    if: env(TRAVIS_RUST_VERSION) =~ stable
+  - install_rustfmt
   - test

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,7 @@ before_script:
 jobs:
   include:
     - stage: install_rustfmt
-      script:
-        - rustup component add rustfmt
+      script: rustup component add rustfmt
     - stage: test
       script:
         - cargo check --verbose

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,19 @@ branches:
 
 before_script:
   - git submodule update --init
-  - rustup component add rustfmt
 
-script:
-  - cargo check --verbose
-  - git diff --exit-code
-  - cargo test --verbose
+jobs:
+  include:
+    - stage: install_rustfmt
+      script:
+        - rustup component add rustfmt
+    - stage: test
+      script:
+        - cargo check --verbose
+        - git diff --exit-code
+        - cargo test --verbose
+
+stages:
+  - name: install_rustfmt
+    if: env(TRAVIS_RUST_VERSION) =~ stable
+  - test


### PR DESCRIPTION
The goal of this change is to fix #126 