### PR TITLE
Pointer should have ty: Token<Type> instead of ty: Word

### DIFF
--- a/autogen/sr.rs
+++ b/autogen/sr.rs
@@ -35,7 +35,7 @@ impl OperandTokens {
                         quote! { StructMember },
                         quote! { StructMember::new(self.types.lookup_token(*value)) },
                     ),
-                    "Parameter Types" => (
+                    "Parameter Types" | "Type" => (
                         quote! { Token<Type> },
                         quote! { self.types.lookup_token(*value) },
                     ),

--- a/rspirv/lift/autogen_context.rs
+++ b/rspirv/lift/autogen_context.rs
@@ -235,7 +235,7 @@ impl LiftContext {
             }),
             6u32 => Ok(ops::Op::MemberName {
                 ty: (match operands.next() {
-                    Some(&dr::Operand::IdRef(ref value)) => Some(*value),
+                    Some(&dr::Operand::IdRef(ref value)) => Some(self.types.lookup_token(*value)),
                     Some(_) => Err(OperandError::WrongType)?,
                     None => None,
                 })
@@ -5651,7 +5651,7 @@ impl LiftContext {
             }),
             5362u32 => Ok(ops::Op::CooperativeMatrixLengthNV {
                 ty: (match operands.next() {
-                    Some(&dr::Operand::IdRef(ref value)) => Some(*value),
+                    Some(&dr::Operand::IdRef(ref value)) => Some(self.types.lookup_token(*value)),
                     Some(_) => Err(OperandError::WrongType)?,
                     None => None,
                 })
@@ -8149,7 +8149,7 @@ impl LiftContext {
                 })
                 .ok_or(OperandError::Missing)?,
                 ty: (match operands.next() {
-                    Some(&dr::Operand::IdRef(ref value)) => Some(*value),
+                    Some(&dr::Operand::IdRef(ref value)) => Some(self.types.lookup_token(*value)),
                     Some(_) => Err(OperandError::WrongType)?,
                     None => None,
                 })

--- a/rspirv/sr/autogen_ops.rs
+++ b/rspirv/sr/autogen_ops.rs
@@ -72,7 +72,7 @@ pub enum Op {
         name: String,
     },
     MemberName {
-        ty: spirv::Word,
+        ty: Token<Type>,
         member: u32,
         name: String,
     },
@@ -1494,7 +1494,7 @@ pub enum Op {
         c: spirv::Word,
     },
     CooperativeMatrixLengthNV {
-        ty: spirv::Word,
+        ty: Token<Type>,
     },
     BeginInvocationInterlockEXT,
     EndInvocationInterlockEXT,

--- a/rspirv/sr/autogen_types.rs
+++ b/rspirv/sr/autogen_types.rs
@@ -50,7 +50,7 @@ pub enum Type {
     },
     Pointer {
         storage_class: spirv::StorageClass,
-        ty: spirv::Word,
+        ty: Token<Type>,
     },
     Function {
         return_type: Token<Type>,


### PR DESCRIPTION
As reported in #131 Pointer should have it's `ty:` member be a `Token<Type>`. 