### PR TITLE
Properly deduplicate type declarations

### DIFF
--- a/autogen/dr.rs
+++ b/autogen/dr.rs
@@ -162,9 +162,7 @@ fn get_push_extras(
                     } else {
                         let kind = get_dr_operand_kind(&param.kind);
                         Some(quote! {
-                            for v in #name.as_ref() {
-                                #container.push(dr::Operand::#kind(*v));
-                            }
+                            #container.extend(#name.as_ref().iter().cloned().map(dr::Operand::#kind));
                         })
                     }
                 }
@@ -313,39 +311,23 @@ pub fn gen_dr_builder_types(grammar: &structs::Grammar) -> TokenStream {
         // Parameters that are not single values thus need special treatment.
         let extras = get_push_extras(&inst.operands[1..],
                                      kinds,
-                                     quote! { self.module.types_global_values.last_mut().expect("interal error").operands });
+                                     quote! { inst.operands });
         let opcode = as_ident(&inst.opname[2..]);
         let name = as_ident(&inst.opname[2..].to_snake_case());
 
-        let aggregate = match inst.opname.as_ref() {
-            "SpvOpTypeArray" | "SpvOpTypeRuntimeArray" | "SpvOpTypePointer" | "SpvOpTypeStruct" => true,
-            _ => false
-        };
-
-        if aggregate {
-            let comment = format!("Appends an Op{} instruction and returns the result id.", opcode);
-            quote! {
-                #[doc = #comment]
-                pub fn #name#generic(&mut self,#(#param_list),*) -> spirv::Word {
-                    let id = self.id();
-                    self.module.types_global_values.push(
-                        dr::Instruction::new(spirv::Op::#opcode, None, Some(id), vec![#(#init_list),*])
-                    );
-                    #(#extras)*
+        let comment = format!("Appends an Op{} instruction and returns the result id, or return the existing id if the instruction was already present.", opcode);
+        quote! {
+            #[doc = #comment]
+            pub fn #name#generic(&mut self,#(#param_list),*) -> spirv::Word {
+                let mut inst = dr::Instruction::new(spirv::Op::#opcode, None, None, vec![#(#init_list),*]);
+                #(#extras)*
+                if let Some(id) = self.dedup_insert_type(&inst) {
                     id
-                }
-            }
-        } else {
-            let comment = format!("Appends an Op{} instruction and returns the result id, or return the existing id if the instruction was already present.", opcode);
-            quote! {
-                #[doc = #comment]
-                pub fn #name#generic(&mut self,#(#param_list),*) -> spirv::Word {
-                    let mut inst = dr::Instruction::new(spirv::Op::#opcode, None, None, vec![#(#init_list),*]);
-                    let id = self.dedup_insert_type(&inst);
-                    inst.result_id = Some(id);
+                } else {
+                    let new_id = self.id();
+                    inst.result_id = Some(new_id);
                     self.module.types_global_values.push(inst);
-                    #(#extras)*
-                    id
+                    new_id
                 }
             }
         }

--- a/rspirv/dr/build/autogen_annotation.rs
+++ b/rspirv/dr/build/autogen_annotation.rs
@@ -58,9 +58,8 @@ impl Builder {
             None,
             vec![dr::Operand::IdRef(decoration_group)],
         );
-        for v in targets.as_ref() {
-            inst.operands.push(dr::Operand::IdRef(*v));
-        }
+        inst.operands
+            .extend(targets.as_ref().iter().cloned().map(dr::Operand::IdRef));
         self.module.annotations.push(inst);
     }
     #[doc = "Appends an OpGroupMemberDecorate instruction."]

--- a/rspirv/dr/build/autogen_constant.rs
+++ b/rspirv/dr/build/autogen_constant.rs
@@ -39,9 +39,13 @@ impl Builder {
             Some(id),
             vec![],
         );
-        for v in constituents.as_ref() {
-            inst.operands.push(dr::Operand::IdRef(*v));
-        }
+        inst.operands.extend(
+            constituents
+                .as_ref()
+                .iter()
+                .cloned()
+                .map(dr::Operand::IdRef),
+        );
         self.module.types_global_values.push(inst);
         id
     }
@@ -117,9 +121,13 @@ impl Builder {
             Some(id),
             vec![],
         );
-        for v in constituents.as_ref() {
-            inst.operands.push(dr::Operand::IdRef(*v));
-        }
+        inst.operands.extend(
+            constituents
+                .as_ref()
+                .iter()
+                .cloned()
+                .map(dr::Operand::IdRef),
+        );
         self.module.types_global_values.push(inst);
         id
     }

