### PR TITLE
 OperandExceeded when using specialization constants in work group size

### DIFF
--- a/rspirv/binary/parser.rs
+++ b/rspirv/binary/parser.rs
@@ -348,10 +348,11 @@ impl<'c, 'd> Parser<'c, 'd> {
         if let Some(g) = GInstTable::lookup_opcode(number as u16) {
             // TODO: check whether this opcode is allowed here.
             operands.push(dr::Operand::LiteralSpecConstantOpInteger(g.opcode));
-            // We need id parameters to this SpecConstantOp.
-            for operand in g.operands {
-                if operand.kind == GOpKind::IdRef {
-                    operands.push(dr::Operand::IdRef(self.decoder.id()?))
+
+            // We need all parameters to this SpecConstantOp.
+            for loperand in g.operands {
+                if loperand.kind != GOpKind::IdResultType && loperand.kind != GOpKind::IdResult {
+                    operands.append(&mut self.parse_operand(loperand.kind)?);
                 }
             }
             Ok(operands)


### PR DESCRIPTION
OpSpecConstantOp only supported IdRefs which was incorrect, it just needed to parse parameters as usual. Fixes #121