### PR TITLE
Add support for parsing 8 and 16 bit OpConstants

### DIFF
--- a/rspirv/binary/parser.rs
+++ b/rspirv/binary/parser.rs
@@ -293,7 +293,7 @@ impl<'c, 'd> Parser<'c, 'd> {
             }
             if let Some(grammar) = GInstTable::lookup_opcode(opcode) {
                 self.decoder.set_limit((wc - 1) as usize);
-                let result = self.parse_operands(grammar);
+                let result = self.parse_operands(grammar)?;
                 if !self.decoder.limit_reached() {
                     return Err(State::OperandExceeded(
                         self.decoder.offset(),
@@ -301,7 +301,7 @@ impl<'c, 'd> Parser<'c, 'd> {
                     ));
                 }
                 self.decoder.clear_limit();
-                result
+                Ok(result)
             } else {
                 Err(State::OpcodeUnknown(
                     self.decoder.offset() - WORD_NUM_BYTES,

--- a/rspirv/binary/parser.rs
+++ b/rspirv/binary/parser.rs
@@ -319,6 +319,9 @@ impl<'c, 'd> Parser<'c, 'd> {
         match tracked_type {
             Some(t) => match t {
                 Type::Integer(size, _) => match size {
+                    // "Value is the bit pattern for the constant. Types 32 bits wide or smaller take one word."
+                    8 => Ok(dr::Operand::LiteralInt32(self.decoder.int32()?)),
+                    16 => Ok(dr::Operand::LiteralInt32(self.decoder.int32()?)),
                     32 => Ok(dr::Operand::LiteralInt32(self.decoder.int32()?)),
                     64 => Ok(dr::Operand::LiteralInt64(self.decoder.int64()?)),
                     _ => Err(State::TypeUnsupported(


### PR DESCRIPTION
Also fail when the type is unknown, instead of failing at limit_reached and obscuring the actual error.