### PR TITLE
[FIXUP] GitHub Actions: Run check and test on Windows+MacOS and Nightly

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,12 +3,29 @@ on: [push, pull_request]
 name: Continuous integration
 
 jobs:
-  lint:
-    name: Lint and test
+  fmt:
+    name: Cargo fmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          components: rustfmt
+      - uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+  test:
+    name: Cargo check and test
     strategy:
+      fail-fast: false
       matrix:
-        # os: [ubuntu-latest, windows-latest]
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        rust: [stable, nightly]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -16,17 +33,12 @@ jobs:
           submodules: true
       - uses: actions-rs/toolchain@v1
         with:
-          # TODO: Nightly
-          toolchain: stable
+          toolchain: ${{ matrix.rust }}
           override: true
       - uses: actions-rs/cargo@v1
         with:
           command: check
           args: --workspace --all-targets --verbose
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
       - uses: actions-rs/cargo@v1
         with:
           command: test


### PR DESCRIPTION
Re-add build matrices to compile on Nightly and Windows+MacOS again, which went missing in #135.

Should we go out of our way to test the minimum advertised 1.20 as well? It doesn't seem to understand `--workspace` (but `--all` works) nor `--all-targets` (can be replaced by `--tests` afaik).

For reference, splitting `check`, `fmt`, `test` and `clippy` in separate steps and running them on all OS-es and relevant toolchains is a bit over the top https://github.com/MarijnS95/rspirv/actions/runs/193378697 :sweat_smile: 