### PR TITLE
Pass in which instruction got detached

### DIFF
--- a/rspirv/dr/build/mod.rs
+++ b/rspirv/dr/build/mod.rs
@@ -147,7 +147,7 @@ impl Builder {
             || self.selected_function.is_some() && self.selected_block.is_some();
 
         if !allow {
-            return Err(Error::DetachedInstruction);
+            return Err(Error::DetachedInstruction(Some(inst)));
         }
 
         let ref mut block = if self.new_block.is_some() {
@@ -175,7 +175,7 @@ impl Builder {
             || self.selected_function.is_some() && self.selected_block.is_some();
 
         if !allow {
-            return Err(Error::DetachedInstruction);
+            return Err(Error::DetachedInstruction(None));
         }
 
         let ref mut block = if self.new_block.is_some() {

--- a/rspirv/dr/loader.rs
+++ b/rspirv/dr/loader.rs
@@ -4,7 +4,7 @@ use crate::grammar;
 use crate::spirv;
 
 use crate::binary::{ParseAction, ParseResult};
-use std::{error, fmt};
+use std::{borrow::Cow, error, fmt};
 
 /// Data representation loading errors.
 #[derive(Debug)]
@@ -32,32 +32,32 @@ impl Error {
     ///
     /// This method is intended to be used by fmt::Display and error::Error to
     /// avoid duplication in implementation. So it's private.
-    fn describe(&self) -> String {
+    fn describe(&self) -> Cow<'static, str> {
         match &*self {
-            Error::NestedFunction => "found nested function".to_string(),
-            Error::UnclosedFunction => "found unclosed function".to_string(),
-            Error::MismatchedFunctionEnd => "found mismatched OpFunctionEnd".to_string(),
+            Error::NestedFunction => Cow::Borrowed("found nested function"),
+            Error::UnclosedFunction => Cow::Borrowed("found unclosed function"),
+            Error::MismatchedFunctionEnd => Cow::Borrowed("found mismatched OpFunctionEnd"),
             Error::DetachedFunctionParameter => {
-                "found function OpFunctionParameter not inside function".to_string()
+                Cow::Borrowed("found function OpFunctionParameter not inside function")
             }
-            Error::DetachedBlock => "found block not inside function".to_string(),
-            Error::NestedBlock => "found nested block".to_string(),
-            Error::UnclosedBlock => "found block without terminator".to_string(),
-            Error::MismatchedTerminator => "found mismatched terminator".to_string(),
-            Error::DetachedInstruction(Some(inst)) => format!(
+            Error::DetachedBlock => Cow::Borrowed("found block not inside function"),
+            Error::NestedBlock => Cow::Borrowed("found nested block"),
+            Error::UnclosedBlock => Cow::Borrowed("found block without terminator"),
+            Error::MismatchedTerminator => Cow::Borrowed("found mismatched terminator"),
+            Error::DetachedInstruction(Some(inst)) => Cow::Owned(format!(
                 "found instruction `{:?}` not inside block",
                 inst.class.opname
-            ),
+            )),
             Error::DetachedInstruction(None) => {
-                "found unknown instruction not inside block".to_string()
+                Cow::Borrowed("found unknown instruction not inside block")
             }
-            Error::EmptyInstructionList => "list of instructions is empty".to_string(),
-            Error::WrongOpCapabilityOperand => "wrong OpCapability operand".to_string(),
-            Error::WrongOpExtensionOperand => "wrong OpExtension operand".to_string(),
-            Error::WrongOpExtInstImportOperand => "wrong OpExtInstImport operand".to_string(),
-            Error::WrongOpMemoryModelOperand => "wrong OpMemoryModel operand".to_string(),
-            Error::WrongOpNameOperand => "wrong OpName operand".to_string(),
-            Error::FunctionNotFound => "can't find the function".to_string(),
+            Error::EmptyInstructionList => Cow::Borrowed("list of instructions is empty"),
+            Error::WrongOpCapabilityOperand => Cow::Borrowed("wrong OpCapability operand"),
+            Error::WrongOpExtensionOperand => Cow::Borrowed("wrong OpExtension operand"),
+            Error::WrongOpExtInstImportOperand => Cow::Borrowed("wrong OpExtInstImport operand"),
+            Error::WrongOpMemoryModelOperand => Cow::Borrowed("wrong OpMemoryModel operand"),
+            Error::WrongOpNameOperand => Cow::Borrowed("wrong OpName operand"),
+            Error::FunctionNotFound => Cow::Borrowed("can't find the function"),
         }
     }
 }


### PR DESCRIPTION
This improves the DetachedInstruction error message because we occasionally run into it.

Also adds an ignore for OpLine since it wasn't handled properly before.