### PR TITLE
Adds a getter for index in rspirv::sr::storage::Token

### DIFF
--- a/rspirv/sr/storage.rs
+++ b/rspirv/sr/storage.rs
@@ -51,6 +51,10 @@ impl<T> Token<T> {
             marker: PhantomData,
         }
     }
+
+    pub fn index(&self) -> Index {
+        self.index
+    }
 }
 
 /// A structure holding some kind of SPIR-V entity (e.g., type, constant,


### PR DESCRIPTION
This is very helpful and enables me to build a cache for types and constants using the structured representation already, even if the rest is not done yet. Exposing the index of a token to be read from the outside should not cause any problems.