### PR TITLE
Handle duplicate names to be able to handle OpCopyMemory{,Sized}

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,7 +263,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rspirv"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clippy 0.0.302 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -290,7 +290,7 @@ name = "rspirv-dis"
 version = "0.1.0"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rspirv 0.6.0",
+ "rspirv 0.7.0",
 ]
 
 [[package]]

--- a/autogen/dr.rs
+++ b/autogen/dr.rs
@@ -33,8 +33,9 @@ fn get_param_list(
     let mut type_generics = TokenStream::new();
     let mut list: Vec<_> = params
         .iter()
-        .filter_map(|param| {
-            let name = get_param_name(param);
+        .enumerate()
+        .filter_map(|(param_index, param)| {
+            let name = get_param_name(params, param_index);
             let kind = get_enum_underlying_type(&param.kind, true);
             if param.kind == "IdResult" {
                 if keep_result_id {
@@ -94,13 +95,14 @@ fn get_function_name_with_prepend(prepend: &str, opname: &str) -> TokenStream {
 fn get_init_list(params: &[structs::Operand]) -> Vec<TokenStream> {
     params
         .iter()
-        .filter_map(|param| {
+        .enumerate()
+        .filter_map(|(param_index, param)| {
             if param.quantifier == structs::Quantifier::One {
                 if param.kind == "IdResult" || param.kind == "IdResultType" {
                     // These two operands are not stored in the operands field.
                     None
                 } else {
-                    let name = get_param_name(param);
+                    let name = get_param_name(params, param_index);
                     let kind = get_dr_operand_kind(&param.kind);
                     Some(if kind == "LiteralString" {
                         quote! { dr::Operand::LiteralString(#name.into()) }
@@ -122,8 +124,9 @@ fn get_push_extras(
 ) -> Vec<TokenStream> {
     let mut list: Vec<_> = params
         .iter()
-        .filter_map(|param| {
-            let name = get_param_name(param);
+        .enumerate()
+        .filter_map(|(param_index, param)| {
+            let name = get_param_name(params, param_index);
             match param.quantifier {
                 structs::Quantifier::One => None,
                 structs::Quantifier::ZeroOrOne => {
@@ -417,8 +420,6 @@ pub fn gen_dr_builder_normal_insts(grammar: &structs::Grammar) -> TokenStream {
             inst.opname == "OpTypeOpaque" ||
             inst.opname == "OpUndef" ||
             inst.opname == "OpVariable" ||
-            inst.opname == "OpCopyMemory" ||
-            inst.opname == "OpCopyMemorySized" ||
             inst.opname.starts_with("OpType");
         !skip
     }).map(|inst| {

--- a/rspirv/dr/build/autogen_norm_insts.rs
+++ b/rspirv/dr/build/autogen_norm_insts.rs
@@ -208,6 +208,130 @@ impl Builder {
         self.insert_into_block(insert_point, inst)?;
         Ok(())
     }
+    #[doc = "Appends an OpCopyMemory instruction to the current block."]
+    pub fn copy_memory<T: IntoIterator<Item = dr::Operand>>(
+        &mut self,
+        target: spirv::Word,
+        source: spirv::Word,
+        memory_access: Option<spirv::MemoryAccess>,
+        memory_access_2: Option<spirv::MemoryAccess>,
+        additional_params: T,
+    ) -> BuildResult<()> {
+        #[allow(unused_mut)]
+        let mut inst = dr::Instruction::new(
+            spirv::Op::CopyMemory,
+            None,
+            None,
+            vec![dr::Operand::IdRef(target), dr::Operand::IdRef(source)],
+        );
+        if let Some(v) = memory_access {
+            #[allow(clippy::identity_conversion)]
+            inst.operands.push(dr::Operand::MemoryAccess(v.into()));
+        }
+        if let Some(v) = memory_access_2 {
+            #[allow(clippy::identity_conversion)]
+            inst.operands.push(dr::Operand::MemoryAccess(v.into()));
+        }
+        inst.operands.extend(additional_params);
+        self.insert_into_block(InsertPoint::End, inst)?;
+        Ok(())
+    }
+    #[doc = "Appends an OpCopyMemory instruction to the current block."]
+    pub fn insert_copy_memory<T: IntoIterator<Item = dr::Operand>>(
+        &mut self,
+        insert_point: InsertPoint,
+        target: spirv::Word,
+        source: spirv::Word,
+        memory_access: Option<spirv::MemoryAccess>,
+        memory_access_2: Option<spirv::MemoryAccess>,
+        additional_params: T,
+    ) -> BuildResult<()> {
+        #[allow(unused_mut)]
+        let mut inst = dr::Instruction::new(
+            spirv::Op::CopyMemory,
+            None,
+            None,
+            vec![dr::Operand::IdRef(target), dr::Operand::IdRef(source)],
+        );
+        if let Some(v) = memory_access {
+            #[allow(clippy::identity_conversion)]
+            inst.operands.push(dr::Operand::MemoryAccess(v.into()));
+        }
+        if let Some(v) = memory_access_2 {
+            #[allow(clippy::identity_conversion)]
+            inst.operands.push(dr::Operand::MemoryAccess(v.into()));
+        }
+        inst.operands.extend(additional_params);
+        self.insert_into_block(insert_point, inst)?;
+        Ok(())
+    }
+    #[doc = "Appends an OpCopyMemorySized instruction to the current block."]
+    pub fn copy_memory_sized<T: IntoIterator<Item = dr::Operand>>(
+        &mut self,
+        target: spirv::Word,
+        source: spirv::Word,
+        size: spirv::Word,
+        memory_access: Option<spirv::MemoryAccess>,
+        memory_access_2: Option<spirv::MemoryAccess>,
+        additional_params: T,
+    ) -> BuildResult<()> {
+        #[allow(unused_mut)]
+        let mut inst = dr::Instruction::new(
+            spirv::Op::CopyMemorySized,
+            None,
+            None,
+            vec![
+                dr::Operand::IdRef(target),
+                dr::Operand::IdRef(source),
+                dr::Operand::IdRef(size),
+            ],
+        );
+        if let Some(v) = memory_access {
+            #[allow(clippy::identity_conversion)]
+            inst.operands.push(dr::Operand::MemoryAccess(v.into()));
+        }
+        if let Some(v) = memory_access_2 {
+            #[allow(clippy::identity_conversion)]
+            inst.operands.push(dr::Operand::MemoryAccess(v.into()));
+        }
+        inst.operands.extend(additional_params);
+        self.insert_into_block(InsertPoint::End, inst)?;
+        Ok(())
+    }
+    #[doc = "Appends an OpCopyMemorySized instruction to the current block."]
+    pub fn insert_copy_memory_sized<T: IntoIterator<Item = dr::Operand>>(
+        &mut self,
+        insert_point: InsertPoint,
+        target: spirv::Word,
+        source: spirv::Word,
+        size: spirv::Word,
+        memory_access: Option<spirv::MemoryAccess>,
+        memory_access_2: Option<spirv::MemoryAccess>,
+        additional_params: T,
+    ) -> BuildResult<()> {
+        #[allow(unused_mut)]
+        let mut inst = dr::Instruction::new(
+            spirv::Op::CopyMemorySized,
+            None,
+            None,
+            vec![
+                dr::Operand::IdRef(target),
+                dr::Operand::IdRef(source),
+                dr::Operand::IdRef(size),
+            ],
+        );
+        if let Some(v) = memory_access {
+            #[allow(clippy::identity_conversion)]
+            inst.operands.push(dr::Operand::MemoryAccess(v.into()));
+        }
+        if let Some(v) = memory_access_2 {
+            #[allow(clippy::identity_conversion)]
+            inst.operands.push(dr::Operand::MemoryAccess(v.into()));
+        }
+        inst.operands.extend(additional_params);
+        self.insert_into_block(insert_point, inst)?;
+        Ok(())
+    }
     #[doc = "Appends an OpAccessChain instruction to the current block."]
     pub fn access_chain<T: IntoIterator<Item = spirv::Word>>(
         &mut self,

--- a/rspirv/dr/build/autogen_norm_insts.rs
+++ b/rspirv/dr/build/autogen_norm_insts.rs
@@ -19,7 +19,7 @@ impl Builder {
         Ok(())
     }
     #[doc = "Appends an OpFunctionCall instruction to the current block."]
-    pub fn function_call<T: AsRef<[spirv::Word]>>(
+    pub fn function_call<T: IntoIterator<Item = spirv::Word>>(
         &mut self,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
@@ -34,18 +34,13 @@ impl Builder {
             Some(_id),
             vec![dr::Operand::IdRef(function)],
         );
-        inst.operands.extend(
-            argument_0_argument_1
-                .as_ref()
-                .iter()
-                .cloned()
-                .map(dr::Operand::IdRef),
-        );
+        inst.operands
+            .extend(argument_0_argument_1.into_iter().map(dr::Operand::IdRef));
         self.insert_into_block(InsertPoint::End, inst)?;
         Ok(_id)
     }
     #[doc = "Appends an OpFunctionCall instruction to the current block."]
-    pub fn insert_function_call<T: AsRef<[spirv::Word]>>(
+    pub fn insert_function_call<T: IntoIterator<Item = spirv::Word>>(
         &mut self,
         insert_point: InsertPoint,
         result_type: spirv::Word,
@@ -61,13 +56,8 @@ impl Builder {
             Some(_id),
             vec![dr::Operand::IdRef(function)],
         );
-        inst.operands.extend(
-            argument_0_argument_1
-                .as_ref()
-                .iter()
-                .cloned()
-                .map(dr::Operand::IdRef),
-        );
+        inst.operands
+            .extend(argument_0_argument_1.into_iter().map(dr::Operand::IdRef));
         self.insert_into_block(insert_point, inst)?;
         Ok(_id)
     }

--- a/rspirv/lift/autogen_context.rs
+++ b/rspirv/lift/autogen_context.rs
@@ -346,6 +346,60 @@ impl LiftContext {
                     None => None,
                 },
             }),
+            63u32 => Ok(ops::Op::CopyMemory {
+                target: (match operands.next() {
+                    Some(&dr::Operand::IdRef(ref value)) => Some(*value),
+                    Some(_) => Err(OperandError::WrongType)?,
+                    None => None,
+                })
+                .ok_or(OperandError::Missing)?,
+                source: (match operands.next() {
+                    Some(&dr::Operand::IdRef(ref value)) => Some(*value),
+                    Some(_) => Err(OperandError::WrongType)?,
+                    None => None,
+                })
+                .ok_or(OperandError::Missing)?,
+                memory_access: match operands.next() {
+                    Some(&dr::Operand::MemoryAccess(ref value)) => Some(*value),
+                    Some(_) => Err(OperandError::WrongType)?,
+                    None => None,
+                },
+                memory_access_2: match operands.next() {
+                    Some(&dr::Operand::MemoryAccess(ref value)) => Some(*value),
+                    Some(_) => Err(OperandError::WrongType)?,
+                    None => None,
+                },
+            }),
+            64u32 => Ok(ops::Op::CopyMemorySized {
+                target: (match operands.next() {
+                    Some(&dr::Operand::IdRef(ref value)) => Some(*value),
+                    Some(_) => Err(OperandError::WrongType)?,
+                    None => None,
+                })
+                .ok_or(OperandError::Missing)?,
+                source: (match operands.next() {
+                    Some(&dr::Operand::IdRef(ref value)) => Some(*value),
+                    Some(_) => Err(OperandError::WrongType)?,
+                    None => None,
+                })
+                .ok_or(OperandError::Missing)?,
+                size: (match operands.next() {
+                    Some(&dr::Operand::IdRef(ref value)) => Some(*value),
+                    Some(_) => Err(OperandError::WrongType)?,
+                    None => None,
+                })
+                .ok_or(OperandError::Missing)?,
+                memory_access: match operands.next() {
+                    Some(&dr::Operand::MemoryAccess(ref value)) => Some(*value),
+                    Some(_) => Err(OperandError::WrongType)?,
+                    None => None,
+                },
+                memory_access_2: match operands.next() {
+                    Some(&dr::Operand::MemoryAccess(ref value)) => Some(*value),
+                    Some(_) => Err(OperandError::WrongType)?,
+                    None => None,
+                },
+            }),
             65u32 => Ok(ops::Op::AccessChain {
                 base: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),

--- a/rspirv/sr/autogen_ops.rs
+++ b/rspirv/sr/autogen_ops.rs
@@ -102,6 +102,19 @@ pub enum Op {
         object: spirv::Word,
         memory_access: Option<spirv::MemoryAccess>,
     },
+    CopyMemory {
+        target: spirv::Word,
+        source: spirv::Word,
+        memory_access: Option<spirv::MemoryAccess>,
+        memory_access_2: Option<spirv::MemoryAccess>,
+    },
+    CopyMemorySized {
+        target: spirv::Word,
+        source: spirv::Word,
+        size: spirv::Word,
+        memory_access: Option<spirv::MemoryAccess>,
+        memory_access_2: Option<spirv::MemoryAccess>,
+    },
     AccessChain {
         base: spirv::Word,
         indexes: Vec<spirv::Word>,


### PR DESCRIPTION
The tree is dirty if you checkout master and run `cargo build`, so the first commit fixes that.