### PR TITLE
Fix typo in type_struct_id

### DIFF
--- a/rspirv/dr/build/mod.rs
+++ b/rspirv/dr/build/mod.rs
@@ -667,7 +667,7 @@ impl Builder {
         let mut inst = dr::Instruction::new(
             spirv::Op::TypeStruct,
             None,
-            None,
+            result_id,
             member_0_type_member_1_type
                 .into_iter()
                 .map(dr::Operand::IdRef)


### PR DESCRIPTION
Problem was introduced in https://github.com/gfx-rs/rspirv/pull/156 when copying the `type_pointer` method and missing this.