### PR TITLE
binary: parser: Make ConsumerError contain dyn Error + Send

### DIFF
--- a/rspirv/binary/parser.rs
+++ b/rspirv/binary/parser.rs
@@ -30,7 +30,7 @@ pub enum State {
     /// Consumer requested to stop parse
     ConsumerStopRequested,
     /// Consumer errored out with the given error
-    ConsumerError(Box<dyn error::Error>),
+    ConsumerError(Box<dyn error::Error + Send>),
     /// Incomplete module header
     HeaderIncomplete(DecodeError),
     /// Incorrect module header
@@ -117,7 +117,7 @@ pub enum Action {
     /// Normally stop the parsing
     Stop,
     /// Error out with the given error
-    Error(Box<dyn error::Error>),
+    Error(Box<dyn error::Error + Send>),
 }
 
 impl Action {


### PR DESCRIPTION
In one of our projects we propagate errors out of a thread using `thiserror` to nest them recursively. The enum `State` ends up in that error type too, hence needs to be Send. Fortunately only `StringError` seems to be stored in this field currently.