--- a/rspirv/dr/build/autogen_norm_insts.rs
+++ b/rspirv/dr/build/autogen_norm_insts.rs
@@ -181,9 +181,8 @@ impl Builder {
             Some(_id),
             vec![dr::Operand::IdRef(base)],
         );
-        for v in indexes.as_ref() {
-            inst.operands.push(dr::Operand::IdRef(*v));
-        }
+        inst.operands
+            .extend(indexes.as_ref().iter().cloned().map(dr::Operand::IdRef));
         self.insert_into_block(InsertPoint::End, inst)?;
         Ok(_id)
     }
@@ -204,9 +203,8 @@ impl Builder {
             Some(_id),
             vec![dr::Operand::IdRef(base)],
         );
-        for v in indexes.as_ref() {
-            inst.operands.push(dr::Operand::IdRef(*v));
-        }
+        inst.operands
+            .extend(indexes.as_ref().iter().cloned().map(dr::Operand::IdRef));
         self.insert_into_block(insert_point, inst)?;
         Ok(_id)
     }
@@ -226,9 +224,8 @@ impl Builder {
             Some(_id),
             vec![dr::Operand::IdRef(base)],
         );
-        for v in indexes.as_ref() {
-            inst.operands.push(dr::Operand::IdRef(*v));
-        }
+        inst.operands
+            .extend(indexes.as_ref().iter().cloned().map(dr::Operand::IdRef));
         self.insert_into_block(InsertPoint::End, inst)?;
         Ok(_id)
     }
@@ -249,9 +246,8 @@ impl Builder {
             Some(_id),
             vec![dr::Operand::IdRef(base)],
         );
-        for v in indexes.as_ref() {
-            inst.operands.push(dr::Operand::IdRef(*v));
-        }
+        inst.operands
+            .extend(indexes.as_ref().iter().cloned().map(dr::Operand::IdRef));
         self.insert_into_block(insert_point, inst)?;
         Ok(_id)
     }
@@ -272,9 +268,8 @@ impl Builder {
             Some(_id),
             vec![dr::Operand::IdRef(base), dr::Operand::IdRef(element)],
         );
-        for v in indexes.as_ref() {
-            inst.operands.push(dr::Operand::IdRef(*v));
-        }
+        inst.operands
+            .extend(indexes.as_ref().iter().cloned().map(dr::Operand::IdRef));
         self.insert_into_block(InsertPoint::End, inst)?;
         Ok(_id)
     }
@@ -296,9 +291,8 @@ impl Builder {
             Some(_id),
             vec![dr::Operand::IdRef(base), dr::Operand::IdRef(element)],
         );
-        for v in indexes.as_ref() {
-            inst.operands.push(dr::Operand::IdRef(*v));
-        }
+        inst.operands
+            .extend(indexes.as_ref().iter().cloned().map(dr::Operand::IdRef));
         self.insert_into_block(insert_point, inst)?;
         Ok(_id)
     }
@@ -401,9 +395,8 @@ impl Builder {
             Some(_id),
             vec![dr::Operand::IdRef(base), dr::Operand::IdRef(element)],
         );
-        for v in indexes.as_ref() {
-            inst.operands.push(dr::Operand::IdRef(*v));
-        }
+        inst.operands
+            .extend(indexes.as_ref().iter().cloned().map(dr::Operand::IdRef));
         self.insert_into_block(InsertPoint::End, inst)?;
         Ok(_id)
     }
@@ -425,9 +418,8 @@ impl Builder {
             Some(_id),
             vec![dr::Operand::IdRef(base), dr::Operand::IdRef(element)],
         );
-        for v in indexes.as_ref() {
-            inst.operands.push(dr::Operand::IdRef(*v));
-        }
+        inst.operands
+            .extend(indexes.as_ref().iter().cloned().map(dr::Operand::IdRef));
         self.insert_into_block(insert_point, inst)?;
         Ok(_id)
     }
@@ -536,9 +528,13 @@ impl Builder {
             Some(_id),
             vec![dr::Operand::IdRef(vector_1), dr::Operand::IdRef(vector_2)],
         );
