### PR TITLE
impl trait is cooler than generics, use it

### DIFF
--- a/autogen/build.rs
+++ b/autogen/build.rs
@@ -16,13 +16,13 @@ use std::{
 };
 use utils::write_autogen_comment;
 
-fn write<T: ToString>(path: &PathBuf, contents: T) {
+fn write(path: &PathBuf, contents: impl ToString) {
     let mut f = fs::File::create(path).expect(&format!("cannot open file: {:?}", path));
     write_autogen_comment(&mut f);
     write!(f, "{}", contents.to_string()).unwrap()
 }
 
-fn write_formatted<T: ToString>(path: &PathBuf, contents: T) {
+fn write_formatted(path: &PathBuf, contents: impl ToString) {
     write(path, contents);
     match process::Command::new("rustfmt").arg(path).status() {
         Ok(status) if !status.success() => {

--- a/autogen/utils.rs
+++ b/autogen/utils.rs
@@ -49,7 +49,7 @@ pub fn get_enum_underlying_type(kind: &str, generic_string: bool) -> TokenStream
         panic!("this kind is not expected to be handled here")
     } else if kind == "LiteralString" {
         if generic_string {
-            quote! { T }
+            quote! { impl Into<String> }
         } else {
             quote! { String }
         }

--- a/rspirv/binary/disassemble.rs
+++ b/rspirv/binary/disassemble.rs
@@ -43,7 +43,7 @@ impl Disassemble for dr::Operand {
 
 /// Disassembles each instruction in `insts` and joins them together
 /// with the given `delimiter`.
-fn disas_join<T: Disassemble>(insts: &[T], delimiter: &str) -> String {
+fn disas_join(insts: &[impl Disassemble], delimiter: &str) -> String {
     insts
         .iter()
         .map(|i| i.disassemble())
@@ -255,7 +255,7 @@ mod tests {
         b.extension("awesome-extension");
         b.ext_inst_import("GLSL.std.450");
         b.memory_model(spirv::AddressingModel::Logical, spirv::MemoryModel::Simple);
-        b.source::<String>(spirv::SourceLanguage::GLSL, 450, None, None);
+        b.source(spirv::SourceLanguage::GLSL, 450, None, None::<String>);
 
         let void = b.type_void();
         let float32 = b.type_float(32);

--- a/rspirv/binary/parser.rs
+++ b/rspirv/binary/parser.rs
@@ -155,13 +155,13 @@ pub trait Consumer {
 
 /// Parses the given `binary` and consumes the module using the given
 /// `consumer`.
-pub fn parse_bytes<T: AsRef<[u8]>>(binary: T, consumer: &mut dyn Consumer) -> Result<()> {
+pub fn parse_bytes(binary: impl AsRef<[u8]>, consumer: &mut dyn Consumer) -> Result<()> {
     Parser::new(binary.as_ref(), consumer).parse()
 }
 
 /// Parses the given `binary` and consumes the module using the given
 /// `consumer`.
-pub fn parse_words<T: AsRef<[u32]>>(binary: T, consumer: &mut dyn Consumer) -> Result<()> {
+pub fn parse_words(binary: impl AsRef<[u32]>, consumer: &mut dyn Consumer) -> Result<()> {
     let len = binary.as_ref().len() * 4;
     let buf = unsafe { slice::from_raw_parts(binary.as_ref().as_ptr() as *const u8, len) };
     Parser::new(buf, consumer).parse()

--- a/rspirv/dr/build/autogen_annotation.rs
+++ b/rspirv/dr/build/autogen_annotation.rs
@@ -4,11 +4,11 @@
 
 impl Builder {
     #[doc = "Appends an OpDecorate instruction."]
-    pub fn decorate<T: IntoIterator<Item = dr::Operand>>(
+    pub fn decorate(
         &mut self,
         target: spirv::Word,
         decoration: spirv::Decoration,
-        additional_params: T,
+        additional_params: impl IntoIterator<Item = dr::Operand>,
     ) {
         #[allow(unused_mut)]
         let mut inst = dr::Instruction::new(
@@ -24,12 +24,12 @@ impl Builder {
         self.module.annotations.push(inst);
     }
     #[doc = "Appends an OpMemberDecorate instruction."]
-    pub fn member_decorate<T: IntoIterator<Item = dr::Operand>>(
+    pub fn member_decorate(
         &mut self,
         structure_type: spirv::Word,
         member: u32,
         decoration: spirv::Decoration,
-        additional_params: T,
+        additional_params: impl IntoIterator<Item = dr::Operand>,
     ) {
         #[allow(unused_mut)]
         let mut inst = dr::Instruction::new(
@@ -46,10 +46,10 @@ impl Builder {
         self.module.annotations.push(inst);
     }
     #[doc = "Appends an OpGroupDecorate instruction."]
-    pub fn group_decorate<T: IntoIterator<Item = spirv::Word>>(
+    pub fn group_decorate(
         &mut self,
         decoration_group: spirv::Word,
-        targets: T,
+        targets: impl IntoIterator<Item = spirv::Word>,
     ) {
         #[allow(unused_mut)]
         let mut inst = dr::Instruction::new(
@@ -63,10 +63,10 @@ impl Builder {
         self.module.annotations.push(inst);
     }
     #[doc = "Appends an OpGroupMemberDecorate instruction."]
-    pub fn group_member_decorate<T: IntoIterator<Item = (spirv::Word, u32)>>(
+    pub fn group_member_decorate(
         &mut self,
         decoration_group: spirv::Word,
-        targets: T,
+        targets: impl IntoIterator<Item = (spirv::Word, u32)>,
     ) {
         #[allow(unused_mut)]
         let mut inst = dr::Instruction::new(
@@ -82,11 +82,11 @@ impl Builder {
         self.module.annotations.push(inst);
     }
     #[doc = "Appends an OpDecorateId instruction."]
-    pub fn decorate_id<T: IntoIterator<Item = dr::Operand>>(
+    pub fn decorate_id(
         &mut self,
         target: spirv::Word,
         decoration: spirv::Decoration,
-        additional_params: T,
+        additional_params: impl IntoIterator<Item = dr::Operand>,
     ) {
         #[allow(unused_mut)]
         let mut inst = dr::Instruction::new(
@@ -102,11 +102,11 @@ impl Builder {
         self.module.annotations.push(inst);
     }
     #[doc = "Appends an OpDecorateString instruction."]
-    pub fn decorate_string<T: IntoIterator<Item = dr::Operand>>(
+    pub fn decorate_string(
         &mut self,
         target: spirv::Word,
         decoration: spirv::Decoration,
-        additional_params: T,
+        additional_params: impl IntoIterator<Item = dr::Operand>,
     ) {
         #[allow(unused_mut)]
         let mut inst = dr::Instruction::new(
@@ -122,11 +122,11 @@ impl Builder {
         self.module.annotations.push(inst);
     }
     #[doc = "Appends an OpDecorateStringGOOGLE instruction."]
-    pub fn decorate_string_google<T: IntoIterator<Item = dr::Operand>>(
+    pub fn decorate_string_google(
         &mut self,
         target: spirv::Word,
         decoration: spirv::Decoration,
-        additional_params: T,
+        additional_params: impl IntoIterator<Item = dr::Operand>,
     ) {
         #[allow(unused_mut)]
         let mut inst = dr::Instruction::new(
@@ -142,12 +142,12 @@ impl Builder {
         self.module.annotations.push(inst);
     }
     #[doc = "Appends an OpMemberDecorateString instruction."]
-    pub fn member_decorate_string<T: IntoIterator<Item = dr::Operand>>(
+    pub fn member_decorate_string(
         &mut self,
         struct_type: spirv::Word,
         member: u32,
         decoration: spirv::Decoration,
-        additional_params: T,
+        additional_params: impl IntoIterator<Item = dr::Operand>,
     ) {
         #[allow(unused_mut)]
         let mut inst = dr::Instruction::new(
@@ -164,12 +164,12 @@ impl Builder {
         self.module.annotations.push(inst);
     }
     #[doc = "Appends an OpMemberDecorateStringGOOGLE instruction."]
-    pub fn member_decorate_string_google<T: IntoIterator<Item = dr::Operand>>(
+    pub fn member_decorate_string_google(
         &mut self,
         struct_type: spirv::Word,
         member: u32,
         decoration: spirv::Decoration,
-        additional_params: T,
+        additional_params: impl IntoIterator<Item = dr::Operand>,
     ) {
         #[allow(unused_mut)]
         let mut inst = dr::Instruction::new(

--- a/rspirv/dr/build/autogen_constant.rs
+++ b/rspirv/dr/build/autogen_constant.rs
@@ -26,10 +26,10 @@ impl Builder {
         id
     }
     #[doc = "Appends an OpConstantComposite instruction."]
-    pub fn constant_composite<T: IntoIterator<Item = spirv::Word>>(
+    pub fn constant_composite(
         &mut self,
         result_type: spirv::Word,
-        constituents: T,
+        constituents: impl IntoIterator<Item = spirv::Word>,
     ) -> spirv::Word {
         let id = self.id();
         #[allow(unused_mut)]
@@ -103,10 +103,10 @@ impl Builder {
         id
     }
     #[doc = "Appends an OpSpecConstantComposite instruction."]
-    pub fn spec_constant_composite<T: IntoIterator<Item = spirv::Word>>(
+    pub fn spec_constant_composite(
         &mut self,
         result_type: spirv::Word,
-        constituents: T,
+        constituents: impl IntoIterator<Item = spirv::Word>,
     ) -> spirv::Word {
         let id = self.id();
         #[allow(unused_mut)]

--- a/rspirv/dr/build/autogen_debug.rs
+++ b/rspirv/dr/build/autogen_debug.rs
@@ -4,7 +4,7 @@
 
 impl Builder {
     #[doc = "Appends an OpSourceContinued instruction."]
-    pub fn source_continued<T: Into<String>>(&mut self, continued_source: T) {
+    pub fn source_continued(&mut self, continued_source: impl Into<String>) {
         #[allow(unused_mut)]
         let mut inst = dr::Instruction::new(
             spirv::Op::SourceContinued,
@@ -15,12 +15,12 @@ impl Builder {
         self.module.debugs.push(inst);
     }
     #[doc = "Appends an OpSource instruction."]
-    pub fn source<T: Into<String>>(
+    pub fn source(
         &mut self,
         source_language: spirv::SourceLanguage,
         version: u32,
         file: Option<spirv::Word>,
-        source: Option<T>,
+        source: Option<impl Into<String>>,
     ) {
         #[allow(unused_mut)]
         let mut inst = dr::Instruction::new(
@@ -43,7 +43,7 @@ impl Builder {
         self.module.debugs.push(inst);
     }
     #[doc = "Appends an OpSourceExtension instruction."]
-    pub fn source_extension<T: Into<String>>(&mut self, extension: T) {
+    pub fn source_extension(&mut self, extension: impl Into<String>) {
         #[allow(unused_mut)]
         let mut inst = dr::Instruction::new(
             spirv::Op::SourceExtension,
@@ -54,7 +54,7 @@ impl Builder {
         self.module.debugs.push(inst);
     }
     #[doc = "Appends an OpName instruction."]
-    pub fn name<T: Into<String>>(&mut self, target: spirv::Word, name: T) {
+    pub fn name(&mut self, target: spirv::Word, name: impl Into<String>) {
         #[allow(unused_mut)]
         let mut inst = dr::Instruction::new(
             spirv::Op::Name,
@@ -68,7 +68,7 @@ impl Builder {
         self.module.debugs.push(inst);
     }
     #[doc = "Appends an OpMemberName instruction."]
-    pub fn member_name<T: Into<String>>(&mut self, ty: spirv::Word, member: u32, name: T) {
+    pub fn member_name(&mut self, ty: spirv::Word, member: u32, name: impl Into<String>) {
         #[allow(unused_mut)]
         let mut inst = dr::Instruction::new(
             spirv::Op::MemberName,
@@ -83,7 +83,7 @@ impl Builder {
         self.module.debugs.push(inst);
     }
     #[doc = "Appends an OpLine instruction."]
-    pub fn line<T: Into<String>>(&mut self, file: spirv::Word, line: u32, column: u32) {
+    pub fn line(&mut self, file: spirv::Word, line: u32, column: u32) {
         #[allow(unused_mut)]
         let mut inst = dr::Instruction::new(
             spirv::Op::Line,
@@ -98,13 +98,13 @@ impl Builder {
         self.module.debugs.push(inst);
     }
     #[doc = "Appends an OpNoLine instruction."]
-    pub fn no_line<T: Into<String>>(&mut self) {
+    pub fn no_line(&mut self) {
         #[allow(unused_mut)]
         let mut inst = dr::Instruction::new(spirv::Op::NoLine, None, None, vec![]);
         self.module.debugs.push(inst);
     }
     #[doc = "Appends an OpModuleProcessed instruction."]
-    pub fn module_processed<T: Into<String>>(&mut self, process: T) {
+    pub fn module_processed(&mut self, process: impl Into<String>) {
         #[allow(unused_mut)]
         let mut inst = dr::Instruction::new(
             spirv::Op::ModuleProcessed,

--- a/rspirv/dr/build/autogen_norm_insts.rs
+++ b/rspirv/dr/build/autogen_norm_insts.rs
@@ -19,12 +19,12 @@ impl Builder {
         Ok(())
     }
     #[doc = "Appends an OpFunctionCall instruction to the current block."]
-    pub fn function_call<T: IntoIterator<Item = spirv::Word>>(
+    pub fn function_call(
         &mut self,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
         function: spirv::Word,
-        argument_0_argument_1: T,
+        argument_0_argument_1: impl IntoIterator<Item = spirv::Word>,
     ) -> BuildResult<spirv::Word> {
         let _id = result_id.unwrap_or_else(|| self.id());
         #[allow(unused_mut)]
@@ -40,13 +40,13 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpFunctionCall instruction to the current block."]
-    pub fn insert_function_call<T: IntoIterator<Item = spirv::Word>>(
+    pub fn insert_function_call(
         &mut self,
         insert_point: InsertPoint,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
         function: spirv::Word,
-        argument_0_argument_1: T,
+        argument_0_argument_1: impl IntoIterator<Item = spirv::Word>,
     ) -> BuildResult<spirv::Word> {
         let _id = result_id.unwrap_or_else(|| self.id());
         #[allow(unused_mut)]
@@ -111,13 +111,13 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpLoad instruction to the current block."]
-    pub fn load<T: IntoIterator<Item = dr::Operand>>(
+    pub fn load(
         &mut self,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
         pointer: spirv::Word,
         memory_access: Option<spirv::MemoryAccess>,
-        additional_params: T,
+        additional_params: impl IntoIterator<Item = dr::Operand>,
     ) -> BuildResult<spirv::Word> {
         let _id = result_id.unwrap_or_else(|| self.id());
         #[allow(unused_mut)]
@@ -136,14 +136,14 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpLoad instruction to the current block."]
-    pub fn insert_load<T: IntoIterator<Item = dr::Operand>>(
+    pub fn insert_load(
         &mut self,
         insert_point: InsertPoint,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
         pointer: spirv::Word,
         memory_access: Option<spirv::MemoryAccess>,
-        additional_params: T,
+        additional_params: impl IntoIterator<Item = dr::Operand>,
     ) -> BuildResult<spirv::Word> {
         let _id = result_id.unwrap_or_else(|| self.id());
         #[allow(unused_mut)]
@@ -162,12 +162,12 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpStore instruction to the current block."]
-    pub fn store<T: IntoIterator<Item = dr::Operand>>(
+    pub fn store(
         &mut self,
         pointer: spirv::Word,
         object: spirv::Word,
         memory_access: Option<spirv::MemoryAccess>,
-        additional_params: T,
+        additional_params: impl IntoIterator<Item = dr::Operand>,
     ) -> BuildResult<()> {
         #[allow(unused_mut)]
         let mut inst = dr::Instruction::new(
@@ -185,13 +185,13 @@ impl Builder {
         Ok(())
     }
     #[doc = "Appends an OpStore instruction to the current block."]
-    pub fn insert_store<T: IntoIterator<Item = dr::Operand>>(
+    pub fn insert_store(
         &mut self,
         insert_point: InsertPoint,
         pointer: spirv::Word,
         object: spirv::Word,
         memory_access: Option<spirv::MemoryAccess>,
-        additional_params: T,
+        additional_params: impl IntoIterator<Item = dr::Operand>,
     ) -> BuildResult<()> {
         #[allow(unused_mut)]
         let mut inst = dr::Instruction::new(
@@ -209,13 +209,13 @@ impl Builder {
         Ok(())
     }
     #[doc = "Appends an OpCopyMemory instruction to the current block."]
-    pub fn copy_memory<T: IntoIterator<Item = dr::Operand>>(
+    pub fn copy_memory(
         &mut self,
         target: spirv::Word,
         source: spirv::Word,
         memory_access: Option<spirv::MemoryAccess>,
         memory_access_2: Option<spirv::MemoryAccess>,
-        additional_params: T,
+        additional_params: impl IntoIterator<Item = dr::Operand>,
     ) -> BuildResult<()> {
         #[allow(unused_mut)]
         let mut inst = dr::Instruction::new(
@@ -237,14 +237,14 @@ impl Builder {
         Ok(())
     }
     #[doc = "Appends an OpCopyMemory instruction to the current block."]
-    pub fn insert_copy_memory<T: IntoIterator<Item = dr::Operand>>(
+    pub fn insert_copy_memory(
         &mut self,
         insert_point: InsertPoint,
         target: spirv::Word,
         source: spirv::Word,
         memory_access: Option<spirv::MemoryAccess>,
         memory_access_2: Option<spirv::MemoryAccess>,
-        additional_params: T,
+        additional_params: impl IntoIterator<Item = dr::Operand>,
     ) -> BuildResult<()> {
         #[allow(unused_mut)]
         let mut inst = dr::Instruction::new(
@@ -266,14 +266,14 @@ impl Builder {
         Ok(())
     }
     #[doc = "Appends an OpCopyMemorySized instruction to the current block."]
-    pub fn copy_memory_sized<T: IntoIterator<Item = dr::Operand>>(
+    pub fn copy_memory_sized(
         &mut self,
         target: spirv::Word,
         source: spirv::Word,
         size: spirv::Word,
         memory_access: Option<spirv::MemoryAccess>,
         memory_access_2: Option<spirv::MemoryAccess>,
-        additional_params: T,
+        additional_params: impl IntoIterator<Item = dr::Operand>,
     ) -> BuildResult<()> {
         #[allow(unused_mut)]
         let mut inst = dr::Instruction::new(
@@ -299,7 +299,7 @@ impl Builder {
         Ok(())
     }
     #[doc = "Appends an OpCopyMemorySized instruction to the current block."]
-    pub fn insert_copy_memory_sized<T: IntoIterator<Item = dr::Operand>>(
+    pub fn insert_copy_memory_sized(
         &mut self,
         insert_point: InsertPoint,
         target: spirv::Word,
@@ -307,7 +307,7 @@ impl Builder {
         size: spirv::Word,
         memory_access: Option<spirv::MemoryAccess>,
         memory_access_2: Option<spirv::MemoryAccess>,
-        additional_params: T,
+        additional_params: impl IntoIterator<Item = dr::Operand>,
     ) -> BuildResult<()> {
         #[allow(unused_mut)]
         let mut inst = dr::Instruction::new(
@@ -333,12 +333,12 @@ impl Builder {
         Ok(())
     }
     #[doc = "Appends an OpAccessChain instruction to the current block."]
-    pub fn access_chain<T: IntoIterator<Item = spirv::Word>>(
+    pub fn access_chain(
         &mut self,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
         base: spirv::Word,
-        indexes: T,
+        indexes: impl IntoIterator<Item = spirv::Word>,
     ) -> BuildResult<spirv::Word> {
         let _id = result_id.unwrap_or_else(|| self.id());
         #[allow(unused_mut)]
@@ -354,13 +354,13 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpAccessChain instruction to the current block."]
-    pub fn insert_access_chain<T: IntoIterator<Item = spirv::Word>>(
+    pub fn insert_access_chain(
         &mut self,
         insert_point: InsertPoint,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
         base: spirv::Word,
-        indexes: T,
+        indexes: impl IntoIterator<Item = spirv::Word>,
     ) -> BuildResult<spirv::Word> {
         let _id = result_id.unwrap_or_else(|| self.id());
         #[allow(unused_mut)]
@@ -376,12 +376,12 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpInBoundsAccessChain instruction to the current block."]
-    pub fn in_bounds_access_chain<T: IntoIterator<Item = spirv::Word>>(
+    pub fn in_bounds_access_chain(
         &mut self,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
         base: spirv::Word,
-        indexes: T,
+        indexes: impl IntoIterator<Item = spirv::Word>,
     ) -> BuildResult<spirv::Word> {
         let _id = result_id.unwrap_or_else(|| self.id());
         #[allow(unused_mut)]
@@ -397,13 +397,13 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpInBoundsAccessChain instruction to the current block."]
-    pub fn insert_in_bounds_access_chain<T: IntoIterator<Item = spirv::Word>>(
+    pub fn insert_in_bounds_access_chain(
         &mut self,
         insert_point: InsertPoint,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
         base: spirv::Word,
-        indexes: T,
+        indexes: impl IntoIterator<Item = spirv::Word>,
     ) -> BuildResult<spirv::Word> {
         let _id = result_id.unwrap_or_else(|| self.id());
         #[allow(unused_mut)]
@@ -419,13 +419,13 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpPtrAccessChain instruction to the current block."]
-    pub fn ptr_access_chain<T: IntoIterator<Item = spirv::Word>>(
+    pub fn ptr_access_chain(
         &mut self,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
         base: spirv::Word,
         element: spirv::Word,
-        indexes: T,
+        indexes: impl IntoIterator<Item = spirv::Word>,
     ) -> BuildResult<spirv::Word> {
         let _id = result_id.unwrap_or_else(|| self.id());
         #[allow(unused_mut)]
@@ -441,14 +441,14 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpPtrAccessChain instruction to the current block."]
-    pub fn insert_ptr_access_chain<T: IntoIterator<Item = spirv::Word>>(
+    pub fn insert_ptr_access_chain(
         &mut self,
         insert_point: InsertPoint,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
         base: spirv::Word,
         element: spirv::Word,
-        indexes: T,
+        indexes: impl IntoIterator<Item = spirv::Word>,
     ) -> BuildResult<spirv::Word> {
         let _id = result_id.unwrap_or_else(|| self.id());
         #[allow(unused_mut)]
@@ -546,13 +546,13 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpInBoundsPtrAccessChain instruction to the current block."]
-    pub fn in_bounds_ptr_access_chain<T: IntoIterator<Item = spirv::Word>>(
+    pub fn in_bounds_ptr_access_chain(
         &mut self,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
         base: spirv::Word,
         element: spirv::Word,
-        indexes: T,
+        indexes: impl IntoIterator<Item = spirv::Word>,
     ) -> BuildResult<spirv::Word> {
         let _id = result_id.unwrap_or_else(|| self.id());
         #[allow(unused_mut)]
@@ -568,14 +568,14 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpInBoundsPtrAccessChain instruction to the current block."]
-    pub fn insert_in_bounds_ptr_access_chain<T: IntoIterator<Item = spirv::Word>>(
+    pub fn insert_in_bounds_ptr_access_chain(
         &mut self,
         insert_point: InsertPoint,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
         base: spirv::Word,
         element: spirv::Word,
-        indexes: T,
+        indexes: impl IntoIterator<Item = spirv::Word>,
     ) -> BuildResult<spirv::Word> {
         let _id = result_id.unwrap_or_else(|| self.id());
         #[allow(unused_mut)]
@@ -679,13 +679,13 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpVectorShuffle instruction to the current block."]
-    pub fn vector_shuffle<T: IntoIterator<Item = u32>>(
+    pub fn vector_shuffle(
         &mut self,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
         vector_1: spirv::Word,
         vector_2: spirv::Word,
-        components: T,
+        components: impl IntoIterator<Item = u32>,
     ) -> BuildResult<spirv::Word> {
         let _id = result_id.unwrap_or_else(|| self.id());
         #[allow(unused_mut)]
@@ -701,14 +701,14 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpVectorShuffle instruction to the current block."]
-    pub fn insert_vector_shuffle<T: IntoIterator<Item = u32>>(
+    pub fn insert_vector_shuffle(
         &mut self,
         insert_point: InsertPoint,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
         vector_1: spirv::Word,
         vector_2: spirv::Word,
-        components: T,
+        components: impl IntoIterator<Item = u32>,
     ) -> BuildResult<spirv::Word> {
         let _id = result_id.unwrap_or_else(|| self.id());
         #[allow(unused_mut)]
@@ -724,11 +724,11 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpCompositeConstruct instruction to the current block."]
-    pub fn composite_construct<T: IntoIterator<Item = spirv::Word>>(
+    pub fn composite_construct(
         &mut self,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
-        constituents: T,
+        constituents: impl IntoIterator<Item = spirv::Word>,
     ) -> BuildResult<spirv::Word> {
         let _id = result_id.unwrap_or_else(|| self.id());
         #[allow(unused_mut)]
@@ -744,12 +744,12 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpCompositeConstruct instruction to the current block."]
-    pub fn insert_composite_construct<T: IntoIterator<Item = spirv::Word>>(
+    pub fn insert_composite_construct(
         &mut self,
         insert_point: InsertPoint,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
-        constituents: T,
+        constituents: impl IntoIterator<Item = spirv::Word>,
     ) -> BuildResult<spirv::Word> {
         let _id = result_id.unwrap_or_else(|| self.id());
         #[allow(unused_mut)]
@@ -765,12 +765,12 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpCompositeExtract instruction to the current block."]
-    pub fn composite_extract<T: IntoIterator<Item = u32>>(
+    pub fn composite_extract(
         &mut self,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
         composite: spirv::Word,
-        indexes: T,
+        indexes: impl IntoIterator<Item = u32>,
     ) -> BuildResult<spirv::Word> {
         let _id = result_id.unwrap_or_else(|| self.id());
         #[allow(unused_mut)]
@@ -786,13 +786,13 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpCompositeExtract instruction to the current block."]
-    pub fn insert_composite_extract<T: IntoIterator<Item = u32>>(
+    pub fn insert_composite_extract(
         &mut self,
         insert_point: InsertPoint,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
         composite: spirv::Word,
-        indexes: T,
+        indexes: impl IntoIterator<Item = u32>,
     ) -> BuildResult<spirv::Word> {
         let _id = result_id.unwrap_or_else(|| self.id());
         #[allow(unused_mut)]
@@ -808,13 +808,13 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpCompositeInsert instruction to the current block."]
-    pub fn composite_insert<T: IntoIterator<Item = u32>>(
+    pub fn composite_insert(
         &mut self,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
         object: spirv::Word,
         composite: spirv::Word,
-        indexes: T,
+        indexes: impl IntoIterator<Item = u32>,
     ) -> BuildResult<spirv::Word> {
         let _id = result_id.unwrap_or_else(|| self.id());
         #[allow(unused_mut)]
@@ -830,14 +830,14 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpCompositeInsert instruction to the current block."]
-    pub fn insert_composite_insert<T: IntoIterator<Item = u32>>(
+    pub fn insert_composite_insert(
         &mut self,
         insert_point: InsertPoint,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
         object: spirv::Word,
         composite: spirv::Word,
-        indexes: T,
+        indexes: impl IntoIterator<Item = u32>,
     ) -> BuildResult<spirv::Word> {
         let _id = result_id.unwrap_or_else(|| self.id());
         #[allow(unused_mut)]
@@ -966,14 +966,14 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpImageSampleImplicitLod instruction to the current block."]
-    pub fn image_sample_implicit_lod<T: IntoIterator<Item = dr::Operand>>(
+    pub fn image_sample_implicit_lod(
         &mut self,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
         sampled_image: spirv::Word,
         coordinate: spirv::Word,
         image_operands: Option<spirv::ImageOperands>,
-        additional_params: T,
+        additional_params: impl IntoIterator<Item = dr::Operand>,
     ) -> BuildResult<spirv::Word> {
         let _id = result_id.unwrap_or_else(|| self.id());
         #[allow(unused_mut)]
@@ -995,7 +995,7 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpImageSampleImplicitLod instruction to the current block."]
-    pub fn insert_image_sample_implicit_lod<T: IntoIterator<Item = dr::Operand>>(
+    pub fn insert_image_sample_implicit_lod(
         &mut self,
         insert_point: InsertPoint,
         result_type: spirv::Word,
@@ -1003,7 +1003,7 @@ impl Builder {
         sampled_image: spirv::Word,
         coordinate: spirv::Word,
         image_operands: Option<spirv::ImageOperands>,
-        additional_params: T,
+        additional_params: impl IntoIterator<Item = dr::Operand>,
     ) -> BuildResult<spirv::Word> {
         let _id = result_id.unwrap_or_else(|| self.id());
         #[allow(unused_mut)]
@@ -1025,14 +1025,14 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpImageSampleExplicitLod instruction to the current block."]
-    pub fn image_sample_explicit_lod<T: IntoIterator<Item = dr::Operand>>(
+    pub fn image_sample_explicit_lod(
         &mut self,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
         sampled_image: spirv::Word,
         coordinate: spirv::Word,
         image_operands: spirv::ImageOperands,
-        additional_params: T,
+        additional_params: impl IntoIterator<Item = dr::Operand>,
     ) -> BuildResult<spirv::Word> {
         let _id = result_id.unwrap_or_else(|| self.id());
         #[allow(unused_mut)]
@@ -1051,7 +1051,7 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpImageSampleExplicitLod instruction to the current block."]
-    pub fn insert_image_sample_explicit_lod<T: IntoIterator<Item = dr::Operand>>(
+    pub fn insert_image_sample_explicit_lod(
         &mut self,
         insert_point: InsertPoint,
         result_type: spirv::Word,
@@ -1059,7 +1059,7 @@ impl Builder {
         sampled_image: spirv::Word,
         coordinate: spirv::Word,
         image_operands: spirv::ImageOperands,
-        additional_params: T,
+        additional_params: impl IntoIterator<Item = dr::Operand>,
     ) -> BuildResult<spirv::Word> {
         let _id = result_id.unwrap_or_else(|| self.id());
         #[allow(unused_mut)]
@@ -1078,7 +1078,7 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpImageSampleDrefImplicitLod instruction to the current block."]
-    pub fn image_sample_dref_implicit_lod<T: IntoIterator<Item = dr::Operand>>(
+    pub fn image_sample_dref_implicit_lod(
         &mut self,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
@@ -1086,7 +1086,7 @@ impl Builder {
         coordinate: spirv::Word,
         d_ref: spirv::Word,
         image_operands: Option<spirv::ImageOperands>,
-        additional_params: T,
+        additional_params: impl IntoIterator<Item = dr::Operand>,
     ) -> BuildResult<spirv::Word> {
         let _id = result_id.unwrap_or_else(|| self.id());
         #[allow(unused_mut)]
@@ -1109,7 +1109,7 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpImageSampleDrefImplicitLod instruction to the current block."]
-    pub fn insert_image_sample_dref_implicit_lod<T: IntoIterator<Item = dr::Operand>>(
+    pub fn insert_image_sample_dref_implicit_lod(
         &mut self,
         insert_point: InsertPoint,
         result_type: spirv::Word,
@@ -1118,7 +1118,7 @@ impl Builder {
         coordinate: spirv::Word,
         d_ref: spirv::Word,
         image_operands: Option<spirv::ImageOperands>,
-        additional_params: T,
+        additional_params: impl IntoIterator<Item = dr::Operand>,
     ) -> BuildResult<spirv::Word> {
         let _id = result_id.unwrap_or_else(|| self.id());
         #[allow(unused_mut)]
@@ -1141,7 +1141,7 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpImageSampleDrefExplicitLod instruction to the current block."]
-    pub fn image_sample_dref_explicit_lod<T: IntoIterator<Item = dr::Operand>>(
+    pub fn image_sample_dref_explicit_lod(
         &mut self,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
@@ -1149,7 +1149,7 @@ impl Builder {
         coordinate: spirv::Word,
         d_ref: spirv::Word,
         image_operands: spirv::ImageOperands,
-        additional_params: T,
+        additional_params: impl IntoIterator<Item = dr::Operand>,
     ) -> BuildResult<spirv::Word> {
         let _id = result_id.unwrap_or_else(|| self.id());
         #[allow(unused_mut)]
@@ -1169,7 +1169,7 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpImageSampleDrefExplicitLod instruction to the current block."]
-    pub fn insert_image_sample_dref_explicit_lod<T: IntoIterator<Item = dr::Operand>>(
+    pub fn insert_image_sample_dref_explicit_lod(
         &mut self,
         insert_point: InsertPoint,
         result_type: spirv::Word,
@@ -1178,7 +1178,7 @@ impl Builder {
         coordinate: spirv::Word,
         d_ref: spirv::Word,
         image_operands: spirv::ImageOperands,
-        additional_params: T,
+        additional_params: impl IntoIterator<Item = dr::Operand>,
     ) -> BuildResult<spirv::Word> {
         let _id = result_id.unwrap_or_else(|| self.id());
         #[allow(unused_mut)]
@@ -1198,14 +1198,14 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpImageSampleProjImplicitLod instruction to the current block."]
-    pub fn image_sample_proj_implicit_lod<T: IntoIterator<Item = dr::Operand>>(
+    pub fn image_sample_proj_implicit_lod(
         &mut self,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
         sampled_image: spirv::Word,
         coordinate: spirv::Word,
         image_operands: Option<spirv::ImageOperands>,
-        additional_params: T,
+        additional_params: impl IntoIterator<Item = dr::Operand>,
     ) -> BuildResult<spirv::Word> {
         let _id = result_id.unwrap_or_else(|| self.id());
         #[allow(unused_mut)]
@@ -1227,7 +1227,7 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpImageSampleProjImplicitLod instruction to the current block."]
-    pub fn insert_image_sample_proj_implicit_lod<T: IntoIterator<Item = dr::Operand>>(
+    pub fn insert_image_sample_proj_implicit_lod(
         &mut self,
         insert_point: InsertPoint,
         result_type: spirv::Word,
@@ -1235,7 +1235,7 @@ impl Builder {
         sampled_image: spirv::Word,
         coordinate: spirv::Word,
         image_operands: Option<spirv::ImageOperands>,
-        additional_params: T,
+        additional_params: impl IntoIterator<Item = dr::Operand>,
     ) -> BuildResult<spirv::Word> {
         let _id = result_id.unwrap_or_else(|| self.id());
         #[allow(unused_mut)]
@@ -1257,14 +1257,14 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpImageSampleProjExplicitLod instruction to the current block."]
-    pub fn image_sample_proj_explicit_lod<T: IntoIterator<Item = dr::Operand>>(
+    pub fn image_sample_proj_explicit_lod(
         &mut self,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
         sampled_image: spirv::Word,
         coordinate: spirv::Word,
         image_operands: spirv::ImageOperands,
-        additional_params: T,
+        additional_params: impl IntoIterator<Item = dr::Operand>,
     ) -> BuildResult<spirv::Word> {
         let _id = result_id.unwrap_or_else(|| self.id());
         #[allow(unused_mut)]
@@ -1283,7 +1283,7 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpImageSampleProjExplicitLod instruction to the current block."]
-    pub fn insert_image_sample_proj_explicit_lod<T: IntoIterator<Item = dr::Operand>>(
+    pub fn insert_image_sample_proj_explicit_lod(
         &mut self,
         insert_point: InsertPoint,
         result_type: spirv::Word,
@@ -1291,7 +1291,7 @@ impl Builder {
         sampled_image: spirv::Word,
         coordinate: spirv::Word,
         image_operands: spirv::ImageOperands,
-        additional_params: T,
+        additional_params: impl IntoIterator<Item = dr::Operand>,
     ) -> BuildResult<spirv::Word> {
         let _id = result_id.unwrap_or_else(|| self.id());
         #[allow(unused_mut)]
@@ -1310,7 +1310,7 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpImageSampleProjDrefImplicitLod instruction to the current block."]
-    pub fn image_sample_proj_dref_implicit_lod<T: IntoIterator<Item = dr::Operand>>(
+    pub fn image_sample_proj_dref_implicit_lod(
         &mut self,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
@@ -1318,7 +1318,7 @@ impl Builder {
         coordinate: spirv::Word,
         d_ref: spirv::Word,
         image_operands: Option<spirv::ImageOperands>,
-        additional_params: T,
+        additional_params: impl IntoIterator<Item = dr::Operand>,
     ) -> BuildResult<spirv::Word> {
         let _id = result_id.unwrap_or_else(|| self.id());
         #[allow(unused_mut)]
@@ -1341,7 +1341,7 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpImageSampleProjDrefImplicitLod instruction to the current block."]
-    pub fn insert_image_sample_proj_dref_implicit_lod<T: IntoIterator<Item = dr::Operand>>(
+    pub fn insert_image_sample_proj_dref_implicit_lod(
         &mut self,
         insert_point: InsertPoint,
         result_type: spirv::Word,
@@ -1350,7 +1350,7 @@ impl Builder {
         coordinate: spirv::Word,
         d_ref: spirv::Word,
         image_operands: Option<spirv::ImageOperands>,
-        additional_params: T,
+        additional_params: impl IntoIterator<Item = dr::Operand>,
     ) -> BuildResult<spirv::Word> {
         let _id = result_id.unwrap_or_else(|| self.id());
         #[allow(unused_mut)]
@@ -1373,7 +1373,7 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpImageSampleProjDrefExplicitLod instruction to the current block."]
-    pub fn image_sample_proj_dref_explicit_lod<T: IntoIterator<Item = dr::Operand>>(
+    pub fn image_sample_proj_dref_explicit_lod(
         &mut self,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
@@ -1381,7 +1381,7 @@ impl Builder {
         coordinate: spirv::Word,
         d_ref: spirv::Word,
         image_operands: spirv::ImageOperands,
-        additional_params: T,
+        additional_params: impl IntoIterator<Item = dr::Operand>,
     ) -> BuildResult<spirv::Word> {
         let _id = result_id.unwrap_or_else(|| self.id());
         #[allow(unused_mut)]
@@ -1401,7 +1401,7 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpImageSampleProjDrefExplicitLod instruction to the current block."]
-    pub fn insert_image_sample_proj_dref_explicit_lod<T: IntoIterator<Item = dr::Operand>>(
+    pub fn insert_image_sample_proj_dref_explicit_lod(
         &mut self,
         insert_point: InsertPoint,
         result_type: spirv::Word,
@@ -1410,7 +1410,7 @@ impl Builder {
         coordinate: spirv::Word,
         d_ref: spirv::Word,
         image_operands: spirv::ImageOperands,
-        additional_params: T,
+        additional_params: impl IntoIterator<Item = dr::Operand>,
     ) -> BuildResult<spirv::Word> {
         let _id = result_id.unwrap_or_else(|| self.id());
         #[allow(unused_mut)]
@@ -1430,14 +1430,14 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpImageFetch instruction to the current block."]
-    pub fn image_fetch<T: IntoIterator<Item = dr::Operand>>(
+    pub fn image_fetch(
         &mut self,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
         image: spirv::Word,
         coordinate: spirv::Word,
         image_operands: Option<spirv::ImageOperands>,
-        additional_params: T,
+        additional_params: impl IntoIterator<Item = dr::Operand>,
     ) -> BuildResult<spirv::Word> {
         let _id = result_id.unwrap_or_else(|| self.id());
         #[allow(unused_mut)]
@@ -1456,7 +1456,7 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpImageFetch instruction to the current block."]
-    pub fn insert_image_fetch<T: IntoIterator<Item = dr::Operand>>(
+    pub fn insert_image_fetch(
         &mut self,
         insert_point: InsertPoint,
         result_type: spirv::Word,
@@ -1464,7 +1464,7 @@ impl Builder {
         image: spirv::Word,
         coordinate: spirv::Word,
         image_operands: Option<spirv::ImageOperands>,
-        additional_params: T,
+        additional_params: impl IntoIterator<Item = dr::Operand>,
     ) -> BuildResult<spirv::Word> {
         let _id = result_id.unwrap_or_else(|| self.id());
         #[allow(unused_mut)]
@@ -1483,7 +1483,7 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpImageGather instruction to the current block."]
-    pub fn image_gather<T: IntoIterator<Item = dr::Operand>>(
+    pub fn image_gather(
         &mut self,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
@@ -1491,7 +1491,7 @@ impl Builder {
         coordinate: spirv::Word,
         component: spirv::Word,
         image_operands: Option<spirv::ImageOperands>,
-        additional_params: T,
+        additional_params: impl IntoIterator<Item = dr::Operand>,
     ) -> BuildResult<spirv::Word> {
         let _id = result_id.unwrap_or_else(|| self.id());
         #[allow(unused_mut)]
@@ -1514,7 +1514,7 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpImageGather instruction to the current block."]
-    pub fn insert_image_gather<T: IntoIterator<Item = dr::Operand>>(
+    pub fn insert_image_gather(
         &mut self,
         insert_point: InsertPoint,
         result_type: spirv::Word,
@@ -1523,7 +1523,7 @@ impl Builder {
         coordinate: spirv::Word,
         component: spirv::Word,
         image_operands: Option<spirv::ImageOperands>,
-        additional_params: T,
+        additional_params: impl IntoIterator<Item = dr::Operand>,
     ) -> BuildResult<spirv::Word> {
         let _id = result_id.unwrap_or_else(|| self.id());
         #[allow(unused_mut)]
@@ -1546,7 +1546,7 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpImageDrefGather instruction to the current block."]
-    pub fn image_dref_gather<T: IntoIterator<Item = dr::Operand>>(
+    pub fn image_dref_gather(
         &mut self,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
@@ -1554,7 +1554,7 @@ impl Builder {
         coordinate: spirv::Word,
         d_ref: spirv::Word,
         image_operands: Option<spirv::ImageOperands>,
-        additional_params: T,
+        additional_params: impl IntoIterator<Item = dr::Operand>,
     ) -> BuildResult<spirv::Word> {
         let _id = result_id.unwrap_or_else(|| self.id());
         #[allow(unused_mut)]
@@ -1577,7 +1577,7 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpImageDrefGather instruction to the current block."]
-    pub fn insert_image_dref_gather<T: IntoIterator<Item = dr::Operand>>(
+    pub fn insert_image_dref_gather(
         &mut self,
         insert_point: InsertPoint,
         result_type: spirv::Word,
@@ -1586,7 +1586,7 @@ impl Builder {
         coordinate: spirv::Word,
         d_ref: spirv::Word,
         image_operands: Option<spirv::ImageOperands>,
-        additional_params: T,
+        additional_params: impl IntoIterator<Item = dr::Operand>,
     ) -> BuildResult<spirv::Word> {
         let _id = result_id.unwrap_or_else(|| self.id());
         #[allow(unused_mut)]
@@ -1609,14 +1609,14 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpImageRead instruction to the current block."]
-    pub fn image_read<T: IntoIterator<Item = dr::Operand>>(
+    pub fn image_read(
         &mut self,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
         image: spirv::Word,
         coordinate: spirv::Word,
         image_operands: Option<spirv::ImageOperands>,
-        additional_params: T,
+        additional_params: impl IntoIterator<Item = dr::Operand>,
     ) -> BuildResult<spirv::Word> {
         let _id = result_id.unwrap_or_else(|| self.id());
         #[allow(unused_mut)]
@@ -1635,7 +1635,7 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpImageRead instruction to the current block."]
-    pub fn insert_image_read<T: IntoIterator<Item = dr::Operand>>(
+    pub fn insert_image_read(
         &mut self,
         insert_point: InsertPoint,
         result_type: spirv::Word,
@@ -1643,7 +1643,7 @@ impl Builder {
         image: spirv::Word,
         coordinate: spirv::Word,
         image_operands: Option<spirv::ImageOperands>,
-        additional_params: T,
+        additional_params: impl IntoIterator<Item = dr::Operand>,
     ) -> BuildResult<spirv::Word> {
         let _id = result_id.unwrap_or_else(|| self.id());
         #[allow(unused_mut)]
@@ -1662,13 +1662,13 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpImageWrite instruction to the current block."]
-    pub fn image_write<T: IntoIterator<Item = dr::Operand>>(
+    pub fn image_write(
         &mut self,
         image: spirv::Word,
         coordinate: spirv::Word,
         texel: spirv::Word,
         image_operands: Option<spirv::ImageOperands>,
-        additional_params: T,
+        additional_params: impl IntoIterator<Item = dr::Operand>,
     ) -> BuildResult<()> {
         #[allow(unused_mut)]
         let mut inst = dr::Instruction::new(
@@ -1690,14 +1690,14 @@ impl Builder {
         Ok(())
     }
     #[doc = "Appends an OpImageWrite instruction to the current block."]
-    pub fn insert_image_write<T: IntoIterator<Item = dr::Operand>>(
+    pub fn insert_image_write(
         &mut self,
         insert_point: InsertPoint,
         image: spirv::Word,
         coordinate: spirv::Word,
         texel: spirv::Word,
         image_operands: Option<spirv::ImageOperands>,
-        additional_params: T,
+        additional_params: impl IntoIterator<Item = dr::Operand>,
     ) -> BuildResult<()> {
         #[allow(unused_mut)]
         let mut inst = dr::Instruction::new(
@@ -7003,11 +7003,11 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpPhi instruction to the current block."]
-    pub fn phi<T: IntoIterator<Item = (spirv::Word, spirv::Word)>>(
+    pub fn phi(
         &mut self,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
-        variable_parent: T,
+        variable_parent: impl IntoIterator<Item = (spirv::Word, spirv::Word)>,
     ) -> BuildResult<spirv::Word> {
         let _id = result_id.unwrap_or_else(|| self.id());
         #[allow(unused_mut)]
@@ -7020,12 +7020,12 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpPhi instruction to the current block."]
-    pub fn insert_phi<T: IntoIterator<Item = (spirv::Word, spirv::Word)>>(
+    pub fn insert_phi(
         &mut self,
         insert_point: InsertPoint,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
-        variable_parent: T,
+        variable_parent: impl IntoIterator<Item = (spirv::Word, spirv::Word)>,
     ) -> BuildResult<spirv::Word> {
         let _id = result_id.unwrap_or_else(|| self.id());
         #[allow(unused_mut)]
@@ -8505,7 +8505,7 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpEnqueueKernel instruction to the current block."]
-    pub fn enqueue_kernel<T: IntoIterator<Item = spirv::Word>>(
+    pub fn enqueue_kernel(
         &mut self,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
@@ -8519,7 +8519,7 @@ impl Builder {
         param: spirv::Word,
         param_size: spirv::Word,
         param_align: spirv::Word,
-        local_size: T,
+        local_size: impl IntoIterator<Item = spirv::Word>,
     ) -> BuildResult<spirv::Word> {
         let _id = result_id.unwrap_or_else(|| self.id());
         #[allow(unused_mut)]
@@ -8546,7 +8546,7 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpEnqueueKernel instruction to the current block."]
-    pub fn insert_enqueue_kernel<T: IntoIterator<Item = spirv::Word>>(
+    pub fn insert_enqueue_kernel(
         &mut self,
         insert_point: InsertPoint,
         result_type: spirv::Word,
@@ -8561,7 +8561,7 @@ impl Builder {
         param: spirv::Word,
         param_size: spirv::Word,
         param_align: spirv::Word,
-        local_size: T,
+        local_size: impl IntoIterator<Item = spirv::Word>,
     ) -> BuildResult<spirv::Word> {
         let _id = result_id.unwrap_or_else(|| self.id());
         #[allow(unused_mut)]
@@ -9096,14 +9096,14 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpImageSparseSampleImplicitLod instruction to the current block."]
-    pub fn image_sparse_sample_implicit_lod<T: IntoIterator<Item = dr::Operand>>(
+    pub fn image_sparse_sample_implicit_lod(
         &mut self,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
         sampled_image: spirv::Word,
         coordinate: spirv::Word,
         image_operands: Option<spirv::ImageOperands>,
-        additional_params: T,
+        additional_params: impl IntoIterator<Item = dr::Operand>,
     ) -> BuildResult<spirv::Word> {
         let _id = result_id.unwrap_or_else(|| self.id());
         #[allow(unused_mut)]
@@ -9125,7 +9125,7 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpImageSparseSampleImplicitLod instruction to the current block."]
-    pub fn insert_image_sparse_sample_implicit_lod<T: IntoIterator<Item = dr::Operand>>(
+    pub fn insert_image_sparse_sample_implicit_lod(
         &mut self,
         insert_point: InsertPoint,
         result_type: spirv::Word,
@@ -9133,7 +9133,7 @@ impl Builder {
         sampled_image: spirv::Word,
         coordinate: spirv::Word,
         image_operands: Option<spirv::ImageOperands>,
-        additional_params: T,
+        additional_params: impl IntoIterator<Item = dr::Operand>,
     ) -> BuildResult<spirv::Word> {
         let _id = result_id.unwrap_or_else(|| self.id());
         #[allow(unused_mut)]
@@ -9155,14 +9155,14 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpImageSparseSampleExplicitLod instruction to the current block."]
-    pub fn image_sparse_sample_explicit_lod<T: IntoIterator<Item = dr::Operand>>(
+    pub fn image_sparse_sample_explicit_lod(
         &mut self,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
         sampled_image: spirv::Word,
         coordinate: spirv::Word,
         image_operands: spirv::ImageOperands,
-        additional_params: T,
+        additional_params: impl IntoIterator<Item = dr::Operand>,
     ) -> BuildResult<spirv::Word> {
         let _id = result_id.unwrap_or_else(|| self.id());
         #[allow(unused_mut)]
@@ -9181,7 +9181,7 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpImageSparseSampleExplicitLod instruction to the current block."]
-    pub fn insert_image_sparse_sample_explicit_lod<T: IntoIterator<Item = dr::Operand>>(
+    pub fn insert_image_sparse_sample_explicit_lod(
         &mut self,
         insert_point: InsertPoint,
         result_type: spirv::Word,
@@ -9189,7 +9189,7 @@ impl Builder {
         sampled_image: spirv::Word,
         coordinate: spirv::Word,
         image_operands: spirv::ImageOperands,
-        additional_params: T,
+        additional_params: impl IntoIterator<Item = dr::Operand>,
     ) -> BuildResult<spirv::Word> {
         let _id = result_id.unwrap_or_else(|| self.id());
         #[allow(unused_mut)]
@@ -9208,7 +9208,7 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpImageSparseSampleDrefImplicitLod instruction to the current block."]
-    pub fn image_sparse_sample_dref_implicit_lod<T: IntoIterator<Item = dr::Operand>>(
+    pub fn image_sparse_sample_dref_implicit_lod(
         &mut self,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
@@ -9216,7 +9216,7 @@ impl Builder {
         coordinate: spirv::Word,
         d_ref: spirv::Word,
         image_operands: Option<spirv::ImageOperands>,
-        additional_params: T,
+        additional_params: impl IntoIterator<Item = dr::Operand>,
     ) -> BuildResult<spirv::Word> {
         let _id = result_id.unwrap_or_else(|| self.id());
         #[allow(unused_mut)]
@@ -9239,7 +9239,7 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpImageSparseSampleDrefImplicitLod instruction to the current block."]
-    pub fn insert_image_sparse_sample_dref_implicit_lod<T: IntoIterator<Item = dr::Operand>>(
+    pub fn insert_image_sparse_sample_dref_implicit_lod(
         &mut self,
         insert_point: InsertPoint,
         result_type: spirv::Word,
@@ -9248,7 +9248,7 @@ impl Builder {
         coordinate: spirv::Word,
         d_ref: spirv::Word,
         image_operands: Option<spirv::ImageOperands>,
-        additional_params: T,
+        additional_params: impl IntoIterator<Item = dr::Operand>,
     ) -> BuildResult<spirv::Word> {
         let _id = result_id.unwrap_or_else(|| self.id());
         #[allow(unused_mut)]
@@ -9271,7 +9271,7 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpImageSparseSampleDrefExplicitLod instruction to the current block."]
-    pub fn image_sparse_sample_dref_explicit_lod<T: IntoIterator<Item = dr::Operand>>(
+    pub fn image_sparse_sample_dref_explicit_lod(
         &mut self,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
@@ -9279,7 +9279,7 @@ impl Builder {
         coordinate: spirv::Word,
         d_ref: spirv::Word,
         image_operands: spirv::ImageOperands,
-        additional_params: T,
+        additional_params: impl IntoIterator<Item = dr::Operand>,
     ) -> BuildResult<spirv::Word> {
         let _id = result_id.unwrap_or_else(|| self.id());
         #[allow(unused_mut)]
@@ -9299,7 +9299,7 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpImageSparseSampleDrefExplicitLod instruction to the current block."]
-    pub fn insert_image_sparse_sample_dref_explicit_lod<T: IntoIterator<Item = dr::Operand>>(
+    pub fn insert_image_sparse_sample_dref_explicit_lod(
         &mut self,
         insert_point: InsertPoint,
         result_type: spirv::Word,
@@ -9308,7 +9308,7 @@ impl Builder {
         coordinate: spirv::Word,
         d_ref: spirv::Word,
         image_operands: spirv::ImageOperands,
-        additional_params: T,
+        additional_params: impl IntoIterator<Item = dr::Operand>,
     ) -> BuildResult<spirv::Word> {
         let _id = result_id.unwrap_or_else(|| self.id());
         #[allow(unused_mut)]
@@ -9328,14 +9328,14 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpImageSparseSampleProjImplicitLod instruction to the current block."]
-    pub fn image_sparse_sample_proj_implicit_lod<T: IntoIterator<Item = dr::Operand>>(
+    pub fn image_sparse_sample_proj_implicit_lod(
         &mut self,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
         sampled_image: spirv::Word,
         coordinate: spirv::Word,
         image_operands: Option<spirv::ImageOperands>,
-        additional_params: T,
+        additional_params: impl IntoIterator<Item = dr::Operand>,
     ) -> BuildResult<spirv::Word> {
         let _id = result_id.unwrap_or_else(|| self.id());
         #[allow(unused_mut)]
@@ -9357,7 +9357,7 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpImageSparseSampleProjImplicitLod instruction to the current block."]
-    pub fn insert_image_sparse_sample_proj_implicit_lod<T: IntoIterator<Item = dr::Operand>>(
+    pub fn insert_image_sparse_sample_proj_implicit_lod(
         &mut self,
         insert_point: InsertPoint,
         result_type: spirv::Word,
@@ -9365,7 +9365,7 @@ impl Builder {
         sampled_image: spirv::Word,
         coordinate: spirv::Word,
         image_operands: Option<spirv::ImageOperands>,
-        additional_params: T,
+        additional_params: impl IntoIterator<Item = dr::Operand>,
     ) -> BuildResult<spirv::Word> {
         let _id = result_id.unwrap_or_else(|| self.id());
         #[allow(unused_mut)]
@@ -9387,14 +9387,14 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpImageSparseSampleProjExplicitLod instruction to the current block."]
-    pub fn image_sparse_sample_proj_explicit_lod<T: IntoIterator<Item = dr::Operand>>(
+    pub fn image_sparse_sample_proj_explicit_lod(
         &mut self,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
         sampled_image: spirv::Word,
         coordinate: spirv::Word,
         image_operands: spirv::ImageOperands,
-        additional_params: T,
+        additional_params: impl IntoIterator<Item = dr::Operand>,
     ) -> BuildResult<spirv::Word> {
         let _id = result_id.unwrap_or_else(|| self.id());
         #[allow(unused_mut)]
@@ -9413,7 +9413,7 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpImageSparseSampleProjExplicitLod instruction to the current block."]
-    pub fn insert_image_sparse_sample_proj_explicit_lod<T: IntoIterator<Item = dr::Operand>>(
+    pub fn insert_image_sparse_sample_proj_explicit_lod(
         &mut self,
         insert_point: InsertPoint,
         result_type: spirv::Word,
@@ -9421,7 +9421,7 @@ impl Builder {
         sampled_image: spirv::Word,
         coordinate: spirv::Word,
         image_operands: spirv::ImageOperands,
-        additional_params: T,
+        additional_params: impl IntoIterator<Item = dr::Operand>,
     ) -> BuildResult<spirv::Word> {
         let _id = result_id.unwrap_or_else(|| self.id());
         #[allow(unused_mut)]
@@ -9440,7 +9440,7 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpImageSparseSampleProjDrefImplicitLod instruction to the current block."]
-    pub fn image_sparse_sample_proj_dref_implicit_lod<T: IntoIterator<Item = dr::Operand>>(
+    pub fn image_sparse_sample_proj_dref_implicit_lod(
         &mut self,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
@@ -9448,7 +9448,7 @@ impl Builder {
         coordinate: spirv::Word,
         d_ref: spirv::Word,
         image_operands: Option<spirv::ImageOperands>,
-        additional_params: T,
+        additional_params: impl IntoIterator<Item = dr::Operand>,
     ) -> BuildResult<spirv::Word> {
         let _id = result_id.unwrap_or_else(|| self.id());
         #[allow(unused_mut)]
@@ -9471,9 +9471,7 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpImageSparseSampleProjDrefImplicitLod instruction to the current block."]
-    pub fn insert_image_sparse_sample_proj_dref_implicit_lod<
-        T: IntoIterator<Item = dr::Operand>,
-    >(
+    pub fn insert_image_sparse_sample_proj_dref_implicit_lod(
         &mut self,
         insert_point: InsertPoint,
         result_type: spirv::Word,
@@ -9482,7 +9480,7 @@ impl Builder {
         coordinate: spirv::Word,
         d_ref: spirv::Word,
         image_operands: Option<spirv::ImageOperands>,
-        additional_params: T,
+        additional_params: impl IntoIterator<Item = dr::Operand>,
     ) -> BuildResult<spirv::Word> {
         let _id = result_id.unwrap_or_else(|| self.id());
         #[allow(unused_mut)]
@@ -9505,7 +9503,7 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpImageSparseSampleProjDrefExplicitLod instruction to the current block."]
-    pub fn image_sparse_sample_proj_dref_explicit_lod<T: IntoIterator<Item = dr::Operand>>(
+    pub fn image_sparse_sample_proj_dref_explicit_lod(
         &mut self,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
@@ -9513,7 +9511,7 @@ impl Builder {
         coordinate: spirv::Word,
         d_ref: spirv::Word,
         image_operands: spirv::ImageOperands,
-        additional_params: T,
+        additional_params: impl IntoIterator<Item = dr::Operand>,
     ) -> BuildResult<spirv::Word> {
         let _id = result_id.unwrap_or_else(|| self.id());
         #[allow(unused_mut)]
@@ -9533,9 +9531,7 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpImageSparseSampleProjDrefExplicitLod instruction to the current block."]
-    pub fn insert_image_sparse_sample_proj_dref_explicit_lod<
-        T: IntoIterator<Item = dr::Operand>,
-    >(
+    pub fn insert_image_sparse_sample_proj_dref_explicit_lod(
         &mut self,
         insert_point: InsertPoint,
         result_type: spirv::Word,
@@ -9544,7 +9540,7 @@ impl Builder {
         coordinate: spirv::Word,
         d_ref: spirv::Word,
         image_operands: spirv::ImageOperands,
-        additional_params: T,
+        additional_params: impl IntoIterator<Item = dr::Operand>,
     ) -> BuildResult<spirv::Word> {
         let _id = result_id.unwrap_or_else(|| self.id());
         #[allow(unused_mut)]
@@ -9564,14 +9560,14 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpImageSparseFetch instruction to the current block."]
-    pub fn image_sparse_fetch<T: IntoIterator<Item = dr::Operand>>(
+    pub fn image_sparse_fetch(
         &mut self,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
         image: spirv::Word,
         coordinate: spirv::Word,
         image_operands: Option<spirv::ImageOperands>,
-        additional_params: T,
+        additional_params: impl IntoIterator<Item = dr::Operand>,
     ) -> BuildResult<spirv::Word> {
         let _id = result_id.unwrap_or_else(|| self.id());
         #[allow(unused_mut)]
@@ -9590,7 +9586,7 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpImageSparseFetch instruction to the current block."]
-    pub fn insert_image_sparse_fetch<T: IntoIterator<Item = dr::Operand>>(
+    pub fn insert_image_sparse_fetch(
         &mut self,
         insert_point: InsertPoint,
         result_type: spirv::Word,
@@ -9598,7 +9594,7 @@ impl Builder {
         image: spirv::Word,
         coordinate: spirv::Word,
         image_operands: Option<spirv::ImageOperands>,
-        additional_params: T,
+        additional_params: impl IntoIterator<Item = dr::Operand>,
     ) -> BuildResult<spirv::Word> {
         let _id = result_id.unwrap_or_else(|| self.id());
         #[allow(unused_mut)]
@@ -9617,7 +9613,7 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpImageSparseGather instruction to the current block."]
-    pub fn image_sparse_gather<T: IntoIterator<Item = dr::Operand>>(
+    pub fn image_sparse_gather(
         &mut self,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
@@ -9625,7 +9621,7 @@ impl Builder {
         coordinate: spirv::Word,
         component: spirv::Word,
         image_operands: Option<spirv::ImageOperands>,
-        additional_params: T,
+        additional_params: impl IntoIterator<Item = dr::Operand>,
     ) -> BuildResult<spirv::Word> {
         let _id = result_id.unwrap_or_else(|| self.id());
         #[allow(unused_mut)]
@@ -9648,7 +9644,7 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpImageSparseGather instruction to the current block."]
-    pub fn insert_image_sparse_gather<T: IntoIterator<Item = dr::Operand>>(
+    pub fn insert_image_sparse_gather(
         &mut self,
         insert_point: InsertPoint,
         result_type: spirv::Word,
@@ -9657,7 +9653,7 @@ impl Builder {
         coordinate: spirv::Word,
         component: spirv::Word,
         image_operands: Option<spirv::ImageOperands>,
-        additional_params: T,
+        additional_params: impl IntoIterator<Item = dr::Operand>,
     ) -> BuildResult<spirv::Word> {
         let _id = result_id.unwrap_or_else(|| self.id());
         #[allow(unused_mut)]
@@ -9680,7 +9676,7 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpImageSparseDrefGather instruction to the current block."]
-    pub fn image_sparse_dref_gather<T: IntoIterator<Item = dr::Operand>>(
+    pub fn image_sparse_dref_gather(
         &mut self,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
@@ -9688,7 +9684,7 @@ impl Builder {
         coordinate: spirv::Word,
         d_ref: spirv::Word,
         image_operands: Option<spirv::ImageOperands>,
-        additional_params: T,
+        additional_params: impl IntoIterator<Item = dr::Operand>,
     ) -> BuildResult<spirv::Word> {
         let _id = result_id.unwrap_or_else(|| self.id());
         #[allow(unused_mut)]
@@ -9711,7 +9707,7 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpImageSparseDrefGather instruction to the current block."]
-    pub fn insert_image_sparse_dref_gather<T: IntoIterator<Item = dr::Operand>>(
+    pub fn insert_image_sparse_dref_gather(
         &mut self,
         insert_point: InsertPoint,
         result_type: spirv::Word,
@@ -9720,7 +9716,7 @@ impl Builder {
         coordinate: spirv::Word,
         d_ref: spirv::Word,
         image_operands: Option<spirv::ImageOperands>,
-        additional_params: T,
+        additional_params: impl IntoIterator<Item = dr::Operand>,
     ) -> BuildResult<spirv::Word> {
         let _id = result_id.unwrap_or_else(|| self.id());
         #[allow(unused_mut)]
@@ -9872,14 +9868,14 @@ impl Builder {
         Ok(())
     }
     #[doc = "Appends an OpImageSparseRead instruction to the current block."]
-    pub fn image_sparse_read<T: IntoIterator<Item = dr::Operand>>(
+    pub fn image_sparse_read(
         &mut self,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
         image: spirv::Word,
         coordinate: spirv::Word,
         image_operands: Option<spirv::ImageOperands>,
-        additional_params: T,
+        additional_params: impl IntoIterator<Item = dr::Operand>,
     ) -> BuildResult<spirv::Word> {
         let _id = result_id.unwrap_or_else(|| self.id());
         #[allow(unused_mut)]
@@ -9898,7 +9894,7 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpImageSparseRead instruction to the current block."]
-    pub fn insert_image_sparse_read<T: IntoIterator<Item = dr::Operand>>(
+    pub fn insert_image_sparse_read(
         &mut self,
         insert_point: InsertPoint,
         result_type: spirv::Word,
@@ -9906,7 +9902,7 @@ impl Builder {
         image: spirv::Word,
         coordinate: spirv::Word,
         image_operands: Option<spirv::ImageOperands>,
-        additional_params: T,
+        additional_params: impl IntoIterator<Item = dr::Operand>,
     ) -> BuildResult<spirv::Word> {
         let _id = result_id.unwrap_or_else(|| self.id());
         #[allow(unused_mut)]
@@ -13122,7 +13118,7 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpImageSampleFootprintNV instruction to the current block."]
-    pub fn image_sample_footprint_nv<T: IntoIterator<Item = dr::Operand>>(
+    pub fn image_sample_footprint_nv(
         &mut self,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
@@ -13131,7 +13127,7 @@ impl Builder {
         granularity: spirv::Word,
         coarse: spirv::Word,
         image_operands: Option<spirv::ImageOperands>,
-        additional_params: T,
+        additional_params: impl IntoIterator<Item = dr::Operand>,
     ) -> BuildResult<spirv::Word> {
         let _id = result_id.unwrap_or_else(|| self.id());
         #[allow(unused_mut)]
@@ -13155,7 +13151,7 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpImageSampleFootprintNV instruction to the current block."]
-    pub fn insert_image_sample_footprint_nv<T: IntoIterator<Item = dr::Operand>>(
+    pub fn insert_image_sample_footprint_nv(
         &mut self,
         insert_point: InsertPoint,
         result_type: spirv::Word,
@@ -13165,7 +13161,7 @@ impl Builder {
         granularity: spirv::Word,
         coarse: spirv::Word,
         image_operands: Option<spirv::ImageOperands>,
-        additional_params: T,
+        additional_params: impl IntoIterator<Item = dr::Operand>,
     ) -> BuildResult<spirv::Word> {
         let _id = result_id.unwrap_or_else(|| self.id());
         #[allow(unused_mut)]
@@ -13627,7 +13623,7 @@ impl Builder {
         Ok(())
     }
     #[doc = "Appends an OpCooperativeMatrixLoadNV instruction to the current block."]
-    pub fn cooperative_matrix_load_nv<T: IntoIterator<Item = dr::Operand>>(
+    pub fn cooperative_matrix_load_nv(
         &mut self,
         result_type: spirv::Word,
         result_id: Option<spirv::Word>,
@@ -13635,7 +13631,7 @@ impl Builder {
         stride: spirv::Word,
         column_major: spirv::Word,
         memory_access: Option<spirv::MemoryAccess>,
-        additional_params: T,
+        additional_params: impl IntoIterator<Item = dr::Operand>,
     ) -> BuildResult<spirv::Word> {
         let _id = result_id.unwrap_or_else(|| self.id());
         #[allow(unused_mut)]
@@ -13658,7 +13654,7 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpCooperativeMatrixLoadNV instruction to the current block."]
-    pub fn insert_cooperative_matrix_load_nv<T: IntoIterator<Item = dr::Operand>>(
+    pub fn insert_cooperative_matrix_load_nv(
         &mut self,
         insert_point: InsertPoint,
         result_type: spirv::Word,
@@ -13667,7 +13663,7 @@ impl Builder {
         stride: spirv::Word,
         column_major: spirv::Word,
         memory_access: Option<spirv::MemoryAccess>,
-        additional_params: T,
+        additional_params: impl IntoIterator<Item = dr::Operand>,
     ) -> BuildResult<spirv::Word> {
         let _id = result_id.unwrap_or_else(|| self.id());
         #[allow(unused_mut)]
@@ -13690,14 +13686,14 @@ impl Builder {
         Ok(_id)
     }
     #[doc = "Appends an OpCooperativeMatrixStoreNV instruction to the current block."]
-    pub fn cooperative_matrix_store_nv<T: IntoIterator<Item = dr::Operand>>(
+    pub fn cooperative_matrix_store_nv(
         &mut self,
         pointer: spirv::Word,
         object: spirv::Word,
         stride: spirv::Word,
         column_major: spirv::Word,
         memory_access: Option<spirv::MemoryAccess>,
-        additional_params: T,
+        additional_params: impl IntoIterator<Item = dr::Operand>,
     ) -> BuildResult<()> {
         #[allow(unused_mut)]
         let mut inst = dr::Instruction::new(
@@ -13720,7 +13716,7 @@ impl Builder {
         Ok(())
     }
     #[doc = "Appends an OpCooperativeMatrixStoreNV instruction to the current block."]
-    pub fn insert_cooperative_matrix_store_nv<T: IntoIterator<Item = dr::Operand>>(
+    pub fn insert_cooperative_matrix_store_nv(
         &mut self,
         insert_point: InsertPoint,
         pointer: spirv::Word,
@@ -13728,7 +13724,7 @@ impl Builder {
         stride: spirv::Word,
         column_major: spirv::Word,
         memory_access: Option<spirv::MemoryAccess>,
-        additional_params: T,
+        additional_params: impl IntoIterator<Item = dr::Operand>,
     ) -> BuildResult<()> {
         #[allow(unused_mut)]
         let mut inst = dr::Instruction::new(

--- a/rspirv/dr/build/autogen_terminator.rs
+++ b/rspirv/dr/build/autogen_terminator.rs
@@ -4,12 +4,12 @@
 
 impl Builder {
     #[doc = "Appends an OpLoopMerge instruction and ends the current block."]
-    pub fn loop_merge<T: IntoIterator<Item = dr::Operand>>(
+    pub fn loop_merge(
         &mut self,
         merge_block: spirv::Word,
         continue_target: spirv::Word,
         loop_control: spirv::LoopControl,
-        additional_params: T,
+        additional_params: impl IntoIterator<Item = dr::Operand>,
     ) -> BuildResult<()> {
         #[allow(unused_mut)]
         let mut inst = dr::Instruction::new(
@@ -26,13 +26,13 @@ impl Builder {
         self.end_block(inst)
     }
     #[doc = "Insert an OpLoopMerge instruction and ends the current block."]
-    pub fn insert_loop_merge<T: IntoIterator<Item = dr::Operand>>(
+    pub fn insert_loop_merge(
         &mut self,
         insert_point: InsertPoint,
         merge_block: spirv::Word,
         continue_target: spirv::Word,
         loop_control: spirv::LoopControl,
-        additional_params: T,
+        additional_params: impl IntoIterator<Item = dr::Operand>,
     ) -> BuildResult<()> {
         #[allow(unused_mut)]
         let mut inst = dr::Instruction::new(
@@ -128,12 +128,12 @@ impl Builder {
         self.insert_end_block(insert_point, inst)
     }
     #[doc = "Appends an OpBranchConditional instruction and ends the current block."]
-    pub fn branch_conditional<T: IntoIterator<Item = u32>>(
+    pub fn branch_conditional(
         &mut self,
         condition: spirv::Word,
         true_label: spirv::Word,
         false_label: spirv::Word,
-        branch_weights: T,
+        branch_weights: impl IntoIterator<Item = u32>,
     ) -> BuildResult<()> {
         #[allow(unused_mut)]
         let mut inst = dr::Instruction::new(
@@ -151,13 +151,13 @@ impl Builder {
         self.end_block(inst)
     }
     #[doc = "Insert an OpBranchConditional instruction and ends the current block."]
-    pub fn insert_branch_conditional<T: IntoIterator<Item = u32>>(
+    pub fn insert_branch_conditional(
         &mut self,
         insert_point: InsertPoint,
         condition: spirv::Word,
         true_label: spirv::Word,
         false_label: spirv::Word,
-        branch_weights: T,
+        branch_weights: impl IntoIterator<Item = u32>,
     ) -> BuildResult<()> {
         #[allow(unused_mut)]
         let mut inst = dr::Instruction::new(
@@ -175,11 +175,11 @@ impl Builder {
         self.insert_end_block(insert_point, inst)
     }
     #[doc = "Appends an OpSwitch instruction and ends the current block."]
-    pub fn switch<T: IntoIterator<Item = (dr::Operand, spirv::Word)>>(
+    pub fn switch(
         &mut self,
         selector: spirv::Word,
         default: spirv::Word,
-        target: T,
+        target: impl IntoIterator<Item = (dr::Operand, spirv::Word)>,
     ) -> BuildResult<()> {
         #[allow(unused_mut)]
         let mut inst = dr::Instruction::new(
@@ -195,12 +195,12 @@ impl Builder {
         self.end_block(inst)
     }
     #[doc = "Insert an OpSwitch instruction and ends the current block."]
-    pub fn insert_switch<T: IntoIterator<Item = (dr::Operand, spirv::Word)>>(
+    pub fn insert_switch(
         &mut self,
         insert_point: InsertPoint,
         selector: spirv::Word,
         default: spirv::Word,
-        target: T,
+        target: impl IntoIterator<Item = (dr::Operand, spirv::Word)>,
     ) -> BuildResult<()> {
         #[allow(unused_mut)]
         let mut inst = dr::Instruction::new(

--- a/rspirv/dr/build/autogen_type.rs
+++ b/rspirv/dr/build/autogen_type.rs
@@ -211,9 +211,9 @@ impl Builder {
         }
     }
     #[doc = "Appends an OpTypeStruct instruction and returns the result id, or return the existing id if the instruction was already present."]
-    pub fn type_struct<T: IntoIterator<Item = spirv::Word>>(
+    pub fn type_struct(
         &mut self,
-        member_0_type_member_1_type: T,
+        member_0_type_member_1_type: impl IntoIterator<Item = spirv::Word>,
     ) -> spirv::Word {
         let mut inst = dr::Instruction::new(spirv::Op::TypeStruct, None, None, vec![]);
         inst.operands.extend(
@@ -231,10 +231,10 @@ impl Builder {
         }
     }
     #[doc = "Appends an OpTypeFunction instruction and returns the result id, or return the existing id if the instruction was already present."]
-    pub fn type_function<T: IntoIterator<Item = spirv::Word>>(
+    pub fn type_function(
         &mut self,
         return_type: spirv::Word,
-        parameter_0_type_parameter_1_type: T,
+        parameter_0_type_parameter_1_type: impl IntoIterator<Item = spirv::Word>,
     ) -> spirv::Word {
         let mut inst = dr::Instruction::new(
             spirv::Op::TypeFunction,

--- a/rspirv/dr/build/mod.rs
+++ b/rspirv/dr/build/mod.rs
@@ -491,7 +491,7 @@ impl Builder {
     }
 
     /// Appends an OpExtension instruction.
-    pub fn extension<T: Into<String>>(&mut self, extension: T) {
+    pub fn extension(&mut self, extension: impl Into<String>) {
         let inst = dr::Instruction::new(
             spirv::Op::Extension,
             None,
@@ -502,7 +502,7 @@ impl Builder {
     }
 
     /// Appends an OpExtInstImport instruction and returns the result id.
-    pub fn ext_inst_import<T: Into<String>>(&mut self, extended_inst_set: T) -> spirv::Word {
+    pub fn ext_inst_import(&mut self, extended_inst_set: impl Into<String>) -> spirv::Word {
         let id = self.id();
         let inst = dr::Instruction::new(
             spirv::Op::ExtInstImport,
@@ -533,12 +533,12 @@ impl Builder {
     }
 
     /// Appends an OpEntryPoint instruction.
-    pub fn entry_point<T: Into<String>, U: AsRef<[spirv::Word]>>(
+    pub fn entry_point(
         &mut self,
         execution_model: spirv::ExecutionModel,
         entry_point: spirv::Word,
-        name: T,
-        interface: U,
+        name: impl Into<String>,
+        interface: impl AsRef<[spirv::Word]>,
     ) {
         let mut operands = vec![
             dr::Operand::ExecutionModel(execution_model),
@@ -554,11 +554,11 @@ impl Builder {
     }
 
     /// Appends an OpExecutionMode instruction.
-    pub fn execution_mode<T: AsRef<[u32]>>(
+    pub fn execution_mode(
         &mut self,
         entry_point: spirv::Word,
         execution_mode: spirv::ExecutionMode,
-        params: T,
+        params: impl AsRef<[u32]>,
     ) {
         let mut operands = vec![
             dr::Operand::IdRef(entry_point),
@@ -611,7 +611,7 @@ impl Builder {
         id
     }
 
-    pub fn string<T: Into<String>>(&mut self, s: T) -> spirv::Word {
+    pub fn string(&mut self, s: impl Into<String>) -> spirv::Word {
         let id = self.id();
         self.module.debugs.push(dr::Instruction::new(
             spirv::Op::String,
@@ -674,7 +674,7 @@ impl Builder {
     }
 
     /// Appends an OpTypeOpaque instruction and returns the result id.
-    pub fn type_opaque<T: Into<String>>(&mut self, type_name: T) -> spirv::Word {
+    pub fn type_opaque(&mut self, type_name: impl Into<String>) -> spirv::Word {
         let id = self.id();
         self.module.types_global_values.push(dr::Instruction::new(
             spirv::Op::TypeOpaque,

--- a/rspirv/dr/loader.rs
+++ b/rspirv/dr/loader.rs
@@ -231,7 +231,7 @@ impl binary::Consumer for Loader {
 ///             ; Bound: 0\n\
 ///             OpMemoryModel Logical GLSL450");
 /// ```
-pub fn load_bytes<T: AsRef<[u8]>>(binary: T) -> ParseResult<dr::Module> {
+pub fn load_bytes(binary: impl AsRef<[u8]>) -> ParseResult<dr::Module> {
     let mut loader = Loader::new();
     binary::parse_bytes(binary, &mut loader)?;
     Ok(loader.module())
@@ -268,7 +268,7 @@ pub fn load_bytes<T: AsRef<[u8]>>(binary: T) -> ParseResult<dr::Module> {
 ///             ; Bound: 0\n\
 ///             OpMemoryModel Logical GLSL450");
 /// ```
-pub fn load_words<T: AsRef<[u32]>>(binary: T) -> ParseResult<dr::Module> {
+pub fn load_words(binary: impl AsRef<[u32]>) -> ParseResult<dr::Module> {
     let mut loader = Loader::new();
     binary::parse_words(binary, &mut loader)?;
     Ok(loader.module())


### PR DESCRIPTION
This _is_ a breaking change: see `rspirv/binary/disassemble.rs` `mod test` for an example of how it breaks.

I'm doing this primarily because the IDE experience in e.g. vscode rust-analyzer is significantly better: when autocompleting a method, the type of `impl trait` is directly in the position of the relevant parameter, and easily readable. With generics, you have to manually check the generic name, then look over to the generic parameter list, find the parameter, and check the type. This extra step has tripped me up enough times and caused me enough development pain that I got frustrated enough to write this PR.