### PR TITLE
Add helper methods I'm constantly redefining

### DIFF
--- a/rspirv/dr/autogen_operand.rs
+++ b/rspirv/dr/autogen_operand.rs
@@ -100,3 +100,315 @@ impl fmt::Display for Operand {
         }
     }
 }
+impl Operand {
+    pub fn unwrap_image_operands(&self) -> spirv::ImageOperands {
+        match *self {
+            Self::ImageOperands(v) => v,
+            ref other => panic!("Expected Operand::ImageOperands, got {} instead", other),
+        }
+    }
+    pub fn unwrap_fp_fast_math_mode(&self) -> spirv::FPFastMathMode {
+        match *self {
+            Self::FPFastMathMode(v) => v,
+            ref other => panic!("Expected Operand::FPFastMathMode, got {} instead", other),
+        }
+    }
+    pub fn unwrap_selection_control(&self) -> spirv::SelectionControl {
+        match *self {
+            Self::SelectionControl(v) => v,
+            ref other => panic!("Expected Operand::SelectionControl, got {} instead", other),
+        }
+    }
+    pub fn unwrap_loop_control(&self) -> spirv::LoopControl {
+        match *self {
+            Self::LoopControl(v) => v,
+            ref other => panic!("Expected Operand::LoopControl, got {} instead", other),
+        }
+    }
+    pub fn unwrap_function_control(&self) -> spirv::FunctionControl {
+        match *self {
+            Self::FunctionControl(v) => v,
+            ref other => panic!("Expected Operand::FunctionControl, got {} instead", other),
+        }
+    }
+    pub fn unwrap_memory_semantics(&self) -> spirv::MemorySemantics {
+        match *self {
+            Self::MemorySemantics(v) => v,
+            ref other => panic!("Expected Operand::MemorySemantics, got {} instead", other),
+        }
+    }
+    pub fn unwrap_memory_access(&self) -> spirv::MemoryAccess {
+        match *self {
+            Self::MemoryAccess(v) => v,
+            ref other => panic!("Expected Operand::MemoryAccess, got {} instead", other),
+        }
+    }
+    pub fn unwrap_kernel_profiling_info(&self) -> spirv::KernelProfilingInfo {
+        match *self {
+            Self::KernelProfilingInfo(v) => v,
+            ref other => panic!(
+                "Expected Operand::KernelProfilingInfo, got {} instead",
+                other
+            ),
+        }
+    }
+    pub fn unwrap_ray_flags(&self) -> spirv::RayFlags {
+        match *self {
+            Self::RayFlags(v) => v,
+            ref other => panic!("Expected Operand::RayFlags, got {} instead", other),
+        }
+    }
+    pub fn unwrap_source_language(&self) -> spirv::SourceLanguage {
+        match *self {
+            Self::SourceLanguage(v) => v,
+            ref other => panic!("Expected Operand::SourceLanguage, got {} instead", other),
+        }
+    }
+    pub fn unwrap_execution_model(&self) -> spirv::ExecutionModel {
+        match *self {
+            Self::ExecutionModel(v) => v,
+            ref other => panic!("Expected Operand::ExecutionModel, got {} instead", other),
+        }
+    }
+    pub fn unwrap_addressing_model(&self) -> spirv::AddressingModel {
+        match *self {
+            Self::AddressingModel(v) => v,
+            ref other => panic!("Expected Operand::AddressingModel, got {} instead", other),
+        }
+    }
+    pub fn unwrap_memory_model(&self) -> spirv::MemoryModel {
+        match *self {
+            Self::MemoryModel(v) => v,
+            ref other => panic!("Expected Operand::MemoryModel, got {} instead", other),
+        }
+    }
+    pub fn unwrap_execution_mode(&self) -> spirv::ExecutionMode {
+        match *self {
+            Self::ExecutionMode(v) => v,
+            ref other => panic!("Expected Operand::ExecutionMode, got {} instead", other),
+        }
+    }
+    pub fn unwrap_storage_class(&self) -> spirv::StorageClass {
+        match *self {
+            Self::StorageClass(v) => v,
+            ref other => panic!("Expected Operand::StorageClass, got {} instead", other),
+        }
+    }
+    pub fn unwrap_dim(&self) -> spirv::Dim {
+        match *self {
+            Self::Dim(v) => v,
+            ref other => panic!("Expected Operand::Dim, got {} instead", other),
+        }
+    }
+    pub fn unwrap_sampler_addressing_mode(&self) -> spirv::SamplerAddressingMode {
+        match *self {
+            Self::SamplerAddressingMode(v) => v,
+            ref other => panic!(
+                "Expected Operand::SamplerAddressingMode, got {} instead",
+                other
+            ),
+        }
+    }
+    pub fn unwrap_sampler_filter_mode(&self) -> spirv::SamplerFilterMode {
+        match *self {
+            Self::SamplerFilterMode(v) => v,
+            ref other => panic!("Expected Operand::SamplerFilterMode, got {} instead", other),
+        }
+    }
+    pub fn unwrap_image_format(&self) -> spirv::ImageFormat {
+        match *self {
+            Self::ImageFormat(v) => v,
+            ref other => panic!("Expected Operand::ImageFormat, got {} instead", other),
+        }
+    }
+    pub fn unwrap_image_channel_order(&self) -> spirv::ImageChannelOrder {
+        match *self {
+            Self::ImageChannelOrder(v) => v,
+            ref other => panic!("Expected Operand::ImageChannelOrder, got {} instead", other),
+        }
+    }
+    pub fn unwrap_image_channel_data_type(&self) -> spirv::ImageChannelDataType {
+        match *self {
+            Self::ImageChannelDataType(v) => v,
+            ref other => panic!(
+                "Expected Operand::ImageChannelDataType, got {} instead",
+                other
+            ),
+        }
+    }
+    pub fn unwrap_fp_rounding_mode(&self) -> spirv::FPRoundingMode {
+        match *self {
+            Self::FPRoundingMode(v) => v,
+            ref other => panic!("Expected Operand::FPRoundingMode, got {} instead", other),
+        }
+    }
+    pub fn unwrap_linkage_type(&self) -> spirv::LinkageType {
+        match *self {
+            Self::LinkageType(v) => v,
+            ref other => panic!("Expected Operand::LinkageType, got {} instead", other),
+        }
+    }
+    pub fn unwrap_access_qualifier(&self) -> spirv::AccessQualifier {
+        match *self {
+            Self::AccessQualifier(v) => v,
+            ref other => panic!("Expected Operand::AccessQualifier, got {} instead", other),
+        }
+    }
+    pub fn unwrap_function_parameter_attribute(&self) -> spirv::FunctionParameterAttribute {
+        match *self {
+            Self::FunctionParameterAttribute(v) => v,
+            ref other => panic!(
+                "Expected Operand::FunctionParameterAttribute, got {} instead",
+                other
+            ),
+        }
+    }
+    pub fn unwrap_decoration(&self) -> spirv::Decoration {
+        match *self {
+            Self::Decoration(v) => v,
+            ref other => panic!("Expected Operand::Decoration, got {} instead", other),
+        }
+    }
+    pub fn unwrap_built_in(&self) -> spirv::BuiltIn {
+        match *self {
+            Self::BuiltIn(v) => v,
+            ref other => panic!("Expected Operand::BuiltIn, got {} instead", other),
+        }
+    }
+    pub fn unwrap_scope(&self) -> spirv::Scope {
+        match *self {
+            Self::Scope(v) => v,
+            ref other => panic!("Expected Operand::Scope, got {} instead", other),
+        }
+    }
+    pub fn unwrap_group_operation(&self) -> spirv::GroupOperation {
+        match *self {
+            Self::GroupOperation(v) => v,
+            ref other => panic!("Expected Operand::GroupOperation, got {} instead", other),
+        }
+    }
+    pub fn unwrap_kernel_enqueue_flags(&self) -> spirv::KernelEnqueueFlags {
+        match *self {
+            Self::KernelEnqueueFlags(v) => v,
+            ref other => panic!(
+                "Expected Operand::KernelEnqueueFlags, got {} instead",
+                other
+            ),
+        }
+    }
+    pub fn unwrap_capability(&self) -> spirv::Capability {
+        match *self {
+            Self::Capability(v) => v,
+            ref other => panic!("Expected Operand::Capability, got {} instead", other),
+        }
+    }
+    pub fn unwrap_ray_query_intersection(&self) -> spirv::RayQueryIntersection {
+        match *self {
+            Self::RayQueryIntersection(v) => v,
+            ref other => panic!(
+                "Expected Operand::RayQueryIntersection, got {} instead",
+                other
+            ),
+        }
+    }
+    pub fn unwrap_ray_query_committed_intersection_type(
+        &self,
+    ) -> spirv::RayQueryCommittedIntersectionType {
+        match *self {
+            Self::RayQueryCommittedIntersectionType(v) => v,
+            ref other => panic!(
+                "Expected Operand::RayQueryCommittedIntersectionType, got {} instead",
+                other
+            ),
+        }
+    }
+    pub fn unwrap_ray_query_candidate_intersection_type(
+        &self,
+    ) -> spirv::RayQueryCandidateIntersectionType {
+        match *self {
+            Self::RayQueryCandidateIntersectionType(v) => v,
+            ref other => panic!(
+                "Expected Operand::RayQueryCandidateIntersectionType, got {} instead",
+                other
+            ),
+        }
+    }
+    pub fn unwrap_id_memory_semantics(&self) -> spirv::Word {
+        match *self {
+            Self::IdMemorySemantics(v) => v,
+            ref other => panic!("Expected Operand::IdMemorySemantics, got {} instead", other),
+        }
+    }
+    pub fn unwrap_id_scope(&self) -> spirv::Word {
+        match *self {
+            Self::IdScope(v) => v,
+            ref other => panic!("Expected Operand::IdScope, got {} instead", other),
+        }
+    }
+    pub fn unwrap_id_ref(&self) -> spirv::Word {
+        match *self {
+            Self::IdRef(v) => v,
+            ref other => panic!("Expected Operand::IdRef, got {} instead", other),
+        }
+    }
+    pub fn unwrap_literal_int32(&self) -> u32 {
+        match *self {
+            Self::LiteralInt32(v) => v,
+            ref other => panic!("Expected Operand::LiteralInt32, got {} instead", other),
+        }
+    }
+    pub fn unwrap_literal_int64(&self) -> u64 {
+        match *self {
+            Self::LiteralInt64(v) => v,
+            ref other => panic!("Expected Operand::LiteralInt64, got {} instead", other),
+        }
+    }
+    pub fn unwrap_literal_float32(&self) -> f32 {
+        match *self {
+            Self::LiteralFloat32(v) => v,
+            ref other => panic!("Expected Operand::LiteralFloat32, got {} instead", other),
+        }
+    }
+    pub fn unwrap_literal_float64(&self) -> f64 {
+        match *self {
+            Self::LiteralFloat64(v) => v,
+            ref other => panic!("Expected Operand::LiteralFloat64, got {} instead", other),
+        }
+    }
+    pub fn unwrap_literal_ext_inst_integer(&self) -> u32 {
+        match *self {
+            Self::LiteralExtInstInteger(v) => v,
+            ref other => panic!(
+                "Expected Operand::LiteralExtInstInteger, got {} instead",
+                other
+            ),
+        }
+    }
+    pub fn unwrap_literal_spec_constant_op_integer(&self) -> spirv::Op {
+        match *self {
+            Self::LiteralSpecConstantOpInteger(v) => v,
+            ref other => panic!(
+                "Expected Operand::LiteralSpecConstantOpInteger, got {} instead",
+                other
+            ),
+        }
+    }
+    pub fn unwrap_literal_string(&self) -> &str {
+        match self {
+            Self::LiteralString(v) => v,
+            ref other => panic!("Expected Operand::LiteralString, got {} instead", other),
+        }
+    }
+    pub fn id_ref_any(&self) -> Option<spirv::Word> {
+        match *self {
+            Self::IdRef(v) | Self::IdScope(v) | Self::IdMemorySemantics(v) => Some(v),
+            _ => None,
+        }
+    }
+    pub fn id_ref_any_mut(&mut self) -> Option<&mut spirv::Word> {
+        match self {
+            Self::IdRef(v) | Self::IdScope(v) | Self::IdMemorySemantics(v) => Some(v),
+            _ => None,
+        }
+    }
+}