-        for v in components.as_ref() {
-            inst.operands.push(dr::Operand::LiteralInt32(*v));
-        }
+        inst.operands.extend(
+            components
+                .as_ref()
+                .iter()
+                .cloned()
+                .map(dr::Operand::LiteralInt32),
+        );
         self.insert_into_block(InsertPoint::End, inst)?;
         Ok(_id)
     }
@@ -560,9 +556,13 @@ impl Builder {
             Some(_id),
             vec![dr::Operand::IdRef(vector_1), dr::Operand::IdRef(vector_2)],
         );
-        for v in components.as_ref() {
-            inst.operands.push(dr::Operand::LiteralInt32(*v));
-        }
+        inst.operands.extend(
+            components
+                .as_ref()
+                .iter()
+                .cloned()
+                .map(dr::Operand::LiteralInt32),
+        );
         self.insert_into_block(insert_point, inst)?;
         Ok(_id)
     }
@@ -581,9 +581,13 @@ impl Builder {
             Some(_id),
             vec![],
         );
-        for v in constituents.as_ref() {
-            inst.operands.push(dr::Operand::IdRef(*v));
-        }
+        inst.operands.extend(
+            constituents
+                .as_ref()
+                .iter()
+                .cloned()
+                .map(dr::Operand::IdRef),
+        );
         self.insert_into_block(InsertPoint::End, inst)?;
         Ok(_id)
     }
@@ -603,9 +607,13 @@ impl Builder {
             Some(_id),
             vec![],
         );
-        for v in constituents.as_ref() {
-            inst.operands.push(dr::Operand::IdRef(*v));
-        }
+        inst.operands.extend(
+            constituents
+                .as_ref()
+                .iter()
+                .cloned()
+                .map(dr::Operand::IdRef),
+        );
         self.insert_into_block(insert_point, inst)?;
         Ok(_id)
     }
@@ -625,9 +633,13 @@ impl Builder {
             Some(_id),
             vec![dr::Operand::IdRef(composite)],
         );
-        for v in indexes.as_ref() {
-            inst.operands.push(dr::Operand::LiteralInt32(*v));
-        }
+        inst.operands.extend(
+            indexes
+                .as_ref()
+                .iter()
+                .cloned()
+                .map(dr::Operand::LiteralInt32),
+        );
         self.insert_into_block(InsertPoint::End, inst)?;
         Ok(_id)
     }
@@ -648,9 +660,13 @@ impl Builder {
             Some(_id),
             vec![dr::Operand::IdRef(composite)],
         );
-        for v in indexes.as_ref() {
-            inst.operands.push(dr::Operand::LiteralInt32(*v));
-        }
+        inst.operands.extend(
+            indexes
+                .as_ref()
+                .iter()
+                .cloned()
+                .map(dr::Operand::LiteralInt32),
+        );
         self.insert_into_block(insert_point, inst)?;
         Ok(_id)
     }
@@ -671,9 +687,13 @@ impl Builder {
             Some(_id),
             vec![dr::Operand::IdRef(object), dr::Operand::IdRef(composite)],
         );
-        for v in indexes.as_ref() {
-            inst.operands.push(dr::Operand::LiteralInt32(*v));
-        }
+        inst.operands.extend(
+            indexes
+                .as_ref()
+                .iter()
+                .cloned()
+                .map(dr::Operand::LiteralInt32),
+        );
         self.insert_into_block(InsertPoint::End, inst)?;
         Ok(_id)
     }
@@ -695,9 +715,13 @@ impl Builder {
             Some(_id),
             vec![dr::Operand::IdRef(object), dr::Operand::IdRef(composite)],
         );
-        for v in indexes.as_ref() {
-            inst.operands.push(dr::Operand::LiteralInt32(*v));
-        }
+        inst.operands.extend(
+            indexes
+                .as_ref()
+                .iter()
+                .cloned()
+                .map(dr::Operand::LiteralInt32),
+        );
         self.insert_into_block(insert_point, inst)?;
         Ok(_id)
     }
@@ -8389,9 +8413,8 @@ impl Builder {
                 dr::Operand::IdRef(param_align),
             ],
         );
