### PR TITLE
Add OpFunctionCall explicitly

### DIFF
--- a/autogen/dr.rs
+++ b/autogen/dr.rs
@@ -405,7 +405,7 @@ pub fn gen_dr_builder_normal_insts(grammar: &structs::Grammar) -> TokenStream {
             inst.class == Some(Type) ||
             inst.class == Some(Constant) ||
             inst.class == Some(ExtensionDecl) ||
-            inst.class == Some(FunctionStruct) ||
+            (inst.class == Some(FunctionStruct) && inst.opname != "OpFunctionCall") ||
             inst.class == Some(Debug) ||
             inst.class == Some(Annotation) ||
             inst.class == Some(Terminator) ||

--- a/rspirv/dr/build/autogen_norm_insts.rs
+++ b/rspirv/dr/build/autogen_norm_insts.rs
@@ -18,6 +18,59 @@ impl Builder {
         self.insert_into_block(insert_point, inst)?;
         Ok(())
     }
+    #[doc = "Appends an OpFunctionCall instruction to the current block."]
+    pub fn function_call<T: AsRef<[spirv::Word]>>(
+        &mut self,
+        result_type: spirv::Word,
+        result_id: Option<spirv::Word>,
+        function: spirv::Word,
+        argument_0_argument_1: T,
+    ) -> BuildResult<spirv::Word> {
+        let _id = result_id.unwrap_or_else(|| self.id());
+        #[allow(unused_mut)]
+        let mut inst = dr::Instruction::new(
+            spirv::Op::FunctionCall,
+            Some(result_type),
+            Some(_id),
+            vec![dr::Operand::IdRef(function)],
+        );
+        inst.operands.extend(
+            argument_0_argument_1
+                .as_ref()
+                .iter()
+                .cloned()
+                .map(dr::Operand::IdRef),
+        );
+        self.insert_into_block(InsertPoint::End, inst)?;
+        Ok(_id)
+    }
+    #[doc = "Appends an OpFunctionCall instruction to the current block."]
+    pub fn insert_function_call<T: AsRef<[spirv::Word]>>(
+        &mut self,
+        insert_point: InsertPoint,
+        result_type: spirv::Word,
+        result_id: Option<spirv::Word>,
+        function: spirv::Word,
+        argument_0_argument_1: T,
+    ) -> BuildResult<spirv::Word> {
+        let _id = result_id.unwrap_or_else(|| self.id());
+        #[allow(unused_mut)]
+        let mut inst = dr::Instruction::new(
+            spirv::Op::FunctionCall,
+            Some(result_type),
+            Some(_id),
+            vec![dr::Operand::IdRef(function)],
+        );
+        inst.operands.extend(
+            argument_0_argument_1
+                .as_ref()
+                .iter()
+                .cloned()
+                .map(dr::Operand::IdRef),
+        );
+        self.insert_into_block(insert_point, inst)?;
+        Ok(_id)
+    }
     #[doc = "Appends an OpImageTexelPointer instruction to the current block."]
     pub fn image_texel_pointer(
         &mut self,


### PR DESCRIPTION
Most ops tagged with the Function class are models by our `Function` struct (eg. to create functions) however, OpFunctionCall also has the "Function" class, but should exist in the Builder.