--- a/rspirv/dr/constructs.rs
+++ b/rspirv/dr/constructs.rs
@@ -242,6 +242,10 @@ impl Function {
         }
     }
 
+    pub fn def_id(&self) -> Option<Word> {
+        self.def.as_ref().and_then(|inst| inst.result_id)
+    }
+
     pub fn all_inst_iter(&self) -> impl Iterator<Item = &Instruction> {
         self.def
             .iter()

--- a/rspirv/dr/constructs.rs
+++ b/rspirv/dr/constructs.rs
@@ -267,6 +267,10 @@ impl Block {
             instructions: vec![],
         }
     }
+
+    pub fn label_id(&self) -> Option<Word> {
+        self.label.as_ref().and_then(|inst| inst.result_id)
+    }
 }
 
 impl Instruction {

--- a/rspirv/dr/constructs.rs
+++ b/rspirv/dr/constructs.rs
@@ -159,17 +159,7 @@ impl Module {
             .chain(&self.debugs)
             .chain(&self.annotations)
             .chain(&self.types_global_values)
-            .chain(self.functions.iter().flat_map(|f| {
-                f.def
-                    .iter()
-                    .chain(f.parameters.iter())
-                    .chain(
-                        f.blocks
-                            .iter()
-                            .flat_map(|b| b.label.iter().chain(b.instructions.iter())),
-                    )
-                    .chain(f.end.iter())
-            }))
+            .chain(self.functions.iter().flat_map(|f| f.all_inst_iter()))
     }
 
     /// Returns a mut iterator over all instructions.
@@ -184,17 +174,11 @@ impl Module {
             .chain(&mut self.debugs)
             .chain(&mut self.annotations)
             .chain(&mut self.types_global_values)
-            .chain(self.functions.iter_mut().flat_map(|f| {
-                f.def
+            .chain(
+                self.functions
                     .iter_mut()
-                    .chain(f.parameters.iter_mut())
-                    .chain(
-                        f.blocks
-                            .iter_mut()
-                            .flat_map(|b| b.label.iter_mut().chain(b.instructions.iter_mut())),
-                    )
-                    .chain(f.end.iter_mut())
-            }))
+                    .flat_map(|f| f.all_inst_iter_mut()),
+            )
     }
 }
 
