### PR TITLE
dr: Re-add missing id in builder_types

### DIFF
--- a/autogen/dr.rs
+++ b/autogen/dr.rs
@@ -330,7 +330,8 @@ pub fn gen_dr_builder_terminator(grammar: &structs::Grammar) -> TokenStream {
     let kinds = &grammar.operand_kinds;
     // Generate build methods for all types.
     let elements = grammar.instructions.iter().filter(|inst| {
-        inst.class == Some(structs::Class::Terminator) || inst.class == Some(structs::Class::Branch)
+        inst.class == Some(structs::Class::Terminator) ||
+        (inst.class == Some(structs::Class::Branch) && inst.opname != "OpPhi")
     }).map(|inst| {
         let (params, generic) = get_param_list(&inst.operands, inst.opname == "OpLabel", kinds);
         let extras = get_push_extras(&inst.operands, kinds, quote! { inst.operands });
@@ -395,7 +396,7 @@ pub fn gen_dr_builder_normal_insts(grammar: &structs::Grammar) -> TokenStream {
             inst.class == Some(Debug) ||
             inst.class == Some(Annotation) ||
             inst.class == Some(Terminator) ||
-            inst.class == Some(Branch) ||
+            (inst.class == Some(Branch) && inst.opname != "OpPhi") ||
             inst.class == Some(ModeSetting) ||
             inst.class == Some(Exclude) ||
             inst.opname == "OpTypeForwardPointer" ||

--- a/autogen/dr.rs
+++ b/autogen/dr.rs
@@ -310,7 +310,8 @@ pub fn gen_dr_builder_types(grammar: &structs::Grammar) -> TokenStream {
                 #[doc = #comment]
                 pub fn #name#generic(&mut self,#(#param_list),*) -> spirv::Word {
                     let mut inst = dr::Instruction::new(spirv::Op::#opcode, None, None, vec![#(#init_list),*]);
-                    inst.result_id = Some(self.dedup_insert_type(&inst));
+                    let id = self.dedup_insert_type(&inst);
+                    inst.result_id = Some(id);
                     self.module.types_global_values.push(inst);
                     #(#extras)*
                     id

--- a/rspirv/binary/disassemble.rs
+++ b/rspirv/binary/disassemble.rs
@@ -256,7 +256,7 @@ mod tests {
 
         assert_eq!(b.module().disassemble(),
                    "; SPIR-V\n\
-                    ; Version: 1.4\n\
+                    ; Version: 1.5\n\
                     ; Generator: rspirv\n\
                     ; Bound: 8\n\
                     OpCapability Shader\n\
@@ -299,7 +299,7 @@ mod tests {
 
         assert_eq!(b.module().disassemble(),
                    "; SPIR-V\n\
-                    ; Version: 1.4\n\
+                    ; Version: 1.5\n\
                     ; Generator: rspirv\n\
                     ; Bound: 9\n\
                     OpCapability Shader\n\
@@ -336,7 +336,7 @@ mod tests {
 
         assert_eq!(b.module().disassemble(),
                    "; SPIR-V\n\
-                    ; Version: 1.4\n\
+                    ; Version: 1.5\n\
                     ; Generator: rspirv\n\
                     ; Bound: 9\n\
                     %1 = OpExtInstImport \"OpenCL.std\"\n\

--- a/rspirv/binary/disassemble.rs
+++ b/rspirv/binary/disassemble.rs
@@ -293,7 +293,17 @@ mod tests {
         assert!(b.begin_function(void, None, spirv::FunctionControl::NONE, voidfvoid).is_ok());
         b.begin_block(None).unwrap();
         let var = b.variable(float32, None, spirv::StorageClass::Function, None);
-        assert!(b.ext_inst(float32, None, glsl, 6, vec![var]).is_ok());
+        let mut inst = dr::Instruction::new(
+            spirv::Op::ExtInst,
+            Some(float32),
+            Some(b.id()),
+            vec![
+                dr::Operand::IdRef(glsl),
+                dr::Operand::LiteralExtInstInteger(6),
+            ],
+        );
+        inst.operands.push(dr::Operand::IdRef(var));
+        assert!(b.insert_into_block(dr::InsertPoint::End, inst).is_ok());
         b.ret().unwrap();
         b.end_function().unwrap();
 
@@ -330,8 +340,20 @@ mod tests {
         assert!(b.begin_function(void, None, spirv::FunctionControl::NONE, voidfvoid).is_ok());
         b.begin_block(None).unwrap();
         let var = b.variable(float32, None, spirv::StorageClass::Function, None);
-        assert!(b.ext_inst(float32, None, opencl, 15, vec![var]).is_ok());
+
+        let mut inst = dr::Instruction::new(
+            spirv::Op::ExtInst,
+            Some(float32),
+            Some(b.id()),
+            vec![
+                dr::Operand::IdRef(opencl),
+                dr::Operand::LiteralExtInstInteger(15),
+            ],
+        );
+        inst.operands.push(dr::Operand::IdRef(var));
+        assert!(b.insert_into_block(dr::InsertPoint::End, inst).is_ok());
         b.ret().unwrap();
+
         b.end_function().unwrap();
 
         assert_eq!(b.module().disassemble(),

--- a/rspirv/dr/build/autogen_norm_insts.rs
+++ b/rspirv/dr/build/autogen_norm_insts.rs
@@ -7775,6 +7775,41 @@ impl Builder {
         self.insert_into_block(insert_point, inst)?;
         Ok(_id)
     }
+    #[doc = "Appends an OpPhi instruction to the current block."]
+    pub fn phi<T: AsRef<[(spirv::Word, spirv::Word)]>>(
+        &mut self,
+        result_type: spirv::Word,
+        result_id: Option<spirv::Word>,
+        variable_parent: T,
+    ) -> BuildResult<spirv::Word> {
+        let _id = result_id.unwrap_or_else(|| self.id());
+        #[allow(unused_mut)]
+        let mut inst = dr::Instruction::new(spirv::Op::Phi, Some(result_type), Some(_id), vec![]);
+        for v in variable_parent.as_ref() {
+            inst.operands.push(dr::Operand::IdRef(v.0));
+            inst.operands.push(dr::Operand::IdRef(v.1));
+        }
+        self.insert_into_block(InsertPoint::End, inst)?;
+        Ok(_id)
+    }
+    #[doc = "Appends an OpPhi instruction to the current block."]
+    pub fn insert_phi<T: AsRef<[(spirv::Word, spirv::Word)]>>(
+        &mut self,
+        insert_point: InsertPoint,
+        result_type: spirv::Word,
+        result_id: Option<spirv::Word>,
+        variable_parent: T,
+    ) -> BuildResult<spirv::Word> {
+        let _id = result_id.unwrap_or_else(|| self.id());
+        #[allow(unused_mut)]
+        let mut inst = dr::Instruction::new(spirv::Op::Phi, Some(result_type), Some(_id), vec![]);
+        for v in variable_parent.as_ref() {
+            inst.operands.push(dr::Operand::IdRef(v.0));
+            inst.operands.push(dr::Operand::IdRef(v.1));
+        }
+        self.insert_into_block(insert_point, inst)?;
+        Ok(_id)
+    }
     #[doc = "Appends an OpGroupAsyncCopy instruction to the current block."]
     pub fn group_async_copy(
         &mut self,

--- a/rspirv/dr/build/autogen_terminator.rs
+++ b/rspirv/dr/build/autogen_terminator.rs
@@ -3,35 +3,6 @@
 // DO NOT MODIFY!
 
 impl Builder {
-    #[doc = "Appends an OpPhi instruction and ends the current block."]
-    pub fn phi<T: AsRef<[(spirv::Word, spirv::Word)]>>(
-        &mut self,
-        result_type: spirv::Word,
-        variable_parent: T,
-    ) -> BuildResult<()> {
-        #[allow(unused_mut)]
-        let mut inst = dr::Instruction::new(spirv::Op::Phi, Some(result_type), None, vec![]);
-        for v in variable_parent.as_ref() {
-            inst.operands.push(dr::Operand::IdRef(v.0));
-            inst.operands.push(dr::Operand::IdRef(v.1));
-        }
-        self.end_block(inst)
-    }
-    #[doc = "Insert an OpPhi instruction and ends the current block."]
-    pub fn insert_phi<T: AsRef<[(spirv::Word, spirv::Word)]>>(
-        &mut self,
-        insert_point: InsertPoint,
-        result_type: spirv::Word,
-        variable_parent: T,
-    ) -> BuildResult<()> {
-        #[allow(unused_mut)]
-        let mut inst = dr::Instruction::new(spirv::Op::Phi, Some(result_type), None, vec![]);
-        for v in variable_parent.as_ref() {
-            inst.operands.push(dr::Operand::IdRef(v.0));
-            inst.operands.push(dr::Operand::IdRef(v.1));
-        }
-        self.insert_end_block(insert_point, inst)
-    }
     #[doc = "Appends an OpLoopMerge instruction and ends the current block."]
     pub fn loop_merge<T: AsRef<[dr::Operand]>>(
         &mut self,

--- a/rspirv/dr/build/autogen_type.rs
+++ b/rspirv/dr/build/autogen_type.rs
@@ -6,14 +6,16 @@ impl Builder {
     #[doc = "Appends an OpTypeVoid instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_void(&mut self) -> spirv::Word {
         let mut inst = dr::Instruction::new(spirv::Op::TypeVoid, None, None, vec![]);
-        inst.result_id = Some(self.dedup_insert_type(&inst));
+        let id = self.dedup_insert_type(&inst);
+        inst.result_id = Some(id);
         self.module.types_global_values.push(inst);
         id
     }
     #[doc = "Appends an OpTypeBool instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_bool(&mut self) -> spirv::Word {
         let mut inst = dr::Instruction::new(spirv::Op::TypeBool, None, None, vec![]);
-        inst.result_id = Some(self.dedup_insert_type(&inst));
+        let id = self.dedup_insert_type(&inst);
+        inst.result_id = Some(id);
         self.module.types_global_values.push(inst);
         id
     }
@@ -28,7 +30,8 @@ impl Builder {
                 dr::Operand::LiteralInt32(signedness),
             ],
         );
-        inst.result_id = Some(self.dedup_insert_type(&inst));
+        let id = self.dedup_insert_type(&inst);
+        inst.result_id = Some(id);
         self.module.types_global_values.push(inst);
         id
     }
@@ -40,7 +43,8 @@ impl Builder {
             None,
             vec![dr::Operand::LiteralInt32(width)],
         );
-        inst.result_id = Some(self.dedup_insert_type(&inst));
+        let id = self.dedup_insert_type(&inst);
+        inst.result_id = Some(id);
         self.module.types_global_values.push(inst);
         id
     }
@@ -59,7 +63,8 @@ impl Builder {
                 dr::Operand::LiteralInt32(component_count),
             ],
         );
-        inst.result_id = Some(self.dedup_insert_type(&inst));
+        let id = self.dedup_insert_type(&inst);
+        inst.result_id = Some(id);
         self.module.types_global_values.push(inst);
         id
     }
@@ -74,7 +79,8 @@ impl Builder {
                 dr::Operand::LiteralInt32(column_count),
             ],
         );
-        inst.result_id = Some(self.dedup_insert_type(&inst));
+        let id = self.dedup_insert_type(&inst);
+        inst.result_id = Some(id);
         self.module.types_global_values.push(inst);
         id
     }
@@ -104,7 +110,8 @@ impl Builder {
                 dr::Operand::ImageFormat(image_format),
             ],
         );
-        inst.result_id = Some(self.dedup_insert_type(&inst));
+        let id = self.dedup_insert_type(&inst);
+        inst.result_id = Some(id);
         self.module.types_global_values.push(inst);
         if let Some(v) = access_qualifier {
             #[allow(clippy::identity_conversion)]
@@ -120,7 +127,8 @@ impl Builder {
     #[doc = "Appends an OpTypeSampler instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_sampler(&mut self) -> spirv::Word {
         let mut inst = dr::Instruction::new(spirv::Op::TypeSampler, None, None, vec![]);
-        inst.result_id = Some(self.dedup_insert_type(&inst));
+        let id = self.dedup_insert_type(&inst);
+        inst.result_id = Some(id);
         self.module.types_global_values.push(inst);
         id
     }
@@ -132,7 +140,8 @@ impl Builder {
             None,
             vec![dr::Operand::IdRef(image_type)],
         );
-        inst.result_id = Some(self.dedup_insert_type(&inst));
+        let id = self.dedup_insert_type(&inst);
+        inst.result_id = Some(id);
         self.module.types_global_values.push(inst);
         id
     }
@@ -144,7 +153,8 @@ impl Builder {
             None,
             vec![dr::Operand::IdRef(element_type), dr::Operand::IdRef(length)],
         );
-        inst.result_id = Some(self.dedup_insert_type(&inst));
+        let id = self.dedup_insert_type(&inst);
+        inst.result_id = Some(id);
         self.module.types_global_values.push(inst);
         id
     }
@@ -156,7 +166,8 @@ impl Builder {
             None,
             vec![dr::Operand::IdRef(element_type)],
         );
-        inst.result_id = Some(self.dedup_insert_type(&inst));
+        let id = self.dedup_insert_type(&inst);
+        inst.result_id = Some(id);
         self.module.types_global_values.push(inst);
         id
     }
@@ -166,7 +177,8 @@ impl Builder {
         member_0_type_member_1_type: T,
     ) -> spirv::Word {
         let mut inst = dr::Instruction::new(spirv::Op::TypeStruct, None, None, vec![]);
-        inst.result_id = Some(self.dedup_insert_type(&inst));
+        let id = self.dedup_insert_type(&inst);
+        inst.result_id = Some(id);
         self.module.types_global_values.push(inst);
         for v in member_0_type_member_1_type.as_ref() {
             self.module
@@ -190,7 +202,8 @@ impl Builder {
             None,
             vec![dr::Operand::IdRef(return_type)],
         );
-        inst.result_id = Some(self.dedup_insert_type(&inst));
+        let id = self.dedup_insert_type(&inst);
+        inst.result_id = Some(id);
         self.module.types_global_values.push(inst);
         for v in parameter_0_type_parameter_1_type.as_ref() {
             self.module
@@ -205,28 +218,32 @@ impl Builder {
     #[doc = "Appends an OpTypeEvent instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_event(&mut self) -> spirv::Word {
         let mut inst = dr::Instruction::new(spirv::Op::TypeEvent, None, None, vec![]);
-        inst.result_id = Some(self.dedup_insert_type(&inst));
+        let id = self.dedup_insert_type(&inst);
+        inst.result_id = Some(id);
         self.module.types_global_values.push(inst);
         id
     }
     #[doc = "Appends an OpTypeDeviceEvent instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_device_event(&mut self) -> spirv::Word {
         let mut inst = dr::Instruction::new(spirv::Op::TypeDeviceEvent, None, None, vec![]);
-        inst.result_id = Some(self.dedup_insert_type(&inst));
+        let id = self.dedup_insert_type(&inst);
+        inst.result_id = Some(id);
         self.module.types_global_values.push(inst);
         id
     }
     #[doc = "Appends an OpTypeReserveId instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_reserve_id(&mut self) -> spirv::Word {
         let mut inst = dr::Instruction::new(spirv::Op::TypeReserveId, None, None, vec![]);
-        inst.result_id = Some(self.dedup_insert_type(&inst));
+        let id = self.dedup_insert_type(&inst);
+        inst.result_id = Some(id);
         self.module.types_global_values.push(inst);
         id
     }
     #[doc = "Appends an OpTypeQueue instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_queue(&mut self) -> spirv::Word {
         let mut inst = dr::Instruction::new(spirv::Op::TypeQueue, None, None, vec![]);
-        inst.result_id = Some(self.dedup_insert_type(&inst));
+        let id = self.dedup_insert_type(&inst);
+        inst.result_id = Some(id);
         self.module.types_global_values.push(inst);
         id
     }
@@ -238,21 +255,24 @@ impl Builder {
             None,
             vec![dr::Operand::AccessQualifier(qualifier)],
         );
-        inst.result_id = Some(self.dedup_insert_type(&inst));
+        let id = self.dedup_insert_type(&inst);
+        inst.result_id = Some(id);
         self.module.types_global_values.push(inst);
         id
     }
     #[doc = "Appends an OpTypePipeStorage instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_pipe_storage(&mut self) -> spirv::Word {
         let mut inst = dr::Instruction::new(spirv::Op::TypePipeStorage, None, None, vec![]);
-        inst.result_id = Some(self.dedup_insert_type(&inst));
+        let id = self.dedup_insert_type(&inst);
+        inst.result_id = Some(id);
         self.module.types_global_values.push(inst);
         id
     }
     #[doc = "Appends an OpTypeNamedBarrier instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_named_barrier(&mut self) -> spirv::Word {
         let mut inst = dr::Instruction::new(spirv::Op::TypeNamedBarrier, None, None, vec![]);
-        inst.result_id = Some(self.dedup_insert_type(&inst));
+        let id = self.dedup_insert_type(&inst);
+        inst.result_id = Some(id);
         self.module.types_global_values.push(inst);
         id
     }

--- a/rspirv/dr/build/mod.rs
+++ b/rspirv/dr/build/mod.rs
@@ -1137,7 +1137,7 @@ mod tests {
 
         assert_eq!(
             b.module().disassemble(),
-            "; SPIR-V\n; Version: 1.4\n; Generator: rspirv\n; Bound: 11\n\
+            "; SPIR-V\n; Version: 1.5\n; Generator: rspirv\n; Bound: 11\n\
                     %1 = OpTypeVoid\n\
                     %2 = OpTypeFloat 32\n\
                     %3 = OpTypePointer Input %2\n\
@@ -1184,7 +1184,7 @@ mod tests {
 
         assert_eq!(
             b.module().disassemble(),
-            "; SPIR-V\n; Version: 1.4\n; Generator: rspirv\n; Bound: 9\n\
+            "; SPIR-V\n; Version: 1.5\n; Generator: rspirv\n; Bound: 9\n\
                     %1 = OpTypeVoid\n\
                     %2 = OpTypeFloat 32\n\
                     %3 = OpTypeFunction %1 %1\n\

--- a/rspirv/dr/build/mod.rs
+++ b/rspirv/dr/build/mod.rs
@@ -134,7 +134,7 @@ impl Builder {
         }
     }
 
-    fn insert_into_block(&mut self, insert_point: InsertPoint, inst: dr::Instruction) -> BuildResult<()> {
+    pub fn insert_into_block(&mut self, insert_point: InsertPoint, inst: dr::Instruction) -> BuildResult<()> {
         let allow = self.new_block.is_some() || self.selected_function.is_some() && self.selected_block.is_some();
 
         if !allow {

--- a/rspirv/lib.rs
+++ b/rspirv/lib.rs
@@ -67,7 +67,7 @@
 //!     // Disassembling
 //!     assert_eq!(module.disassemble(),
 //!                "; SPIR-V\n\
-//!                 ; Version: 1.4\n\
+//!                 ; Version: 1.5\n\
 //!                 ; Generator: rspirv\n\
 //!                 ; Bound: 5\n\
 //!                 OpMemoryModel Logical GLSL450\n\


### PR DESCRIPTION
The assignment of `id` for non-aggregate types is missing, resulting in build errors when compiling `autogen_type.rs`.

The desired `id` to return is not `self.id()`, but the result of `dedup_insert_type` which returns an existing `id` or `self.id()` if not found.