-        for v in local_size.as_ref() {
-            inst.operands.push(dr::Operand::IdRef(*v));
-        }
+        inst.operands
+            .extend(local_size.as_ref().iter().cloned().map(dr::Operand::IdRef));
         self.insert_into_block(InsertPoint::End, inst)?;
         Ok(_id)
     }
@@ -8432,9 +8455,8 @@ impl Builder {
                 dr::Operand::IdRef(param_align),
             ],
         );
-        for v in local_size.as_ref() {
-            inst.operands.push(dr::Operand::IdRef(*v));
-        }
+        inst.operands
+            .extend(local_size.as_ref().iter().cloned().map(dr::Operand::IdRef));
         self.insert_into_block(insert_point, inst)?;
         Ok(_id)
     }

--- a/rspirv/dr/build/autogen_terminator.rs
+++ b/rspirv/dr/build/autogen_terminator.rs
@@ -146,9 +146,13 @@ impl Builder {
                 dr::Operand::IdRef(false_label),
             ],
         );
-        for v in branch_weights.as_ref() {
-            inst.operands.push(dr::Operand::LiteralInt32(*v));
-        }
+        inst.operands.extend(
+            branch_weights
+                .as_ref()
+                .iter()
+                .cloned()
+                .map(dr::Operand::LiteralInt32),
+        );
         self.end_block(inst)
     }
     #[doc = "Insert an OpBranchConditional instruction and ends the current block."]
@@ -171,9 +175,13 @@ impl Builder {
                 dr::Operand::IdRef(false_label),
             ],
         );
-        for v in branch_weights.as_ref() {
-            inst.operands.push(dr::Operand::LiteralInt32(*v));
-        }
+        inst.operands.extend(
+            branch_weights
+                .as_ref()
+                .iter()
+                .cloned()
+                .map(dr::Operand::LiteralInt32),
+        );
         self.insert_end_block(insert_point, inst)
     }
     #[doc = "Appends an OpSwitch instruction and ends the current block."]

--- a/rspirv/dr/build/autogen_type.rs
+++ b/rspirv/dr/build/autogen_type.rs
@@ -6,18 +6,26 @@ impl Builder {
     #[doc = "Appends an OpTypeVoid instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_void(&mut self) -> spirv::Word {
         let mut inst = dr::Instruction::new(spirv::Op::TypeVoid, None, None, vec![]);
-        let id = self.dedup_insert_type(&inst);
-        inst.result_id = Some(id);
-        self.module.types_global_values.push(inst);
-        id
+        if let Some(id) = self.dedup_insert_type(&inst) {
+            id
+        } else {
+            let new_id = self.id();
+            inst.result_id = Some(new_id);
+            self.module.types_global_values.push(inst);
+            new_id
+        }
     }
     #[doc = "Appends an OpTypeBool instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_bool(&mut self) -> spirv::Word {
         let mut inst = dr::Instruction::new(spirv::Op::TypeBool, None, None, vec![]);
-        let id = self.dedup_insert_type(&inst);
-        inst.result_id = Some(id);
-        self.module.types_global_values.push(inst);
-        id
+        if let Some(id) = self.dedup_insert_type(&inst) {
+            id
+        } else {
+            let new_id = self.id();
+            inst.result_id = Some(new_id);
+            self.module.types_global_values.push(inst);
+            new_id
+        }
     }
     #[doc = "Appends an OpTypeInt instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_int(&mut self, width: u32, signedness: u32) -> spirv::Word {
@@ -30,10 +38,14 @@ impl Builder {
                 dr::Operand::LiteralInt32(signedness),
             ],
         );
-        let id = self.dedup_insert_type(&inst);
-        inst.result_id = Some(id);
-        self.module.types_global_values.push(inst);
-        id
+        if let Some(id) = self.dedup_insert_type(&inst) {
+            id
+        } else {
+            let new_id = self.id();
+            inst.result_id = Some(new_id);
+            self.module.types_global_values.push(inst);
+            new_id
+        }
     }
     #[doc = "Appends an OpTypeFloat instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_float(&mut self, width: u32) -> spirv::Word {
@@ -43,10 +55,14 @@ impl Builder {
             None,
             vec![dr::Operand::LiteralInt32(width)],
         );