@@ -256,6 +240,30 @@ impl Function {
             parameters: vec![],
             blocks: vec![],
         }
+    }
+
+    pub fn all_inst_iter(&self) -> impl Iterator<Item = &Instruction> {
+        self.def
+            .iter()
+            .chain(self.parameters.iter())
+            .chain(
+                self.blocks
+                    .iter()
+                    .flat_map(|b| b.label.iter().chain(b.instructions.iter())),
+            )
+            .chain(self.end.iter())
+    }
+
+    pub fn all_inst_iter_mut(&mut self) -> impl Iterator<Item = &mut Instruction> {
+        self.def
+            .iter_mut()
+            .chain(self.parameters.iter_mut())
+            .chain(
+                self.blocks
+                    .iter_mut()
+                    .flat_map(|b| b.label.iter_mut().chain(b.instructions.iter_mut())),
+            )
+            .chain(self.end.iter_mut())
     }
 }
 


### PR DESCRIPTION
1) `Operand::unwrap_*`, mostly for `unwrap_id_ref`, but also `unwrap_literal_u32` and friends is useful. Just autogenerated all of them for completeness.
2) `Operand::unwrap_id_ref_any`, useful for rewriting any and all references to another ID
3) `Function::def_id` and `Block::label_id`, the usual chain of `func.def.as_ref().unwrap().result_id.unwrap()` is painfully long.
4) `Function::all_inst_iter{,_mut}`, surprisingly useful and relevant in various places.