### PR TITLE
Remove new_function and new_block

### DIFF
--- a/rspirv/dr/loader.rs
+++ b/rspirv/dr/loader.rs
@@ -25,6 +25,7 @@ pub enum Error {
     WrongOpMemoryModelOperand,
     WrongOpNameOperand,
     FunctionNotFound,
+    BlockNotFound,
 }
 
 impl Error {
@@ -58,6 +59,7 @@ impl Error {
             Error::WrongOpMemoryModelOperand => Cow::Borrowed("wrong OpMemoryModel operand"),
             Error::WrongOpNameOperand => Cow::Borrowed("wrong OpName operand"),
             Error::FunctionNotFound => Cow::Borrowed("can't find the function"),
+            Error::BlockNotFound => Cow::Borrowed("can't find the block"),
         }
     }
 }


### PR DESCRIPTION
Having both new_x and selected_x is overly complex and bug-prone (there indeed were already bugs in the undef and variable methods), so remove the less flexible of the two (new_x) and just keep selected_x.

Also generally clean some stuff up, converting some `.is_some()` followed by `.unwrap()` into matches, etc.

There _are_ two breaking changes here: `select_function` and `select_block` now take `Option<usize>` instead of `usize`, to allow deselecting. The first draft of this code had a separate `unselect_function`/`block` method, without the breaking change, let me know if you'd like me to revert to that - but I think the breaking change is way cleaner.

(Also exposed `selected_function`/`block` as public, since otherwise the `select` function is much less valuable)