-        let id = self.dedup_insert_type(&inst);
-        inst.result_id = Some(id);
-        self.module.types_global_values.push(inst);
-        id
+        if let Some(id) = self.dedup_insert_type(&inst) {
+            id
+        } else {
+            let new_id = self.id();
+            inst.result_id = Some(new_id);
+            self.module.types_global_values.push(inst);
+            new_id
+        }
     }
     #[doc = "Appends an OpTypeVector instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_vector(
@@ -63,10 +79,14 @@ impl Builder {
                 dr::Operand::LiteralInt32(component_count),
             ],
         );
-        let id = self.dedup_insert_type(&inst);
-        inst.result_id = Some(id);
-        self.module.types_global_values.push(inst);
-        id
+        if let Some(id) = self.dedup_insert_type(&inst) {
+            id
+        } else {
+            let new_id = self.id();
+            inst.result_id = Some(new_id);
+            self.module.types_global_values.push(inst);
+            new_id
+        }
     }
     #[doc = "Appends an OpTypeMatrix instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_matrix(&mut self, column_type: spirv::Word, column_count: u32) -> spirv::Word {
@@ -79,10 +99,14 @@ impl Builder {
                 dr::Operand::LiteralInt32(column_count),
             ],
         );
-        let id = self.dedup_insert_type(&inst);
-        inst.result_id = Some(id);
-        self.module.types_global_values.push(inst);
-        id
+        if let Some(id) = self.dedup_insert_type(&inst) {
+            id
+        } else {
+            let new_id = self.id();
+            inst.result_id = Some(new_id);
+            self.module.types_global_values.push(inst);
+            new_id
+        }
     }
     #[doc = "Appends an OpTypeImage instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_image(
@@ -110,27 +134,30 @@ impl Builder {
                 dr::Operand::ImageFormat(image_format),
             ],
         );
-        let id = self.dedup_insert_type(&inst);
-        inst.result_id = Some(id);
-        self.module.types_global_values.push(inst);
         if let Some(v) = access_qualifier {
             #[allow(clippy::identity_conversion)]
-            self.module
-                .types_global_values
-                .last_mut()
-                .expect("interal error")
-                .operands
-                .push(dr::Operand::AccessQualifier(v.into()));
+            inst.operands.push(dr::Operand::AccessQualifier(v.into()));
         }
-        id
+        if let Some(id) = self.dedup_insert_type(&inst) {
+            id
+        } else {
+            let new_id = self.id();
+            inst.result_id = Some(new_id);
+            self.module.types_global_values.push(inst);
+            new_id
+        }
     }
     #[doc = "Appends an OpTypeSampler instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_sampler(&mut self) -> spirv::Word {
         let mut inst = dr::Instruction::new(spirv::Op::TypeSampler, None, None, vec![]);
-        let id = self.dedup_insert_type(&inst);
-        inst.result_id = Some(id);
-        self.module.types_global_values.push(inst);
-        id
+        if let Some(id) = self.dedup_insert_type(&inst) {
+            id
+        } else {
+            let new_id = self.id();
+            inst.result_id = Some(new_id);
+            self.module.types_global_values.push(inst);
+            new_id
+        }
     }
     #[doc = "Appends an OpTypeSampledImage instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_sampled_image(&mut self, image_type: spirv::Word) -> spirv::Word {
@@ -140,10 +167,14 @@ impl Builder {
             None,
             vec![dr::Operand::IdRef(image_type)],
         );
-        let id = self.dedup_insert_type(&inst);
-        inst.result_id = Some(id);
-        self.module.types_global_values.push(inst);
-        id
+        if let Some(id) = self.dedup_insert_type(&inst) {
+            id
+        } else {
+            let new_id = self.id();
+            inst.result_id = Some(new_id);
+            self.module.types_global_values.push(inst);
+            new_id
+        }
     }
     #[doc = "Appends an OpTypeArray instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_array(&mut self, element_type: spirv::Word, length: spirv::Word) -> spirv::Word {
@@ -153,10 +184,14 @@ impl Builder {
             None,
             vec![dr::Operand::IdRef(element_type), dr::Operand::IdRef(length)],
         );
-        let id = self.dedup_insert_type(&inst);
-        inst.result_id = Some(id);
-        self.module.types_global_values.push(inst);
-        id
+        if let Some(id) = self.dedup_insert_type(&inst) {
+            id
+        } else {
+            let new_id = self.id();
+            inst.result_id = Some(new_id);
+            self.module.types_global_values.push(inst);
+            new_id
+        }
     }
     #[doc = "Appends an OpTypeRuntimeArray instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_runtime_array(&mut self, element_type: spirv::Word) -> spirv::Word {
