### PR TITLE
Make ZeroOrMore take Iterator instead of AsRef<[T]>

### DIFF
--- a/autogen/dr.rs
+++ b/autogen/dr.rs
@@ -182,7 +182,7 @@ fn get_push_extras(
 
 /// Returns the generated dr::Operand and its fmt::Display implementation by
 /// walking the given SPIR-V operand kinds `grammar`.
-pub fn gen_dr_operand_kinds(grammar: &Vec<structs::OperandKind>) -> TokenStream {
+pub fn gen_dr_operand_kinds(grammar: &[structs::OperandKind]) -> TokenStream {
     let kinds: Vec<_> = grammar
         .iter()
         .map(|element| element.kind.as_str())
@@ -265,7 +265,7 @@ pub fn gen_dr_operand_kinds(grammar: &Vec<structs::OperandKind>) -> TokenStream 
             .map(as_ident),
         );
         let cases = kinds.iter().map(|element| {
-            if &element.to_string() == &"Dim" {
+            if element.to_string() == "Dim" {
                 // Skip the "Dim" prefix, which is only used in the API to
                 // avoid having an enumerant name starting with a number
                 quote! {

--- a/rspirv/dr/build/autogen_annotation.rs
+++ b/rspirv/dr/build/autogen_annotation.rs
@@ -4,7 +4,7 @@
 
 impl Builder {
     #[doc = "Appends an OpDecorate instruction."]
-    pub fn decorate<T: AsRef<[dr::Operand]>>(
+    pub fn decorate<T: IntoIterator<Item = dr::Operand>>(
         &mut self,
         target: spirv::Word,
         decoration: spirv::Decoration,
@@ -20,11 +20,11 @@ impl Builder {
                 dr::Operand::Decoration(decoration),
             ],
         );
-        inst.operands.extend_from_slice(additional_params.as_ref());
+        inst.operands.extend(additional_params);
         self.module.annotations.push(inst);
     }
     #[doc = "Appends an OpMemberDecorate instruction."]
-    pub fn member_decorate<T: AsRef<[dr::Operand]>>(
+    pub fn member_decorate<T: IntoIterator<Item = dr::Operand>>(
         &mut self,
         structure_type: spirv::Word,
         member: u32,
@@ -42,11 +42,11 @@ impl Builder {
                 dr::Operand::Decoration(decoration),
             ],
         );
-        inst.operands.extend_from_slice(additional_params.as_ref());
+        inst.operands.extend(additional_params);
         self.module.annotations.push(inst);
     }
     #[doc = "Appends an OpGroupDecorate instruction."]
-    pub fn group_decorate<T: AsRef<[spirv::Word]>>(
+    pub fn group_decorate<T: IntoIterator<Item = spirv::Word>>(
         &mut self,
         decoration_group: spirv::Word,
         targets: T,
@@ -59,11 +59,11 @@ impl Builder {
             vec![dr::Operand::IdRef(decoration_group)],
         );
         inst.operands
-            .extend(targets.as_ref().iter().cloned().map(dr::Operand::IdRef));
+            .extend(targets.into_iter().map(dr::Operand::IdRef));
         self.module.annotations.push(inst);
     }
     #[doc = "Appends an OpGroupMemberDecorate instruction."]
-    pub fn group_member_decorate<T: AsRef<[(spirv::Word, u32)]>>(
+    pub fn group_member_decorate<T: IntoIterator<Item = (spirv::Word, u32)>>(
         &mut self,
         decoration_group: spirv::Word,
         targets: T,
@@ -75,14 +75,14 @@ impl Builder {
             None,
             vec![dr::Operand::IdRef(decoration_group)],
         );
-        for v in targets.as_ref() {
+        for v in targets {
             inst.operands.push(dr::Operand::IdRef(v.0));
             inst.operands.push(dr::Operand::LiteralInt32(v.1));
         }
         self.module.annotations.push(inst);
     }
     #[doc = "Appends an OpDecorateId instruction."]
-    pub fn decorate_id<T: AsRef<[dr::Operand]>>(
+    pub fn decorate_id<T: IntoIterator<Item = dr::Operand>>(
         &mut self,
         target: spirv::Word,
         decoration: spirv::Decoration,
@@ -98,11 +98,11 @@ impl Builder {
                 dr::Operand::Decoration(decoration),
             ],
         );
-        inst.operands.extend_from_slice(additional_params.as_ref());
+        inst.operands.extend(additional_params);
         self.module.annotations.push(inst);
     }
     #[doc = "Appends an OpDecorateString instruction."]
-    pub fn decorate_string<T: AsRef<[dr::Operand]>>(
+    pub fn decorate_string<T: IntoIterator<Item = dr::Operand>>(
         &mut self,
         target: spirv::Word,
         decoration: spirv::Decoration,
@@ -118,11 +118,11 @@ impl Builder {
                 dr::Operand::Decoration(decoration),
             ],
         );
-        inst.operands.extend_from_slice(additional_params.as_ref());
+        inst.operands.extend(additional_params);
         self.module.annotations.push(inst);
     }
     #[doc = "Appends an OpDecorateStringGOOGLE instruction."]
-    pub fn decorate_string_google<T: AsRef<[dr::Operand]>>(
+    pub fn decorate_string_google<T: IntoIterator<Item = dr::Operand>>(
         &mut self,
         target: spirv::Word,
         decoration: spirv::Decoration,
@@ -138,11 +138,11 @@ impl Builder {
                 dr::Operand::Decoration(decoration),
             ],
         );
-        inst.operands.extend_from_slice(additional_params.as_ref());
+        inst.operands.extend(additional_params);
         self.module.annotations.push(inst);
     }
     #[doc = "Appends an OpMemberDecorateString instruction."]
-    pub fn member_decorate_string<T: AsRef<[dr::Operand]>>(
+    pub fn member_decorate_string<T: IntoIterator<Item = dr::Operand>>(
         &mut self,
         struct_type: spirv::Word,
         member: u32,
@@ -160,11 +160,11 @@ impl Builder {
                 dr::Operand::Decoration(decoration),
             ],
         );
-        inst.operands.extend_from_slice(additional_params.as_ref());
+        inst.operands.extend(additional_params);
         self.module.annotations.push(inst);
     }
     #[doc = "Appends an OpMemberDecorateStringGOOGLE instruction."]
-    pub fn member_decorate_string_google<T: AsRef<[dr::Operand]>>(
+    pub fn member_decorate_string_google<T: IntoIterator<Item = dr::Operand>>(
         &mut self,
         struct_type: spirv::Word,
         member: u32,
@@ -182,7 +182,7 @@ impl Builder {
                 dr::Operand::Decoration(decoration),
             ],
         );
-        inst.operands.extend_from_slice(additional_params.as_ref());
+        inst.operands.extend(additional_params);
         self.module.annotations.push(inst);
     }
 }

--- a/rspirv/dr/build/autogen_constant.rs
+++ b/rspirv/dr/build/autogen_constant.rs
@@ -26,7 +26,7 @@ impl Builder {
         id
     }
     #[doc = "Appends an OpConstantComposite instruction."]
-    pub fn constant_composite<T: AsRef<[spirv::Word]>>(
+    pub fn constant_composite<T: IntoIterator<Item = spirv::Word>>(
         &mut self,
         result_type: spirv::Word,
         constituents: T,
@@ -39,13 +39,8 @@ impl Builder {
             Some(id),
             vec![],
         );
-        inst.operands.extend(
-            constituents
-                .as_ref()
-                .iter()
-                .cloned()
-                .map(dr::Operand::IdRef),
-        );
+        inst.operands
+            .extend(constituents.into_iter().map(dr::Operand::IdRef));
         self.module.types_global_values.push(inst);
         id
     }
@@ -108,7 +103,7 @@ impl Builder {
         id
     }
     #[doc = "Appends an OpSpecConstantComposite instruction."]
-    pub fn spec_constant_composite<T: AsRef<[spirv::Word]>>(
+    pub fn spec_constant_composite<T: IntoIterator<Item = spirv::Word>>(
         &mut self,
         result_type: spirv::Word,
         constituents: T,
@@ -121,13 +116,8 @@ impl Builder {
             Some(id),
             vec![],
         );
-        inst.operands.extend(
-            constituents
-                .as_ref()
-                .iter()
-                .cloned()
-                .map(dr::Operand::IdRef),
-        );
+        inst.operands
+            .extend(constituents.into_iter().map(dr::Operand::IdRef));
         self.module.types_global_values.push(inst);
         id
     }

--- a/rspirv/dr/build/autogen_norm_insts.rs
+++ b/rspirv/dr/build/autogen_norm_insts.rs
@@ -68,7 +68,7 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpLoad instruction to the current block."]
-    pub fn load<T: AsRef<[dr::Operand]>>(
+    pub fn load<T: IntoIterator<Item = dr::Operand>>(
         &mut self,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
@@ -88,12 +88,12 @@ impl Builder {
             #[allow(clippy::identity_conversion)]
             inst.operands.push(dr::Operand::MemoryAccess(v.into()));
         }
-        inst.operands.extend_from_slice(additional_params.as_ref());
+        inst.operands.extend(additional_params);
         self.insert_into_block(InsertPoint::End, inst)?;
         Ok(_id)
     }
     #[doc = "Appends an OpLoad instruction to the current block."]
-    pub fn insert_load<T: AsRef<[dr::Operand]>>(
+    pub fn insert_load<T: IntoIterator<Item = dr::Operand>>(
         &mut self,
         insert_point: InsertPoint,
         result_type: spirv::Word,
@@ -114,12 +114,12 @@ impl Builder {
             #[allow(clippy::identity_conversion)]
             inst.operands.push(dr::Operand::MemoryAccess(v.into()));
         }
-        inst.operands.extend_from_slice(additional_params.as_ref());
+        inst.operands.extend(additional_params);
         self.insert_into_block(insert_point, inst)?;
         Ok(_id)
     }
     #[doc = "Appends an OpStore instruction to the current block."]
-    pub fn store<T: AsRef<[dr::Operand]>>(
+    pub fn store<T: IntoIterator<Item = dr::Operand>>(
         &mut self,
         pointer: spirv::Word,
         object: spirv::Word,
@@ -137,12 +137,12 @@ impl Builder {
             #[allow(clippy::identity_conversion)]
             inst.operands.push(dr::Operand::MemoryAccess(v.into()));
         }
-        inst.operands.extend_from_slice(additional_params.as_ref());
+        inst.operands.extend(additional_params);
         self.insert_into_block(InsertPoint::End, inst)?;
         Ok(())
     }
     #[doc = "Appends an OpStore instruction to the current block."]
-    pub fn insert_store<T: AsRef<[dr::Operand]>>(
+    pub fn insert_store<T: IntoIterator<Item = dr::Operand>>(
         &mut self,
         insert_point: InsertPoint,
         pointer: spirv::Word,
@@ -161,12 +161,12 @@ impl Builder {
             #[allow(clippy::identity_conversion)]
             inst.operands.push(dr::Operand::MemoryAccess(v.into()));
         }
-        inst.operands.extend_from_slice(additional_params.as_ref());
+        inst.operands.extend(additional_params);
         self.insert_into_block(insert_point, inst)?;
         Ok(())
     }
     #[doc = "Appends an OpAccessChain instruction to the current block."]
-    pub fn access_chain<T: AsRef<[spirv::Word]>>(
+    pub fn access_chain<T: IntoIterator<Item = spirv::Word>>(
         &mut self,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
@@ -182,12 +182,12 @@ impl Builder {
             vec![dr::Operand::IdRef(base)],
         );
         inst.operands
-            .extend(indexes.as_ref().iter().cloned().map(dr::Operand::IdRef));
+            .extend(indexes.into_iter().map(dr::Operand::IdRef));
         self.insert_into_block(InsertPoint::End, inst)?;
         Ok(_id)
     }
     #[doc = "Appends an OpAccessChain instruction to the current block."]
-    pub fn insert_access_chain<T: AsRef<[spirv::Word]>>(
+    pub fn insert_access_chain<T: IntoIterator<Item = spirv::Word>>(
         &mut self,
         insert_point: InsertPoint,
         result_type: spirv::Word,
@@ -204,12 +204,12 @@ impl Builder {
             vec![dr::Operand::IdRef(base)],
         );
         inst.operands
-            .extend(indexes.as_ref().iter().cloned().map(dr::Operand::IdRef));
+            .extend(indexes.into_iter().map(dr::Operand::IdRef));
         self.insert_into_block(insert_point, inst)?;
         Ok(_id)
     }
     #[doc = "Appends an OpInBoundsAccessChain instruction to the current block."]
-    pub fn in_bounds_access_chain<T: AsRef<[spirv::Word]>>(
+    pub fn in_bounds_access_chain<T: IntoIterator<Item = spirv::Word>>(
         &mut self,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
@@ -225,12 +225,12 @@ impl Builder {
             vec![dr::Operand::IdRef(base)],
         );
         inst.operands
-            .extend(indexes.as_ref().iter().cloned().map(dr::Operand::IdRef));
+            .extend(indexes.into_iter().map(dr::Operand::IdRef));
         self.insert_into_block(InsertPoint::End, inst)?;
         Ok(_id)
     }
     #[doc = "Appends an OpInBoundsAccessChain instruction to the current block."]
-    pub fn insert_in_bounds_access_chain<T: AsRef<[spirv::Word]>>(
+    pub fn insert_in_bounds_access_chain<T: IntoIterator<Item = spirv::Word>>(
         &mut self,
         insert_point: InsertPoint,
         result_type: spirv::Word,
@@ -247,12 +247,12 @@ impl Builder {
             vec![dr::Operand::IdRef(base)],
         );
         inst.operands
-            .extend(indexes.as_ref().iter().cloned().map(dr::Operand::IdRef));
+            .extend(indexes.into_iter().map(dr::Operand::IdRef));
         self.insert_into_block(insert_point, inst)?;
         Ok(_id)
     }
     #[doc = "Appends an OpPtrAccessChain instruction to the current block."]
-    pub fn ptr_access_chain<T: AsRef<[spirv::Word]>>(
+    pub fn ptr_access_chain<T: IntoIterator<Item = spirv::Word>>(
         &mut self,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
@@ -269,12 +269,12 @@ impl Builder {
             vec![dr::Operand::IdRef(base), dr::Operand::IdRef(element)],
         );
         inst.operands
-            .extend(indexes.as_ref().iter().cloned().map(dr::Operand::IdRef));
+            .extend(indexes.into_iter().map(dr::Operand::IdRef));
         self.insert_into_block(InsertPoint::End, inst)?;
         Ok(_id)
     }
     #[doc = "Appends an OpPtrAccessChain instruction to the current block."]
-    pub fn insert_ptr_access_chain<T: AsRef<[spirv::Word]>>(
+    pub fn insert_ptr_access_chain<T: IntoIterator<Item = spirv::Word>>(
         &mut self,
         insert_point: InsertPoint,
         result_type: spirv::Word,
@@ -292,7 +292,7 @@ impl Builder {
             vec![dr::Operand::IdRef(base), dr::Operand::IdRef(element)],
         );
         inst.operands
-            .extend(indexes.as_ref().iter().cloned().map(dr::Operand::IdRef));
+            .extend(indexes.into_iter().map(dr::Operand::IdRef));
         self.insert_into_block(insert_point, inst)?;
         Ok(_id)
     }
@@ -379,7 +379,7 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpInBoundsPtrAccessChain instruction to the current block."]
-    pub fn in_bounds_ptr_access_chain<T: AsRef<[spirv::Word]>>(
+    pub fn in_bounds_ptr_access_chain<T: IntoIterator<Item = spirv::Word>>(
         &mut self,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
@@ -396,12 +396,12 @@ impl Builder {
             vec![dr::Operand::IdRef(base), dr::Operand::IdRef(element)],
         );
         inst.operands
-            .extend(indexes.as_ref().iter().cloned().map(dr::Operand::IdRef));
+            .extend(indexes.into_iter().map(dr::Operand::IdRef));
         self.insert_into_block(InsertPoint::End, inst)?;
         Ok(_id)
     }
     #[doc = "Appends an OpInBoundsPtrAccessChain instruction to the current block."]
-    pub fn insert_in_bounds_ptr_access_chain<T: AsRef<[spirv::Word]>>(
+    pub fn insert_in_bounds_ptr_access_chain<T: IntoIterator<Item = spirv::Word>>(
         &mut self,
         insert_point: InsertPoint,
         result_type: spirv::Word,
@@ -419,7 +419,7 @@ impl Builder {
             vec![dr::Operand::IdRef(base), dr::Operand::IdRef(element)],
         );
         inst.operands
-            .extend(indexes.as_ref().iter().cloned().map(dr::Operand::IdRef));
+            .extend(indexes.into_iter().map(dr::Operand::IdRef));
         self.insert_into_block(insert_point, inst)?;
         Ok(_id)
     }
@@ -512,7 +512,7 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpVectorShuffle instruction to the current block."]
-    pub fn vector_shuffle<T: AsRef<[u32]>>(
+    pub fn vector_shuffle<T: IntoIterator<Item = u32>>(
         &mut self,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
@@ -528,18 +528,13 @@ impl Builder {
             Some(_id),
             vec![dr::Operand::IdRef(vector_1), dr::Operand::IdRef(vector_2)],
         );
-        inst.operands.extend(
-            components
-                .as_ref()
-                .iter()
-                .cloned()
-                .map(dr::Operand::LiteralInt32),
-        );
+        inst.operands
+            .extend(components.into_iter().map(dr::Operand::LiteralInt32));
         self.insert_into_block(InsertPoint::End, inst)?;
         Ok(_id)
     }
     #[doc = "Appends an OpVectorShuffle instruction to the current block."]
-    pub fn insert_vector_shuffle<T: AsRef<[u32]>>(
+    pub fn insert_vector_shuffle<T: IntoIterator<Item = u32>>(
         &mut self,
         insert_point: InsertPoint,
         result_type: spirv::Word,
@@ -556,18 +551,13 @@ impl Builder {
             Some(_id),
             vec![dr::Operand::IdRef(vector_1), dr::Operand::IdRef(vector_2)],
         );
-        inst.operands.extend(
-            components
-                .as_ref()
-                .iter()
-                .cloned()
-                .map(dr::Operand::LiteralInt32),
-        );
+        inst.operands
+            .extend(components.into_iter().map(dr::Operand::LiteralInt32));
         self.insert_into_block(insert_point, inst)?;
         Ok(_id)
     }
     #[doc = "Appends an OpCompositeConstruct instruction to the current block."]
-    pub fn composite_construct<T: AsRef<[spirv::Word]>>(
+    pub fn composite_construct<T: IntoIterator<Item = spirv::Word>>(
         &mut self,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
@@ -581,18 +571,13 @@ impl Builder {
             Some(_id),
             vec![],
         );
-        inst.operands.extend(
-            constituents
-                .as_ref()
-                .iter()
-                .cloned()
-                .map(dr::Operand::IdRef),
-        );
+        inst.operands
+            .extend(constituents.into_iter().map(dr::Operand::IdRef));
         self.insert_into_block(InsertPoint::End, inst)?;
         Ok(_id)
     }
     #[doc = "Appends an OpCompositeConstruct instruction to the current block."]
-    pub fn insert_composite_construct<T: AsRef<[spirv::Word]>>(
+    pub fn insert_composite_construct<T: IntoIterator<Item = spirv::Word>>(
         &mut self,
         insert_point: InsertPoint,
         result_type: spirv::Word,
@@ -607,18 +592,13 @@ impl Builder {
             Some(_id),
             vec![],
         );
-        inst.operands.extend(
-            constituents
-                .as_ref()
-                .iter()
-                .cloned()
-                .map(dr::Operand::IdRef),
-        );
+        inst.operands
+            .extend(constituents.into_iter().map(dr::Operand::IdRef));
         self.insert_into_block(insert_point, inst)?;
         Ok(_id)
     }
     #[doc = "Appends an OpCompositeExtract instruction to the current block."]
-    pub fn composite_extract<T: AsRef<[u32]>>(
+    pub fn composite_extract<T: IntoIterator<Item = u32>>(
         &mut self,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
@@ -633,18 +613,13 @@ impl Builder {
             Some(_id),
             vec![dr::Operand::IdRef(composite)],
         );
-        inst.operands.extend(
-            indexes
-                .as_ref()
-                .iter()
-                .cloned()
-                .map(dr::Operand::LiteralInt32),
-        );
+        inst.operands
+            .extend(indexes.into_iter().map(dr::Operand::LiteralInt32));
         self.insert_into_block(InsertPoint::End, inst)?;
         Ok(_id)
     }
     #[doc = "Appends an OpCompositeExtract instruction to the current block."]
-    pub fn insert_composite_extract<T: AsRef<[u32]>>(
+    pub fn insert_composite_extract<T: IntoIterator<Item = u32>>(
         &mut self,
         insert_point: InsertPoint,
         result_type: spirv::Word,
@@ -660,18 +635,13 @@ impl Builder {
             Some(_id),
             vec![dr::Operand::IdRef(composite)],
         );
-        inst.operands.extend(
-            indexes
-                .as_ref()
-                .iter()
-                .cloned()
-                .map(dr::Operand::LiteralInt32),
-        );
+        inst.operands
+            .extend(indexes.into_iter().map(dr::Operand::LiteralInt32));
         self.insert_into_block(insert_point, inst)?;
         Ok(_id)
     }
     #[doc = "Appends an OpCompositeInsert instruction to the current block."]
-    pub fn composite_insert<T: AsRef<[u32]>>(
+    pub fn composite_insert<T: IntoIterator<Item = u32>>(
         &mut self,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
@@ -687,18 +657,13 @@ impl Builder {
             Some(_id),
             vec![dr::Operand::IdRef(object), dr::Operand::IdRef(composite)],
         );
-        inst.operands.extend(
-            indexes
-                .as_ref()
-                .iter()
-                .cloned()
-                .map(dr::Operand::LiteralInt32),
-        );
+        inst.operands
+            .extend(indexes.into_iter().map(dr::Operand::LiteralInt32));
         self.insert_into_block(InsertPoint::End, inst)?;
         Ok(_id)
     }
     #[doc = "Appends an OpCompositeInsert instruction to the current block."]
-    pub fn insert_composite_insert<T: AsRef<[u32]>>(
+    pub fn insert_composite_insert<T: IntoIterator<Item = u32>>(
         &mut self,
         insert_point: InsertPoint,
         result_type: spirv::Word,
@@ -715,13 +680,8 @@ impl Builder {
             Some(_id),
             vec![dr::Operand::IdRef(object), dr::Operand::IdRef(composite)],
         );
-        inst.operands.extend(
-            indexes
-                .as_ref()
-                .iter()
-                .cloned()
-                .map(dr::Operand::LiteralInt32),
-        );
+        inst.operands
+            .extend(indexes.into_iter().map(dr::Operand::LiteralInt32));
         self.insert_into_block(insert_point, inst)?;
         Ok(_id)
     }
@@ -839,7 +799,7 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpImageSampleImplicitLod instruction to the current block."]
-    pub fn image_sample_implicit_lod<T: AsRef<[dr::Operand]>>(
+    pub fn image_sample_implicit_lod<T: IntoIterator<Item = dr::Operand>>(
         &mut self,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
@@ -863,12 +823,12 @@ impl Builder {
             #[allow(clippy::identity_conversion)]
             inst.operands.push(dr::Operand::ImageOperands(v.into()));
         }
-        inst.operands.extend_from_slice(additional_params.as_ref());
+        inst.operands.extend(additional_params);
         self.insert_into_block(InsertPoint::End, inst)?;
         Ok(_id)
     }
     #[doc = "Appends an OpImageSampleImplicitLod instruction to the current block."]
-    pub fn insert_image_sample_implicit_lod<T: AsRef<[dr::Operand]>>(
+    pub fn insert_image_sample_implicit_lod<T: IntoIterator<Item = dr::Operand>>(
         &mut self,
         insert_point: InsertPoint,
         result_type: spirv::Word,
@@ -893,12 +853,12 @@ impl Builder {
             #[allow(clippy::identity_conversion)]
             inst.operands.push(dr::Operand::ImageOperands(v.into()));
         }
-        inst.operands.extend_from_slice(additional_params.as_ref());
+        inst.operands.extend(additional_params);
         self.insert_into_block(insert_point, inst)?;
         Ok(_id)
     }
     #[doc = "Appends an OpImageSampleExplicitLod instruction to the current block."]
-    pub fn image_sample_explicit_lod<T: AsRef<[dr::Operand]>>(
+    pub fn image_sample_explicit_lod<T: IntoIterator<Item = dr::Operand>>(
         &mut self,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
@@ -919,12 +879,12 @@ impl Builder {
                 dr::Operand::ImageOperands(image_operands),
             ],
         );
-        inst.operands.extend_from_slice(additional_params.as_ref());
+        inst.operands.extend(additional_params);
         self.insert_into_block(InsertPoint::End, inst)?;
         Ok(_id)
     }
     #[doc = "Appends an OpImageSampleExplicitLod instruction to the current block."]
-    pub fn insert_image_sample_explicit_lod<T: AsRef<[dr::Operand]>>(
+    pub fn insert_image_sample_explicit_lod<T: IntoIterator<Item = dr::Operand>>(
         &mut self,
         insert_point: InsertPoint,
         result_type: spirv::Word,
@@ -946,12 +906,12 @@ impl Builder {
                 dr::Operand::ImageOperands(image_operands),
             ],
         );
-        inst.operands.extend_from_slice(additional_params.as_ref());
+        inst.operands.extend(additional_params);
         self.insert_into_block(insert_point, inst)?;
         Ok(_id)
     }
     #[doc = "Appends an OpImageSampleDrefImplicitLod instruction to the current block."]
-    pub fn image_sample_dref_implicit_lod<T: AsRef<[dr::Operand]>>(
+    pub fn image_sample_dref_implicit_lod<T: IntoIterator<Item = dr::Operand>>(
         &mut self,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
@@ -977,12 +937,12 @@ impl Builder {
             #[allow(clippy::identity_conversion)]
             inst.operands.push(dr::Operand::ImageOperands(v.into()));
         }
-        inst.operands.extend_from_slice(additional_params.as_ref());
+        inst.operands.extend(additional_params);
         self.insert_into_block(InsertPoint::End, inst)?;
         Ok(_id)
     }
     #[doc = "Appends an OpImageSampleDrefImplicitLod instruction to the current block."]
-    pub fn insert_image_sample_dref_implicit_lod<T: AsRef<[dr::Operand]>>(
+    pub fn insert_image_sample_dref_implicit_lod<T: IntoIterator<Item = dr::Operand>>(
         &mut self,
         insert_point: InsertPoint,
         result_type: spirv::Word,
@@ -1009,12 +969,12 @@ impl Builder {
             #[allow(clippy::identity_conversion)]
             inst.operands.push(dr::Operand::ImageOperands(v.into()));
         }
-        inst.operands.extend_from_slice(additional_params.as_ref());
+        inst.operands.extend(additional_params);
         self.insert_into_block(insert_point, inst)?;
         Ok(_id)
     }
     #[doc = "Appends an OpImageSampleDrefExplicitLod instruction to the current block."]
-    pub fn image_sample_dref_explicit_lod<T: AsRef<[dr::Operand]>>(
+    pub fn image_sample_dref_explicit_lod<T: IntoIterator<Item = dr::Operand>>(
         &mut self,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
@@ -1037,12 +997,12 @@ impl Builder {
                 dr::Operand::ImageOperands(image_operands),
             ],
         );
-        inst.operands.extend_from_slice(additional_params.as_ref());
+        inst.operands.extend(additional_params);
         self.insert_into_block(InsertPoint::End, inst)?;
         Ok(_id)
     }
     #[doc = "Appends an OpImageSampleDrefExplicitLod instruction to the current block."]
-    pub fn insert_image_sample_dref_explicit_lod<T: AsRef<[dr::Operand]>>(
+    pub fn insert_image_sample_dref_explicit_lod<T: IntoIterator<Item = dr::Operand>>(
         &mut self,
         insert_point: InsertPoint,
         result_type: spirv::Word,
@@ -1066,12 +1026,12 @@ impl Builder {
                 dr::Operand::ImageOperands(image_operands),
             ],
         );
-        inst.operands.extend_from_slice(additional_params.as_ref());
+        inst.operands.extend(additional_params);
         self.insert_into_block(insert_point, inst)?;
         Ok(_id)
     }
     #[doc = "Appends an OpImageSampleProjImplicitLod instruction to the current block."]
-    pub fn image_sample_proj_implicit_lod<T: AsRef<[dr::Operand]>>(
+    pub fn image_sample_proj_implicit_lod<T: IntoIterator<Item = dr::Operand>>(
         &mut self,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
@@ -1095,12 +1055,12 @@ impl Builder {
             #[allow(clippy::identity_conversion)]
             inst.operands.push(dr::Operand::ImageOperands(v.into()));
         }
-        inst.operands.extend_from_slice(additional_params.as_ref());
+        inst.operands.extend(additional_params);
         self.insert_into_block(InsertPoint::End, inst)?;
         Ok(_id)
     }
     #[doc = "Appends an OpImageSampleProjImplicitLod instruction to the current block."]
-    pub fn insert_image_sample_proj_implicit_lod<T: AsRef<[dr::Operand]>>(
+    pub fn insert_image_sample_proj_implicit_lod<T: IntoIterator<Item = dr::Operand>>(
         &mut self,
         insert_point: InsertPoint,
         result_type: spirv::Word,
@@ -1125,12 +1085,12 @@ impl Builder {
             #[allow(clippy::identity_conversion)]
             inst.operands.push(dr::Operand::ImageOperands(v.into()));
         }
-        inst.operands.extend_from_slice(additional_params.as_ref());
+        inst.operands.extend(additional_params);
         self.insert_into_block(insert_point, inst)?;
         Ok(_id)
     }
     #[doc = "Appends an OpImageSampleProjExplicitLod instruction to the current block."]
-    pub fn image_sample_proj_explicit_lod<T: AsRef<[dr::Operand]>>(
+    pub fn image_sample_proj_explicit_lod<T: IntoIterator<Item = dr::Operand>>(
         &mut self,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
@@ -1151,12 +1111,12 @@ impl Builder {
                 dr::Operand::ImageOperands(image_operands),
             ],
         );
-        inst.operands.extend_from_slice(additional_params.as_ref());
+        inst.operands.extend(additional_params);
         self.insert_into_block(InsertPoint::End, inst)?;
         Ok(_id)
     }
     #[doc = "Appends an OpImageSampleProjExplicitLod instruction to the current block."]
-    pub fn insert_image_sample_proj_explicit_lod<T: AsRef<[dr::Operand]>>(
+    pub fn insert_image_sample_proj_explicit_lod<T: IntoIterator<Item = dr::Operand>>(
         &mut self,
         insert_point: InsertPoint,
         result_type: spirv::Word,
@@ -1178,12 +1138,12 @@ impl Builder {
                 dr::Operand::ImageOperands(image_operands),
             ],
         );
-        inst.operands.extend_from_slice(additional_params.as_ref());
+        inst.operands.extend(additional_params);
         self.insert_into_block(insert_point, inst)?;
         Ok(_id)
     }
     #[doc = "Appends an OpImageSampleProjDrefImplicitLod instruction to the current block."]
-    pub fn image_sample_proj_dref_implicit_lod<T: AsRef<[dr::Operand]>>(
+    pub fn image_sample_proj_dref_implicit_lod<T: IntoIterator<Item = dr::Operand>>(
         &mut self,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
@@ -1209,12 +1169,12 @@ impl Builder {
             #[allow(clippy::identity_conversion)]
             inst.operands.push(dr::Operand::ImageOperands(v.into()));
         }
-        inst.operands.extend_from_slice(additional_params.as_ref());
+        inst.operands.extend(additional_params);
         self.insert_into_block(InsertPoint::End, inst)?;
         Ok(_id)
     }
     #[doc = "Appends an OpImageSampleProjDrefImplicitLod instruction to the current block."]
-    pub fn insert_image_sample_proj_dref_implicit_lod<T: AsRef<[dr::Operand]>>(
+    pub fn insert_image_sample_proj_dref_implicit_lod<T: IntoIterator<Item = dr::Operand>>(
         &mut self,
         insert_point: InsertPoint,
         result_type: spirv::Word,
@@ -1241,12 +1201,12 @@ impl Builder {
             #[allow(clippy::identity_conversion)]
             inst.operands.push(dr::Operand::ImageOperands(v.into()));
         }
-        inst.operands.extend_from_slice(additional_params.as_ref());
+        inst.operands.extend(additional_params);
         self.insert_into_block(insert_point, inst)?;
         Ok(_id)
     }
     #[doc = "Appends an OpImageSampleProjDrefExplicitLod instruction to the current block."]
-    pub fn image_sample_proj_dref_explicit_lod<T: AsRef<[dr::Operand]>>(
+    pub fn image_sample_proj_dref_explicit_lod<T: IntoIterator<Item = dr::Operand>>(
         &mut self,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
@@ -1269,12 +1229,12 @@ impl Builder {
                 dr::Operand::ImageOperands(image_operands),
             ],
         );
-        inst.operands.extend_from_slice(additional_params.as_ref());
+        inst.operands.extend(additional_params);
         self.insert_into_block(InsertPoint::End, inst)?;
         Ok(_id)
     }
     #[doc = "Appends an OpImageSampleProjDrefExplicitLod instruction to the current block."]
-    pub fn insert_image_sample_proj_dref_explicit_lod<T: AsRef<[dr::Operand]>>(
+    pub fn insert_image_sample_proj_dref_explicit_lod<T: IntoIterator<Item = dr::Operand>>(
         &mut self,
         insert_point: InsertPoint,
         result_type: spirv::Word,
@@ -1298,12 +1258,12 @@ impl Builder {
                 dr::Operand::ImageOperands(image_operands),
             ],
         );
-        inst.operands.extend_from_slice(additional_params.as_ref());
+        inst.operands.extend(additional_params);
         self.insert_into_block(insert_point, inst)?;
         Ok(_id)
     }
     #[doc = "Appends an OpImageFetch instruction to the current block."]
-    pub fn image_fetch<T: AsRef<[dr::Operand]>>(
+    pub fn image_fetch<T: IntoIterator<Item = dr::Operand>>(
         &mut self,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
@@ -1324,12 +1284,12 @@ impl Builder {
             #[allow(clippy::identity_conversion)]
             inst.operands.push(dr::Operand::ImageOperands(v.into()));
         }
-        inst.operands.extend_from_slice(additional_params.as_ref());
+        inst.operands.extend(additional_params);
         self.insert_into_block(InsertPoint::End, inst)?;
         Ok(_id)
     }
     #[doc = "Appends an OpImageFetch instruction to the current block."]
-    pub fn insert_image_fetch<T: AsRef<[dr::Operand]>>(
+    pub fn insert_image_fetch<T: IntoIterator<Item = dr::Operand>>(
         &mut self,
         insert_point: InsertPoint,
         result_type: spirv::Word,
@@ -1351,12 +1311,12 @@ impl Builder {
             #[allow(clippy::identity_conversion)]
             inst.operands.push(dr::Operand::ImageOperands(v.into()));
         }
-        inst.operands.extend_from_slice(additional_params.as_ref());
+        inst.operands.extend(additional_params);
         self.insert_into_block(insert_point, inst)?;
         Ok(_id)
     }
     #[doc = "Appends an OpImageGather instruction to the current block."]
-    pub fn image_gather<T: AsRef<[dr::Operand]>>(
+    pub fn image_gather<T: IntoIterator<Item = dr::Operand>>(
         &mut self,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
@@ -1382,12 +1342,12 @@ impl Builder {
             #[allow(clippy::identity_conversion)]
             inst.operands.push(dr::Operand::ImageOperands(v.into()));
         }
-        inst.operands.extend_from_slice(additional_params.as_ref());
+        inst.operands.extend(additional_params);
         self.insert_into_block(InsertPoint::End, inst)?;
         Ok(_id)
     }
     #[doc = "Appends an OpImageGather instruction to the current block."]
-    pub fn insert_image_gather<T: AsRef<[dr::Operand]>>(
+    pub fn insert_image_gather<T: IntoIterator<Item = dr::Operand>>(
         &mut self,
         insert_point: InsertPoint,
         result_type: spirv::Word,
@@ -1414,12 +1374,12 @@ impl Builder {
             #[allow(clippy::identity_conversion)]
             inst.operands.push(dr::Operand::ImageOperands(v.into()));
         }
-        inst.operands.extend_from_slice(additional_params.as_ref());
+        inst.operands.extend(additional_params);
         self.insert_into_block(insert_point, inst)?;
         Ok(_id)
     }
     #[doc = "Appends an OpImageDrefGather instruction to the current block."]
-    pub fn image_dref_gather<T: AsRef<[dr::Operand]>>(
+    pub fn image_dref_gather<T: IntoIterator<Item = dr::Operand>>(
         &mut self,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
@@ -1445,12 +1405,12 @@ impl Builder {
             #[allow(clippy::identity_conversion)]
             inst.operands.push(dr::Operand::ImageOperands(v.into()));
         }
-        inst.operands.extend_from_slice(additional_params.as_ref());
+        inst.operands.extend(additional_params);
         self.insert_into_block(InsertPoint::End, inst)?;
         Ok(_id)
     }
     #[doc = "Appends an OpImageDrefGather instruction to the current block."]
-    pub fn insert_image_dref_gather<T: AsRef<[dr::Operand]>>(
+    pub fn insert_image_dref_gather<T: IntoIterator<Item = dr::Operand>>(
         &mut self,
         insert_point: InsertPoint,
         result_type: spirv::Word,
@@ -1477,12 +1437,12 @@ impl Builder {
             #[allow(clippy::identity_conversion)]
             inst.operands.push(dr::Operand::ImageOperands(v.into()));
         }
-        inst.operands.extend_from_slice(additional_params.as_ref());
+        inst.operands.extend(additional_params);
         self.insert_into_block(insert_point, inst)?;
         Ok(_id)
     }
     #[doc = "Appends an OpImageRead instruction to the current block."]
-    pub fn image_read<T: AsRef<[dr::Operand]>>(
+    pub fn image_read<T: IntoIterator<Item = dr::Operand>>(
         &mut self,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
@@ -1503,12 +1463,12 @@ impl Builder {
             #[allow(clippy::identity_conversion)]
             inst.operands.push(dr::Operand::ImageOperands(v.into()));
         }
-        inst.operands.extend_from_slice(additional_params.as_ref());
+        inst.operands.extend(additional_params);
         self.insert_into_block(InsertPoint::End, inst)?;
         Ok(_id)
     }
     #[doc = "Appends an OpImageRead instruction to the current block."]
-    pub fn insert_image_read<T: AsRef<[dr::Operand]>>(
+    pub fn insert_image_read<T: IntoIterator<Item = dr::Operand>>(
         &mut self,
         insert_point: InsertPoint,
         result_type: spirv::Word,
@@ -1530,12 +1490,12 @@ impl Builder {
             #[allow(clippy::identity_conversion)]
             inst.operands.push(dr::Operand::ImageOperands(v.into()));
         }
-        inst.operands.extend_from_slice(additional_params.as_ref());
+        inst.operands.extend(additional_params);
         self.insert_into_block(insert_point, inst)?;
         Ok(_id)
     }
     #[doc = "Appends an OpImageWrite instruction to the current block."]
-    pub fn image_write<T: AsRef<[dr::Operand]>>(
+    pub fn image_write<T: IntoIterator<Item = dr::Operand>>(
         &mut self,
         image: spirv::Word,
         coordinate: spirv::Word,
@@ -1558,12 +1518,12 @@ impl Builder {
             #[allow(clippy::identity_conversion)]
             inst.operands.push(dr::Operand::ImageOperands(v.into()));
         }
-        inst.operands.extend_from_slice(additional_params.as_ref());
+        inst.operands.extend(additional_params);
         self.insert_into_block(InsertPoint::End, inst)?;
         Ok(())
     }
     #[doc = "Appends an OpImageWrite instruction to the current block."]
-    pub fn insert_image_write<T: AsRef<[dr::Operand]>>(
+    pub fn insert_image_write<T: IntoIterator<Item = dr::Operand>>(
         &mut self,
         insert_point: InsertPoint,
         image: spirv::Word,
@@ -1587,7 +1547,7 @@ impl Builder {
             #[allow(clippy::identity_conversion)]
             inst.operands.push(dr::Operand::ImageOperands(v.into()));
         }
-        inst.operands.extend_from_slice(additional_params.as_ref());
+        inst.operands.extend(additional_params);
         self.insert_into_block(insert_point, inst)?;
         Ok(())
     }
@@ -6876,7 +6836,7 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpPhi instruction to the current block."]
-    pub fn phi<T: AsRef<[(spirv::Word, spirv::Word)]>>(
+    pub fn phi<T: IntoIterator<Item = (spirv::Word, spirv::Word)>>(
         &mut self,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
@@ -6885,7 +6845,7 @@ impl Builder {
         let _id = result_id.unwrap_or_else(|| self.id());
         #[allow(unused_mut)]
         let mut inst = dr::Instruction::new(spirv::Op::Phi, Some(result_type), Some(_id), vec![]);
-        for v in variable_parent.as_ref() {
+        for v in variable_parent {
             inst.operands.push(dr::Operand::IdRef(v.0));
             inst.operands.push(dr::Operand::IdRef(v.1));
         }
@@ -6893,7 +6853,7 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpPhi instruction to the current block."]
-    pub fn insert_phi<T: AsRef<[(spirv::Word, spirv::Word)]>>(
+    pub fn insert_phi<T: IntoIterator<Item = (spirv::Word, spirv::Word)>>(
         &mut self,
         insert_point: InsertPoint,
         result_type: spirv::Word,
@@ -6903,7 +6863,7 @@ impl Builder {
         let _id = result_id.unwrap_or_else(|| self.id());
         #[allow(unused_mut)]
         let mut inst = dr::Instruction::new(spirv::Op::Phi, Some(result_type), Some(_id), vec![]);
-        for v in variable_parent.as_ref() {
+        for v in variable_parent {
             inst.operands.push(dr::Operand::IdRef(v.0));
             inst.operands.push(dr::Operand::IdRef(v.1));
         }
@@ -8378,7 +8338,7 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpEnqueueKernel instruction to the current block."]
-    pub fn enqueue_kernel<T: AsRef<[spirv::Word]>>(
+    pub fn enqueue_kernel<T: IntoIterator<Item = spirv::Word>>(
         &mut self,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
@@ -8414,12 +8374,12 @@ impl Builder {
             ],
         );
         inst.operands
-            .extend(local_size.as_ref().iter().cloned().map(dr::Operand::IdRef));
+            .extend(local_size.into_iter().map(dr::Operand::IdRef));
         self.insert_into_block(InsertPoint::End, inst)?;
         Ok(_id)
     }
     #[doc = "Appends an OpEnqueueKernel instruction to the current block."]
-    pub fn insert_enqueue_kernel<T: AsRef<[spirv::Word]>>(
+    pub fn insert_enqueue_kernel<T: IntoIterator<Item = spirv::Word>>(
         &mut self,
         insert_point: InsertPoint,
         result_type: spirv::Word,
@@ -8456,7 +8416,7 @@ impl Builder {
             ],
         );
         inst.operands
-            .extend(local_size.as_ref().iter().cloned().map(dr::Operand::IdRef));
+            .extend(local_size.into_iter().map(dr::Operand::IdRef));
         self.insert_into_block(insert_point, inst)?;
         Ok(_id)
     }
@@ -8969,7 +8929,7 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpImageSparseSampleImplicitLod instruction to the current block."]
-    pub fn image_sparse_sample_implicit_lod<T: AsRef<[dr::Operand]>>(
+    pub fn image_sparse_sample_implicit_lod<T: IntoIterator<Item = dr::Operand>>(
         &mut self,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
@@ -8993,12 +8953,12 @@ impl Builder {
             #[allow(clippy::identity_conversion)]
             inst.operands.push(dr::Operand::ImageOperands(v.into()));
         }
-        inst.operands.extend_from_slice(additional_params.as_ref());
+        inst.operands.extend(additional_params);
         self.insert_into_block(InsertPoint::End, inst)?;
         Ok(_id)
     }
     #[doc = "Appends an OpImageSparseSampleImplicitLod instruction to the current block."]
-    pub fn insert_image_sparse_sample_implicit_lod<T: AsRef<[dr::Operand]>>(
+    pub fn insert_image_sparse_sample_implicit_lod<T: IntoIterator<Item = dr::Operand>>(
         &mut self,
         insert_point: InsertPoint,
         result_type: spirv::Word,
@@ -9023,12 +8983,12 @@ impl Builder {
             #[allow(clippy::identity_conversion)]
             inst.operands.push(dr::Operand::ImageOperands(v.into()));
         }
-        inst.operands.extend_from_slice(additional_params.as_ref());
+        inst.operands.extend(additional_params);
         self.insert_into_block(insert_point, inst)?;
         Ok(_id)
     }
     #[doc = "Appends an OpImageSparseSampleExplicitLod instruction to the current block."]
-    pub fn image_sparse_sample_explicit_lod<T: AsRef<[dr::Operand]>>(
+    pub fn image_sparse_sample_explicit_lod<T: IntoIterator<Item = dr::Operand>>(
         &mut self,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
@@ -9049,12 +9009,12 @@ impl Builder {
                 dr::Operand::ImageOperands(image_operands),
             ],
         );
-        inst.operands.extend_from_slice(additional_params.as_ref());
+        inst.operands.extend(additional_params);
         self.insert_into_block(InsertPoint::End, inst)?;
         Ok(_id)
     }
     #[doc = "Appends an OpImageSparseSampleExplicitLod instruction to the current block."]
-    pub fn insert_image_sparse_sample_explicit_lod<T: AsRef<[dr::Operand]>>(
+    pub fn insert_image_sparse_sample_explicit_lod<T: IntoIterator<Item = dr::Operand>>(
         &mut self,
         insert_point: InsertPoint,
         result_type: spirv::Word,
@@ -9076,12 +9036,12 @@ impl Builder {
                 dr::Operand::ImageOperands(image_operands),
             ],
         );
-        inst.operands.extend_from_slice(additional_params.as_ref());
+        inst.operands.extend(additional_params);
         self.insert_into_block(insert_point, inst)?;
         Ok(_id)
     }
     #[doc = "Appends an OpImageSparseSampleDrefImplicitLod instruction to the current block."]
-    pub fn image_sparse_sample_dref_implicit_lod<T: AsRef<[dr::Operand]>>(
+    pub fn image_sparse_sample_dref_implicit_lod<T: IntoIterator<Item = dr::Operand>>(
         &mut self,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
@@ -9107,12 +9067,12 @@ impl Builder {
             #[allow(clippy::identity_conversion)]
             inst.operands.push(dr::Operand::ImageOperands(v.into()));
         }
-        inst.operands.extend_from_slice(additional_params.as_ref());
+        inst.operands.extend(additional_params);
         self.insert_into_block(InsertPoint::End, inst)?;
         Ok(_id)
     }
     #[doc = "Appends an OpImageSparseSampleDrefImplicitLod instruction to the current block."]
-    pub fn insert_image_sparse_sample_dref_implicit_lod<T: AsRef<[dr::Operand]>>(
+    pub fn insert_image_sparse_sample_dref_implicit_lod<T: IntoIterator<Item = dr::Operand>>(
         &mut self,
         insert_point: InsertPoint,
         result_type: spirv::Word,
@@ -9139,12 +9099,12 @@ impl Builder {
             #[allow(clippy::identity_conversion)]
             inst.operands.push(dr::Operand::ImageOperands(v.into()));
         }
-        inst.operands.extend_from_slice(additional_params.as_ref());
+        inst.operands.extend(additional_params);
         self.insert_into_block(insert_point, inst)?;
         Ok(_id)
     }
     #[doc = "Appends an OpImageSparseSampleDrefExplicitLod instruction to the current block."]
-    pub fn image_sparse_sample_dref_explicit_lod<T: AsRef<[dr::Operand]>>(
+    pub fn image_sparse_sample_dref_explicit_lod<T: IntoIterator<Item = dr::Operand>>(
         &mut self,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
@@ -9167,12 +9127,12 @@ impl Builder {
                 dr::Operand::ImageOperands(image_operands),
             ],
         );
-        inst.operands.extend_from_slice(additional_params.as_ref());
+        inst.operands.extend(additional_params);
         self.insert_into_block(InsertPoint::End, inst)?;
         Ok(_id)
     }
     #[doc = "Appends an OpImageSparseSampleDrefExplicitLod instruction to the current block."]
-    pub fn insert_image_sparse_sample_dref_explicit_lod<T: AsRef<[dr::Operand]>>(
+    pub fn insert_image_sparse_sample_dref_explicit_lod<T: IntoIterator<Item = dr::Operand>>(
         &mut self,
         insert_point: InsertPoint,
         result_type: spirv::Word,
@@ -9196,12 +9156,12 @@ impl Builder {
                 dr::Operand::ImageOperands(image_operands),
             ],
         );
-        inst.operands.extend_from_slice(additional_params.as_ref());
+        inst.operands.extend(additional_params);
         self.insert_into_block(insert_point, inst)?;
         Ok(_id)
     }
     #[doc = "Appends an OpImageSparseSampleProjImplicitLod instruction to the current block."]
-    pub fn image_sparse_sample_proj_implicit_lod<T: AsRef<[dr::Operand]>>(
+    pub fn image_sparse_sample_proj_implicit_lod<T: IntoIterator<Item = dr::Operand>>(
         &mut self,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
@@ -9225,12 +9185,12 @@ impl Builder {
             #[allow(clippy::identity_conversion)]
             inst.operands.push(dr::Operand::ImageOperands(v.into()));
         }
-        inst.operands.extend_from_slice(additional_params.as_ref());
+        inst.operands.extend(additional_params);
         self.insert_into_block(InsertPoint::End, inst)?;
         Ok(_id)
     }
     #[doc = "Appends an OpImageSparseSampleProjImplicitLod instruction to the current block."]
-    pub fn insert_image_sparse_sample_proj_implicit_lod<T: AsRef<[dr::Operand]>>(
+    pub fn insert_image_sparse_sample_proj_implicit_lod<T: IntoIterator<Item = dr::Operand>>(
         &mut self,
         insert_point: InsertPoint,
         result_type: spirv::Word,
@@ -9255,12 +9215,12 @@ impl Builder {
             #[allow(clippy::identity_conversion)]
             inst.operands.push(dr::Operand::ImageOperands(v.into()));
         }
-        inst.operands.extend_from_slice(additional_params.as_ref());
+        inst.operands.extend(additional_params);
         self.insert_into_block(insert_point, inst)?;
         Ok(_id)
     }
     #[doc = "Appends an OpImageSparseSampleProjExplicitLod instruction to the current block."]
-    pub fn image_sparse_sample_proj_explicit_lod<T: AsRef<[dr::Operand]>>(
+    pub fn image_sparse_sample_proj_explicit_lod<T: IntoIterator<Item = dr::Operand>>(
         &mut self,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
@@ -9281,12 +9241,12 @@ impl Builder {
                 dr::Operand::ImageOperands(image_operands),
             ],
         );
-        inst.operands.extend_from_slice(additional_params.as_ref());
+        inst.operands.extend(additional_params);
         self.insert_into_block(InsertPoint::End, inst)?;
         Ok(_id)
     }
     #[doc = "Appends an OpImageSparseSampleProjExplicitLod instruction to the current block."]
-    pub fn insert_image_sparse_sample_proj_explicit_lod<T: AsRef<[dr::Operand]>>(
+    pub fn insert_image_sparse_sample_proj_explicit_lod<T: IntoIterator<Item = dr::Operand>>(
         &mut self,
         insert_point: InsertPoint,
         result_type: spirv::Word,
@@ -9308,12 +9268,12 @@ impl Builder {
                 dr::Operand::ImageOperands(image_operands),
             ],
         );
-        inst.operands.extend_from_slice(additional_params.as_ref());
+        inst.operands.extend(additional_params);
         self.insert_into_block(insert_point, inst)?;
         Ok(_id)
     }
     #[doc = "Appends an OpImageSparseSampleProjDrefImplicitLod instruction to the current block."]
-    pub fn image_sparse_sample_proj_dref_implicit_lod<T: AsRef<[dr::Operand]>>(
+    pub fn image_sparse_sample_proj_dref_implicit_lod<T: IntoIterator<Item = dr::Operand>>(
         &mut self,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
@@ -9339,12 +9299,14 @@ impl Builder {
             #[allow(clippy::identity_conversion)]
             inst.operands.push(dr::Operand::ImageOperands(v.into()));
         }
-        inst.operands.extend_from_slice(additional_params.as_ref());
+        inst.operands.extend(additional_params);
         self.insert_into_block(InsertPoint::End, inst)?;
         Ok(_id)
     }
     #[doc = "Appends an OpImageSparseSampleProjDrefImplicitLod instruction to the current block."]
-    pub fn insert_image_sparse_sample_proj_dref_implicit_lod<T: AsRef<[dr::Operand]>>(
+    pub fn insert_image_sparse_sample_proj_dref_implicit_lod<
+        T: IntoIterator<Item = dr::Operand>,
+    >(
         &mut self,
         insert_point: InsertPoint,
         result_type: spirv::Word,
@@ -9371,12 +9333,12 @@ impl Builder {
             #[allow(clippy::identity_conversion)]
             inst.operands.push(dr::Operand::ImageOperands(v.into()));
         }
-        inst.operands.extend_from_slice(additional_params.as_ref());
+        inst.operands.extend(additional_params);
         self.insert_into_block(insert_point, inst)?;
         Ok(_id)
     }
     #[doc = "Appends an OpImageSparseSampleProjDrefExplicitLod instruction to the current block."]
-    pub fn image_sparse_sample_proj_dref_explicit_lod<T: AsRef<[dr::Operand]>>(
+    pub fn image_sparse_sample_proj_dref_explicit_lod<T: IntoIterator<Item = dr::Operand>>(
         &mut self,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
@@ -9399,12 +9361,14 @@ impl Builder {
                 dr::Operand::ImageOperands(image_operands),
             ],
         );
-        inst.operands.extend_from_slice(additional_params.as_ref());
+        inst.operands.extend(additional_params);
         self.insert_into_block(InsertPoint::End, inst)?;
         Ok(_id)
     }
     #[doc = "Appends an OpImageSparseSampleProjDrefExplicitLod instruction to the current block."]
-    pub fn insert_image_sparse_sample_proj_dref_explicit_lod<T: AsRef<[dr::Operand]>>(
+    pub fn insert_image_sparse_sample_proj_dref_explicit_lod<
+        T: IntoIterator<Item = dr::Operand>,
+    >(
         &mut self,
         insert_point: InsertPoint,
         result_type: spirv::Word,
@@ -9428,12 +9392,12 @@ impl Builder {
                 dr::Operand::ImageOperands(image_operands),
             ],
         );
-        inst.operands.extend_from_slice(additional_params.as_ref());
+        inst.operands.extend(additional_params);
         self.insert_into_block(insert_point, inst)?;
         Ok(_id)
     }
     #[doc = "Appends an OpImageSparseFetch instruction to the current block."]
-    pub fn image_sparse_fetch<T: AsRef<[dr::Operand]>>(
+    pub fn image_sparse_fetch<T: IntoIterator<Item = dr::Operand>>(
         &mut self,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
@@ -9454,12 +9418,12 @@ impl Builder {
             #[allow(clippy::identity_conversion)]
             inst.operands.push(dr::Operand::ImageOperands(v.into()));
         }
-        inst.operands.extend_from_slice(additional_params.as_ref());
+        inst.operands.extend(additional_params);
         self.insert_into_block(InsertPoint::End, inst)?;
         Ok(_id)
     }
     #[doc = "Appends an OpImageSparseFetch instruction to the current block."]
-    pub fn insert_image_sparse_fetch<T: AsRef<[dr::Operand]>>(
+    pub fn insert_image_sparse_fetch<T: IntoIterator<Item = dr::Operand>>(
         &mut self,
         insert_point: InsertPoint,
         result_type: spirv::Word,
@@ -9481,12 +9445,12 @@ impl Builder {
             #[allow(clippy::identity_conversion)]
             inst.operands.push(dr::Operand::ImageOperands(v.into()));
         }
-        inst.operands.extend_from_slice(additional_params.as_ref());
+        inst.operands.extend(additional_params);
         self.insert_into_block(insert_point, inst)?;
         Ok(_id)
     }
     #[doc = "Appends an OpImageSparseGather instruction to the current block."]
-    pub fn image_sparse_gather<T: AsRef<[dr::Operand]>>(
+    pub fn image_sparse_gather<T: IntoIterator<Item = dr::Operand>>(
         &mut self,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
@@ -9512,12 +9476,12 @@ impl Builder {
             #[allow(clippy::identity_conversion)]
             inst.operands.push(dr::Operand::ImageOperands(v.into()));
         }
-        inst.operands.extend_from_slice(additional_params.as_ref());
+        inst.operands.extend(additional_params);
         self.insert_into_block(InsertPoint::End, inst)?;
         Ok(_id)
     }
     #[doc = "Appends an OpImageSparseGather instruction to the current block."]
-    pub fn insert_image_sparse_gather<T: AsRef<[dr::Operand]>>(
+    pub fn insert_image_sparse_gather<T: IntoIterator<Item = dr::Operand>>(
         &mut self,
         insert_point: InsertPoint,
         result_type: spirv::Word,
@@ -9544,12 +9508,12 @@ impl Builder {
             #[allow(clippy::identity_conversion)]
             inst.operands.push(dr::Operand::ImageOperands(v.into()));
         }
-        inst.operands.extend_from_slice(additional_params.as_ref());
+        inst.operands.extend(additional_params);
         self.insert_into_block(insert_point, inst)?;
         Ok(_id)
     }
     #[doc = "Appends an OpImageSparseDrefGather instruction to the current block."]
-    pub fn image_sparse_dref_gather<T: AsRef<[dr::Operand]>>(
+    pub fn image_sparse_dref_gather<T: IntoIterator<Item = dr::Operand>>(
         &mut self,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
@@ -9575,12 +9539,12 @@ impl Builder {
             #[allow(clippy::identity_conversion)]
             inst.operands.push(dr::Operand::ImageOperands(v.into()));
         }
-        inst.operands.extend_from_slice(additional_params.as_ref());
+        inst.operands.extend(additional_params);
         self.insert_into_block(InsertPoint::End, inst)?;
         Ok(_id)
     }
     #[doc = "Appends an OpImageSparseDrefGather instruction to the current block."]
-    pub fn insert_image_sparse_dref_gather<T: AsRef<[dr::Operand]>>(
+    pub fn insert_image_sparse_dref_gather<T: IntoIterator<Item = dr::Operand>>(
         &mut self,
         insert_point: InsertPoint,
         result_type: spirv::Word,
@@ -9607,7 +9571,7 @@ impl Builder {
             #[allow(clippy::identity_conversion)]
             inst.operands.push(dr::Operand::ImageOperands(v.into()));
         }
-        inst.operands.extend_from_slice(additional_params.as_ref());
+        inst.operands.extend(additional_params);
         self.insert_into_block(insert_point, inst)?;
         Ok(_id)
     }
@@ -9741,7 +9705,7 @@ impl Builder {
         Ok(())
     }
     #[doc = "Appends an OpImageSparseRead instruction to the current block."]
-    pub fn image_sparse_read<T: AsRef<[dr::Operand]>>(
+    pub fn image_sparse_read<T: IntoIterator<Item = dr::Operand>>(
         &mut self,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
@@ -9762,12 +9726,12 @@ impl Builder {
             #[allow(clippy::identity_conversion)]
             inst.operands.push(dr::Operand::ImageOperands(v.into()));
         }
-        inst.operands.extend_from_slice(additional_params.as_ref());
+        inst.operands.extend(additional_params);
         self.insert_into_block(InsertPoint::End, inst)?;
         Ok(_id)
     }
     #[doc = "Appends an OpImageSparseRead instruction to the current block."]
-    pub fn insert_image_sparse_read<T: AsRef<[dr::Operand]>>(
+    pub fn insert_image_sparse_read<T: IntoIterator<Item = dr::Operand>>(
         &mut self,
         insert_point: InsertPoint,
         result_type: spirv::Word,
@@ -9789,7 +9753,7 @@ impl Builder {
             #[allow(clippy::identity_conversion)]
             inst.operands.push(dr::Operand::ImageOperands(v.into()));
         }
-        inst.operands.extend_from_slice(additional_params.as_ref());
+        inst.operands.extend(additional_params);
         self.insert_into_block(insert_point, inst)?;
         Ok(_id)
     }
@@ -12991,7 +12955,7 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpImageSampleFootprintNV instruction to the current block."]
-    pub fn image_sample_footprint_nv<T: AsRef<[dr::Operand]>>(
+    pub fn image_sample_footprint_nv<T: IntoIterator<Item = dr::Operand>>(
         &mut self,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
@@ -13019,12 +12983,12 @@ impl Builder {
             #[allow(clippy::identity_conversion)]
             inst.operands.push(dr::Operand::ImageOperands(v.into()));
         }
-        inst.operands.extend_from_slice(additional_params.as_ref());
+        inst.operands.extend(additional_params);
         self.insert_into_block(InsertPoint::End, inst)?;
         Ok(_id)
     }
     #[doc = "Appends an OpImageSampleFootprintNV instruction to the current block."]
-    pub fn insert_image_sample_footprint_nv<T: AsRef<[dr::Operand]>>(
+    pub fn insert_image_sample_footprint_nv<T: IntoIterator<Item = dr::Operand>>(
         &mut self,
         insert_point: InsertPoint,
         result_type: spirv::Word,
@@ -13053,7 +13017,7 @@ impl Builder {
             #[allow(clippy::identity_conversion)]
             inst.operands.push(dr::Operand::ImageOperands(v.into()));
         }
-        inst.operands.extend_from_slice(additional_params.as_ref());
+        inst.operands.extend(additional_params);
         self.insert_into_block(insert_point, inst)?;
         Ok(_id)
     }
@@ -13496,7 +13460,7 @@ impl Builder {
         Ok(())
     }
     #[doc = "Appends an OpCooperativeMatrixLoadNV instruction to the current block."]
-    pub fn cooperative_matrix_load_nv<T: AsRef<[dr::Operand]>>(
+    pub fn cooperative_matrix_load_nv<T: IntoIterator<Item = dr::Operand>>(
         &mut self,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
@@ -13522,12 +13486,12 @@ impl Builder {
             #[allow(clippy::identity_conversion)]
             inst.operands.push(dr::Operand::MemoryAccess(v.into()));
         }
-        inst.operands.extend_from_slice(additional_params.as_ref());
+        inst.operands.extend(additional_params);
         self.insert_into_block(InsertPoint::End, inst)?;
         Ok(_id)
     }
     #[doc = "Appends an OpCooperativeMatrixLoadNV instruction to the current block."]
-    pub fn insert_cooperative_matrix_load_nv<T: AsRef<[dr::Operand]>>(
+    pub fn insert_cooperative_matrix_load_nv<T: IntoIterator<Item = dr::Operand>>(
         &mut self,
         insert_point: InsertPoint,
         result_type: spirv::Word,
@@ -13554,12 +13518,12 @@ impl Builder {
             #[allow(clippy::identity_conversion)]
             inst.operands.push(dr::Operand::MemoryAccess(v.into()));
         }
-        inst.operands.extend_from_slice(additional_params.as_ref());
+        inst.operands.extend(additional_params);
         self.insert_into_block(insert_point, inst)?;
         Ok(_id)
     }
     #[doc = "Appends an OpCooperativeMatrixStoreNV instruction to the current block."]
-    pub fn cooperative_matrix_store_nv<T: AsRef<[dr::Operand]>>(
+    pub fn cooperative_matrix_store_nv<T: IntoIterator<Item = dr::Operand>>(
         &mut self,
         pointer: spirv::Word,
         object: spirv::Word,
@@ -13584,12 +13548,12 @@ impl Builder {
             #[allow(clippy::identity_conversion)]
             inst.operands.push(dr::Operand::MemoryAccess(v.into()));
         }
-        inst.operands.extend_from_slice(additional_params.as_ref());
+        inst.operands.extend(additional_params);
         self.insert_into_block(InsertPoint::End, inst)?;
         Ok(())
     }
     #[doc = "Appends an OpCooperativeMatrixStoreNV instruction to the current block."]
-    pub fn insert_cooperative_matrix_store_nv<T: AsRef<[dr::Operand]>>(
+    pub fn insert_cooperative_matrix_store_nv<T: IntoIterator<Item = dr::Operand>>(
         &mut self,
         insert_point: InsertPoint,
         pointer: spirv::Word,
@@ -13615,7 +13579,7 @@ impl Builder {
             #[allow(clippy::identity_conversion)]
             inst.operands.push(dr::Operand::MemoryAccess(v.into()));
         }
-        inst.operands.extend_from_slice(additional_params.as_ref());
+        inst.operands.extend(additional_params);
         self.insert_into_block(insert_point, inst)?;
         Ok(())
     }

--- a/rspirv/dr/build/autogen_terminator.rs
+++ b/rspirv/dr/build/autogen_terminator.rs
@@ -4,7 +4,7 @@
 
 impl Builder {
     #[doc = "Appends an OpLoopMerge instruction and ends the current block."]
-    pub fn loop_merge<T: AsRef<[dr::Operand]>>(
+    pub fn loop_merge<T: IntoIterator<Item = dr::Operand>>(
         &mut self,
         merge_block: spirv::Word,
         continue_target: spirv::Word,
@@ -22,11 +22,11 @@ impl Builder {
                 dr::Operand::LoopControl(loop_control),
             ],
         );
-        inst.operands.extend_from_slice(additional_params.as_ref());
+        inst.operands.extend(additional_params);
         self.end_block(inst)
     }
     #[doc = "Insert an OpLoopMerge instruction and ends the current block."]
-    pub fn insert_loop_merge<T: AsRef<[dr::Operand]>>(
+    pub fn insert_loop_merge<T: IntoIterator<Item = dr::Operand>>(
         &mut self,
         insert_point: InsertPoint,
         merge_block: spirv::Word,
@@ -45,7 +45,7 @@ impl Builder {
                 dr::Operand::LoopControl(loop_control),
             ],
         );
-        inst.operands.extend_from_slice(additional_params.as_ref());
+        inst.operands.extend(additional_params);
         self.insert_end_block(insert_point, inst)
     }
     #[doc = "Appends an OpSelectionMerge instruction and ends the current block."]
@@ -128,7 +128,7 @@ impl Builder {
         self.insert_end_block(insert_point, inst)
     }
     #[doc = "Appends an OpBranchConditional instruction and ends the current block."]
-    pub fn branch_conditional<T: AsRef<[u32]>>(
+    pub fn branch_conditional<T: IntoIterator<Item = u32>>(
         &mut self,
         condition: spirv::Word,
         true_label: spirv::Word,
@@ -146,17 +146,12 @@ impl Builder {
                 dr::Operand::IdRef(false_label),
             ],
         );
-        inst.operands.extend(
-            branch_weights
-                .as_ref()
-                .iter()
-                .cloned()
-                .map(dr::Operand::LiteralInt32),
-        );
+        inst.operands
+            .extend(branch_weights.into_iter().map(dr::Operand::LiteralInt32));
         self.end_block(inst)
     }
     #[doc = "Insert an OpBranchConditional instruction and ends the current block."]
-    pub fn insert_branch_conditional<T: AsRef<[u32]>>(
+    pub fn insert_branch_conditional<T: IntoIterator<Item = u32>>(
         &mut self,
         insert_point: InsertPoint,
         condition: spirv::Word,
@@ -175,17 +170,12 @@ impl Builder {
                 dr::Operand::IdRef(false_label),
             ],
         );
-        inst.operands.extend(
-            branch_weights
-                .as_ref()
-                .iter()
-                .cloned()
-                .map(dr::Operand::LiteralInt32),
-        );
+        inst.operands
+            .extend(branch_weights.into_iter().map(dr::Operand::LiteralInt32));
         self.insert_end_block(insert_point, inst)
     }
     #[doc = "Appends an OpSwitch instruction and ends the current block."]
-    pub fn switch<T: AsRef<[(u32, spirv::Word)]>>(
+    pub fn switch<T: IntoIterator<Item = (u32, spirv::Word)>>(
         &mut self,
         selector: spirv::Word,
         default: spirv::Word,
@@ -198,14 +188,14 @@ impl Builder {
             None,
             vec![dr::Operand::IdRef(selector), dr::Operand::IdRef(default)],
         );
-        for v in target.as_ref() {
+        for v in target {
             inst.operands.push(dr::Operand::LiteralInt32(v.0));
             inst.operands.push(dr::Operand::IdRef(v.1));
         }
         self.end_block(inst)
     }
     #[doc = "Insert an OpSwitch instruction and ends the current block."]
-    pub fn insert_switch<T: AsRef<[(u32, spirv::Word)]>>(
+    pub fn insert_switch<T: IntoIterator<Item = (u32, spirv::Word)>>(
         &mut self,
         insert_point: InsertPoint,
         selector: spirv::Word,
@@ -219,7 +209,7 @@ impl Builder {
             None,
             vec![dr::Operand::IdRef(selector), dr::Operand::IdRef(default)],
         );
-        for v in target.as_ref() {
+        for v in target {
             inst.operands.push(dr::Operand::LiteralInt32(v.0));
             inst.operands.push(dr::Operand::IdRef(v.1));
         }

--- a/rspirv/dr/build/autogen_type.rs
+++ b/rspirv/dr/build/autogen_type.rs
@@ -211,16 +211,14 @@ impl Builder {
         }
     }
     #[doc = "Appends an OpTypeStruct instruction and returns the result id, or return the existing id if the instruction was already present."]
-    pub fn type_struct<T: AsRef<[spirv::Word]>>(
+    pub fn type_struct<T: IntoIterator<Item = spirv::Word>>(
         &mut self,
         member_0_type_member_1_type: T,
     ) -> spirv::Word {
         let mut inst = dr::Instruction::new(spirv::Op::TypeStruct, None, None, vec![]);
         inst.operands.extend(
             member_0_type_member_1_type
-                .as_ref()
-                .iter()
-                .cloned()
+                .into_iter()
                 .map(dr::Operand::IdRef),
         );
         if let Some(id) = self.dedup_insert_type(&inst) {
@@ -233,7 +231,7 @@ impl Builder {
         }
     }
     #[doc = "Appends an OpTypeFunction instruction and returns the result id, or return the existing id if the instruction was already present."]
-    pub fn type_function<T: AsRef<[spirv::Word]>>(
+    pub fn type_function<T: IntoIterator<Item = spirv::Word>>(
         &mut self,
         return_type: spirv::Word,
         parameter_0_type_parameter_1_type: T,
@@ -246,9 +244,7 @@ impl Builder {
         );
         inst.operands.extend(
             parameter_0_type_parameter_1_type
-                .as_ref()
-                .iter()
-                .cloned()
+                .into_iter()
                 .map(dr::Operand::IdRef),
         );
         if let Some(id) = self.dedup_insert_type(&inst) {


### PR DESCRIPTION
This is useful if the user has an iterator instead of a slice/vec, it
saves an allocation.

I think this is a breaking change due to ref differences, not sure if we're okay with that.

(For review, the only file changed is `dr.rs`, the rest are generated)