### PR TITLE
Fix crate name in README

### DIFF
--- a/spirv/README.md
+++ b/spirv/README.md
@@ -18,7 +18,7 @@ First add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-rspirv_headers = "1.4"
+spirv_headers = "1.4"
 ```
 
 Then add to your crate root:


### PR DESCRIPTION
It now says spirv_headers instead of rspirv_headers