@@ -166,10 +201,14 @@ impl Builder {
             None,
             vec![dr::Operand::IdRef(element_type)],
         );
-        let id = self.dedup_insert_type(&inst);
-        inst.result_id = Some(id);
-        self.module.types_global_values.push(inst);
-        id
+        if let Some(id) = self.dedup_insert_type(&inst) {
+            id
+        } else {
+            let new_id = self.id();
+            inst.result_id = Some(new_id);
+            self.module.types_global_values.push(inst);
+            new_id
+        }
     }
     #[doc = "Appends an OpTypeStruct instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_struct<T: AsRef<[spirv::Word]>>(
@@ -177,18 +216,21 @@ impl Builder {
         member_0_type_member_1_type: T,
     ) -> spirv::Word {
         let mut inst = dr::Instruction::new(spirv::Op::TypeStruct, None, None, vec![]);
-        let id = self.dedup_insert_type(&inst);
-        inst.result_id = Some(id);
-        self.module.types_global_values.push(inst);
-        for v in member_0_type_member_1_type.as_ref() {
-            self.module
-                .types_global_values
-                .last_mut()
-                .expect("interal error")
-                .operands
-                .push(dr::Operand::IdRef(*v));
+        inst.operands.extend(
+            member_0_type_member_1_type
+                .as_ref()
+                .iter()
+                .cloned()
+                .map(dr::Operand::IdRef),
+        );
+        if let Some(id) = self.dedup_insert_type(&inst) {
+            id
+        } else {
+            let new_id = self.id();
+            inst.result_id = Some(new_id);
+            self.module.types_global_values.push(inst);
+            new_id
         }
-        id
     }
     #[doc = "Appends an OpTypeFunction instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_function<T: AsRef<[spirv::Word]>>(
@@ -202,50 +244,69 @@ impl Builder {
             None,
             vec![dr::Operand::IdRef(return_type)],
         );
-        let id = self.dedup_insert_type(&inst);
-        inst.result_id = Some(id);
-        self.module.types_global_values.push(inst);
-        for v in parameter_0_type_parameter_1_type.as_ref() {
-            self.module
-                .types_global_values
-                .last_mut()
-                .expect("interal error")
-                .operands
-                .push(dr::Operand::IdRef(*v));
+        inst.operands.extend(
+            parameter_0_type_parameter_1_type
+                .as_ref()
+                .iter()
+                .cloned()
+                .map(dr::Operand::IdRef),
+        );
+        if let Some(id) = self.dedup_insert_type(&inst) {
+            id
+        } else {
+            let new_id = self.id();
+            inst.result_id = Some(new_id);
+            self.module.types_global_values.push(inst);
+            new_id
         }
-        id
     }
     #[doc = "Appends an OpTypeEvent instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_event(&mut self) -> spirv::Word {
         let mut inst = dr::Instruction::new(spirv::Op::TypeEvent, None, None, vec![]);
-        let id = self.dedup_insert_type(&inst);
-        inst.result_id = Some(id);
-        self.module.types_global_values.push(inst);
-        id
+        if let Some(id) = self.dedup_insert_type(&inst) {
+            id
+        } else {
+            let new_id = self.id();
+            inst.result_id = Some(new_id);
+            self.module.types_global_values.push(inst);
+            new_id
+        }
     }
     #[doc = "Appends an OpTypeDeviceEvent instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_device_event(&mut self) -> spirv::Word {
         let mut inst = dr::Instruction::new(spirv::Op::TypeDeviceEvent, None, None, vec![]);
-        let id = self.dedup_insert_type(&inst);
-        inst.result_id = Some(id);
-        self.module.types_global_values.push(inst);
-        id
+        if let Some(id) = self.dedup_insert_type(&inst) {
+            id
+        } else {
+            let new_id = self.id();
+            inst.result_id = Some(new_id);
+            self.module.types_global_values.push(inst);
+            new_id
+        }
     }
     #[doc = "Appends an OpTypeReserveId instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_reserve_id(&mut self) -> spirv::Word {
         let mut inst = dr::Instruction::new(spirv::Op::TypeReserveId, None, None, vec![]);
-        let id = self.dedup_insert_type(&inst);
-        inst.result_id = Some(id);
-        self.module.types_global_values.push(inst);
-        id
+        if let Some(id) = self.dedup_insert_type(&inst) {
+            id
+        } else {
+            let new_id = self.id();
+            inst.result_id = Some(new_id);
+            self.module.types_global_values.push(inst);
+            new_id
+        }
     }
     #[doc = "Appends an OpTypeQueue instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_queue(&mut self) -> spirv::Word {
         let mut inst = dr::Instruction::new(spirv::Op::TypeQueue, None, None, vec![]);
-        let id = self.dedup_insert_type(&inst);
-        inst.result_id = Some(id);
-        self.module.types_global_values.push(inst);
-        id
+        if let Some(id) = self.dedup_insert_type(&inst) {
+            id
+        } else {
+            let new_id = self.id();
+            inst.result_id = Some(new_id);
+            self.module.types_global_values.push(inst);
+            new_id
+        }
     }
     #[doc = "Appends an OpTypePipe instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_pipe(&mut self, qualifier: spirv::AccessQualifier) -> spirv::Word {
@@ -255,25 +316,37 @@ impl Builder {
             None,
             vec![dr::Operand::AccessQualifier(qualifier)],
         );
-        let id = self.dedup_insert_type(&inst);
-        inst.result_id = Some(id);
-        self.module.types_global_values.push(inst);
-        id
+        if let Some(id) = self.dedup_insert_type(&inst) {
+            id
+        } else {
+            let new_id = self.id();
+            inst.result_id = Some(new_id);
+            self.module.types_global_values.push(inst);
+            new_id
+        }
     }
     #[doc = "Appends an OpTypePipeStorage instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_pipe_storage(&mut self) -> spirv::Word {
         let mut inst = dr::Instruction::new(spirv::Op::TypePipeStorage, None, None, vec![]);
-        let id = self.dedup_insert_type(&inst);
-        inst.result_id = Some(id);
-        self.module.types_global_values.push(inst);
-        id
+        if let Some(id) = self.dedup_insert_type(&inst) {
+            id
+        } else {
+            let new_id = self.id();
+            inst.result_id = Some(new_id);
+            self.module.types_global_values.push(inst);
+            new_id
+        }
     }
     #[doc = "Appends an OpTypeNamedBarrier instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_named_barrier(&mut self) -> spirv::Word {
         let mut inst = dr::Instruction::new(spirv::Op::TypeNamedBarrier, None, None, vec![]);
-        let id = self.dedup_insert_type(&inst);
-        inst.result_id = Some(id);
-        self.module.types_global_values.push(inst);
-        id
+        if let Some(id) = self.dedup_insert_type(&inst) {
+            id
+        } else {
+            let new_id = self.id();
+            inst.result_id = Some(new_id);
+            self.module.types_global_values.push(inst);
+            new_id
+        }
     }
 }

--- a/rspirv/dr/build/mod.rs
+++ b/rspirv/dr/build/mod.rs
@@ -232,16 +232,16 @@ impl Builder {
     /// Insert a OpType instruction, deduplicate it if needed and either return the existing ID
     /// or a new unused ID if we can't find find the instruction already. Useful to uphold
     /// the SPIR-V rule that non-aggregate types can't be duplicates.
-    pub fn dedup_insert_type(&mut self, inst: &dr::Instruction) -> spirv::Word {
+    pub fn dedup_insert_type(&mut self, inst: &dr::Instruction) -> Option<spirv::Word> {
         for ty in &self.module.types_global_values {
             if ty.is_type_identical(&inst) {
                 if let Some(id) = ty.result_id {
-                    return id;
+                    return Some(id);
                 }
             }
         }
 
-        self.id()
+        None
     }
 
     /// Find all blocks that end in OpReturn


### PR DESCRIPTION
https://github.com/gfx-rs/rspirv/pull/133/commits/716d74bed6fb5a0ec4ad66f6344f6c840bb0d48d broke deduplication, so, re-fix it. Also fix function deduplication by moving `#(#extras)*` *before* deduplication checks, not after. Also deduplicate aggregate types too. Also did a little micro-optimization to use `extend` instead of repeated `push` (helps with number of allocations).