### PR TITLE
Image operand variable count of id refs 

### DIFF
--- a/rspirv/lift/autogen_context.rs
+++ b/rspirv/lift/autogen_context.rs
@@ -750,12 +750,10 @@ impl LiftContext {
                 .ok_or(OperandError::Missing)?,
                 image_operands: match operands.next() {
                     Some(&dr::Operand::ImageOperands(ref value)) => {
-                        let num_operands = value.bits().count_ones();
-                        let operands = (0..num_operands)
-                            .map(|_| match operands.next() {
-                                Some(&dr::Operand::IdRef(second)) => Ok(second),
-                                Some(_) => Err(OperandError::WrongType),
-                                None => Err(OperandError::Missing),
+                        let operands = operands
+                            .map(|op| match op {
+                                &dr::Operand::IdRef(second) => Ok(second),
+                                _ => Err(OperandError::WrongType),
                             })
                             .collect::<Result<Vec<_>, _>>()?;
                         Some((*value, operands))
@@ -779,12 +777,10 @@ impl LiftContext {
                 .ok_or(OperandError::Missing)?,
                 image_operands: (match operands.next() {
                     Some(&dr::Operand::ImageOperands(ref value)) => {
-                        let num_operands = value.bits().count_ones();
-                        let operands = (0..num_operands)
-                            .map(|_| match operands.next() {
-                                Some(&dr::Operand::IdRef(second)) => Ok(second),
-                                Some(_) => Err(OperandError::WrongType),
-                                None => Err(OperandError::Missing),
+                        let operands = operands
+                            .map(|op| match op {
+                                &dr::Operand::IdRef(second) => Ok(second),
+                                _ => Err(OperandError::WrongType),
                             })
                             .collect::<Result<Vec<_>, _>>()?;
                         Some((*value, operands))
@@ -815,12 +811,10 @@ impl LiftContext {
                 .ok_or(OperandError::Missing)?,
                 image_operands: match operands.next() {
                     Some(&dr::Operand::ImageOperands(ref value)) => {
-                        let num_operands = value.bits().count_ones();
-                        let operands = (0..num_operands)
-                            .map(|_| match operands.next() {
-                                Some(&dr::Operand::IdRef(second)) => Ok(second),
-                                Some(_) => Err(OperandError::WrongType),
-                                None => Err(OperandError::Missing),
+                        let operands = operands
+                            .map(|op| match op {
+                                &dr::Operand::IdRef(second) => Ok(second),
+                                _ => Err(OperandError::WrongType),
                             })
                             .collect::<Result<Vec<_>, _>>()?;
                         Some((*value, operands))
@@ -850,12 +844,10 @@ impl LiftContext {
                 .ok_or(OperandError::Missing)?,
                 image_operands: (match operands.next() {
                     Some(&dr::Operand::ImageOperands(ref value)) => {
-                        let num_operands = value.bits().count_ones();
-                        let operands = (0..num_operands)
-                            .map(|_| match operands.next() {
-                                Some(&dr::Operand::IdRef(second)) => Ok(second),
-                                Some(_) => Err(OperandError::WrongType),
-                                None => Err(OperandError::Missing),
+                        let operands = operands
+                            .map(|op| match op {
+                                &dr::Operand::IdRef(second) => Ok(second),
+                                _ => Err(OperandError::WrongType),
                             })
                             .collect::<Result<Vec<_>, _>>()?;
                         Some((*value, operands))
@@ -880,12 +872,10 @@ impl LiftContext {
                 .ok_or(OperandError::Missing)?,
                 image_operands: match operands.next() {
                     Some(&dr::Operand::ImageOperands(ref value)) => {
-                        let num_operands = value.bits().count_ones();
-                        let operands = (0..num_operands)
-                            .map(|_| match operands.next() {
-                                Some(&dr::Operand::IdRef(second)) => Ok(second),
-                                Some(_) => Err(OperandError::WrongType),
-                                None => Err(OperandError::Missing),
+                        let operands = operands
+                            .map(|op| match op {
+                                &dr::Operand::IdRef(second) => Ok(second),
+                                _ => Err(OperandError::WrongType),
                             })
                             .collect::<Result<Vec<_>, _>>()?;
                         Some((*value, operands))
@@ -909,12 +899,10 @@ impl LiftContext {
                 .ok_or(OperandError::Missing)?,
                 image_operands: (match operands.next() {
                     Some(&dr::Operand::ImageOperands(ref value)) => {
-                        let num_operands = value.bits().count_ones();
-                        let operands = (0..num_operands)
-                            .map(|_| match operands.next() {
-                                Some(&dr::Operand::IdRef(second)) => Ok(second),
-                                Some(_) => Err(OperandError::WrongType),
-                                None => Err(OperandError::Missing),
+                        let operands = operands
+                            .map(|op| match op {
+                                &dr::Operand::IdRef(second) => Ok(second),
+                                _ => Err(OperandError::WrongType),
                             })
                             .collect::<Result<Vec<_>, _>>()?;
                         Some((*value, operands))
@@ -945,12 +933,10 @@ impl LiftContext {
                 .ok_or(OperandError::Missing)?,
                 image_operands: match operands.next() {
                     Some(&dr::Operand::ImageOperands(ref value)) => {
-                        let num_operands = value.bits().count_ones();
-                        let operands = (0..num_operands)
-                            .map(|_| match operands.next() {
-                                Some(&dr::Operand::IdRef(second)) => Ok(second),
-                                Some(_) => Err(OperandError::WrongType),
-                                None => Err(OperandError::Missing),
+                        let operands = operands
+                            .map(|op| match op {
+                                &dr::Operand::IdRef(second) => Ok(second),
+                                _ => Err(OperandError::WrongType),
                             })
                             .collect::<Result<Vec<_>, _>>()?;
                         Some((*value, operands))
@@ -980,12 +966,10 @@ impl LiftContext {
                 .ok_or(OperandError::Missing)?,
                 image_operands: (match operands.next() {
                     Some(&dr::Operand::ImageOperands(ref value)) => {
-                        let num_operands = value.bits().count_ones();
-                        let operands = (0..num_operands)
-                            .map(|_| match operands.next() {
-                                Some(&dr::Operand::IdRef(second)) => Ok(second),
-                                Some(_) => Err(OperandError::WrongType),
-                                None => Err(OperandError::Missing),
+                        let operands = operands
+                            .map(|op| match op {
+                                &dr::Operand::IdRef(second) => Ok(second),
+                                _ => Err(OperandError::WrongType),
                             })
                             .collect::<Result<Vec<_>, _>>()?;
                         Some((*value, operands))
@@ -1010,12 +994,10 @@ impl LiftContext {
                 .ok_or(OperandError::Missing)?,
                 image_operands: match operands.next() {
                     Some(&dr::Operand::ImageOperands(ref value)) => {
-                        let num_operands = value.bits().count_ones();
-                        let operands = (0..num_operands)
-                            .map(|_| match operands.next() {
-                                Some(&dr::Operand::IdRef(second)) => Ok(second),
-                                Some(_) => Err(OperandError::WrongType),
-                                None => Err(OperandError::Missing),
+                        let operands = operands
+                            .map(|op| match op {
+                                &dr::Operand::IdRef(second) => Ok(second),
+                                _ => Err(OperandError::WrongType),
                             })
                             .collect::<Result<Vec<_>, _>>()?;
                         Some((*value, operands))
@@ -1045,12 +1027,10 @@ impl LiftContext {
                 .ok_or(OperandError::Missing)?,
                 image_operands: match operands.next() {
                     Some(&dr::Operand::ImageOperands(ref value)) => {
-                        let num_operands = value.bits().count_ones();
-                        let operands = (0..num_operands)
-                            .map(|_| match operands.next() {
-                                Some(&dr::Operand::IdRef(second)) => Ok(second),
-                                Some(_) => Err(OperandError::WrongType),
-                                None => Err(OperandError::Missing),
+                        let operands = operands
+                            .map(|op| match op {
+                                &dr::Operand::IdRef(second) => Ok(second),
+                                _ => Err(OperandError::WrongType),
                             })
                             .collect::<Result<Vec<_>, _>>()?;
                         Some((*value, operands))
@@ -1080,12 +1060,10 @@ impl LiftContext {
                 .ok_or(OperandError::Missing)?,
                 image_operands: match operands.next() {
                     Some(&dr::Operand::ImageOperands(ref value)) => {
-                        let num_operands = value.bits().count_ones();
-                        let operands = (0..num_operands)
-                            .map(|_| match operands.next() {
-                                Some(&dr::Operand::IdRef(second)) => Ok(second),
-                                Some(_) => Err(OperandError::WrongType),
-                                None => Err(OperandError::Missing),
+                        let operands = operands
+                            .map(|op| match op {
+                                &dr::Operand::IdRef(second) => Ok(second),
+                                _ => Err(OperandError::WrongType),
                             })
                             .collect::<Result<Vec<_>, _>>()?;
                         Some((*value, operands))
@@ -1109,12 +1087,10 @@ impl LiftContext {
                 .ok_or(OperandError::Missing)?,
                 image_operands: match operands.next() {
                     Some(&dr::Operand::ImageOperands(ref value)) => {
-                        let num_operands = value.bits().count_ones();
-                        let operands = (0..num_operands)
-                            .map(|_| match operands.next() {
-                                Some(&dr::Operand::IdRef(second)) => Ok(second),
-                                Some(_) => Err(OperandError::WrongType),
-                                None => Err(OperandError::Missing),
+                        let operands = operands
+                            .map(|op| match op {
+                                &dr::Operand::IdRef(second) => Ok(second),
+                                _ => Err(OperandError::WrongType),
                             })
                             .collect::<Result<Vec<_>, _>>()?;
                         Some((*value, operands))
@@ -1144,12 +1120,10 @@ impl LiftContext {
                 .ok_or(OperandError::Missing)?,
                 image_operands: match operands.next() {
                     Some(&dr::Operand::ImageOperands(ref value)) => {
-                        let num_operands = value.bits().count_ones();
-                        let operands = (0..num_operands)
-                            .map(|_| match operands.next() {
-                                Some(&dr::Operand::IdRef(second)) => Ok(second),
-                                Some(_) => Err(OperandError::WrongType),
-                                None => Err(OperandError::Missing),
+                        let operands = operands
+                            .map(|op| match op {
+                                &dr::Operand::IdRef(second) => Ok(second),
+                                _ => Err(OperandError::WrongType),
                             })
                             .collect::<Result<Vec<_>, _>>()?;
                         Some((*value, operands))
@@ -3928,12 +3902,10 @@ impl LiftContext {
                 .ok_or(OperandError::Missing)?,
                 image_operands: match operands.next() {
                     Some(&dr::Operand::ImageOperands(ref value)) => {
-                        let num_operands = value.bits().count_ones();
-                        let operands = (0..num_operands)
-                            .map(|_| match operands.next() {
-                                Some(&dr::Operand::IdRef(second)) => Ok(second),
-                                Some(_) => Err(OperandError::WrongType),
-                                None => Err(OperandError::Missing),
+                        let operands = operands
+                            .map(|op| match op {
+                                &dr::Operand::IdRef(second) => Ok(second),
+                                _ => Err(OperandError::WrongType),
                             })
                             .collect::<Result<Vec<_>, _>>()?;
                         Some((*value, operands))
@@ -3957,12 +3929,10 @@ impl LiftContext {
                 .ok_or(OperandError::Missing)?,
                 image_operands: (match operands.next() {
                     Some(&dr::Operand::ImageOperands(ref value)) => {
-                        let num_operands = value.bits().count_ones();
-                        let operands = (0..num_operands)
-                            .map(|_| match operands.next() {
-                                Some(&dr::Operand::IdRef(second)) => Ok(second),
-                                Some(_) => Err(OperandError::WrongType),
-                                None => Err(OperandError::Missing),
+                        let operands = operands
+                            .map(|op| match op {
+                                &dr::Operand::IdRef(second) => Ok(second),
+                                _ => Err(OperandError::WrongType),
                             })
                             .collect::<Result<Vec<_>, _>>()?;
                         Some((*value, operands))
@@ -3993,12 +3963,10 @@ impl LiftContext {
                 .ok_or(OperandError::Missing)?,
                 image_operands: match operands.next() {
                     Some(&dr::Operand::ImageOperands(ref value)) => {
-                        let num_operands = value.bits().count_ones();
-                        let operands = (0..num_operands)
-                            .map(|_| match operands.next() {
-                                Some(&dr::Operand::IdRef(second)) => Ok(second),
-                                Some(_) => Err(OperandError::WrongType),
-                                None => Err(OperandError::Missing),
+                        let operands = operands
+                            .map(|op| match op {
+                                &dr::Operand::IdRef(second) => Ok(second),
+                                _ => Err(OperandError::WrongType),
                             })
                             .collect::<Result<Vec<_>, _>>()?;
                         Some((*value, operands))
@@ -4028,12 +3996,10 @@ impl LiftContext {
                 .ok_or(OperandError::Missing)?,
                 image_operands: (match operands.next() {
                     Some(&dr::Operand::ImageOperands(ref value)) => {
-                        let num_operands = value.bits().count_ones();
-                        let operands = (0..num_operands)
-                            .map(|_| match operands.next() {
-                                Some(&dr::Operand::IdRef(second)) => Ok(second),
-                                Some(_) => Err(OperandError::WrongType),
-                                None => Err(OperandError::Missing),
+                        let operands = operands
+                            .map(|op| match op {
+                                &dr::Operand::IdRef(second) => Ok(second),
+                                _ => Err(OperandError::WrongType),
                             })
                             .collect::<Result<Vec<_>, _>>()?;
                         Some((*value, operands))
@@ -4058,12 +4024,10 @@ impl LiftContext {
                 .ok_or(OperandError::Missing)?,
                 image_operands: match operands.next() {
                     Some(&dr::Operand::ImageOperands(ref value)) => {
-                        let num_operands = value.bits().count_ones();
-                        let operands = (0..num_operands)
-                            .map(|_| match operands.next() {
-                                Some(&dr::Operand::IdRef(second)) => Ok(second),
-                                Some(_) => Err(OperandError::WrongType),
-                                None => Err(OperandError::Missing),
+                        let operands = operands
+                            .map(|op| match op {
+                                &dr::Operand::IdRef(second) => Ok(second),
+                                _ => Err(OperandError::WrongType),
                             })
                             .collect::<Result<Vec<_>, _>>()?;
                         Some((*value, operands))
@@ -4087,12 +4051,10 @@ impl LiftContext {
                 .ok_or(OperandError::Missing)?,
                 image_operands: (match operands.next() {
                     Some(&dr::Operand::ImageOperands(ref value)) => {
-                        let num_operands = value.bits().count_ones();
-                        let operands = (0..num_operands)
-                            .map(|_| match operands.next() {
-                                Some(&dr::Operand::IdRef(second)) => Ok(second),
-                                Some(_) => Err(OperandError::WrongType),
-                                None => Err(OperandError::Missing),
+                        let operands = operands
+                            .map(|op| match op {
+                                &dr::Operand::IdRef(second) => Ok(second),
+                                _ => Err(OperandError::WrongType),
                             })
                             .collect::<Result<Vec<_>, _>>()?;
                         Some((*value, operands))
@@ -4123,12 +4085,10 @@ impl LiftContext {
                 .ok_or(OperandError::Missing)?,
                 image_operands: match operands.next() {
                     Some(&dr::Operand::ImageOperands(ref value)) => {
-                        let num_operands = value.bits().count_ones();
-                        let operands = (0..num_operands)
-                            .map(|_| match operands.next() {
-                                Some(&dr::Operand::IdRef(second)) => Ok(second),
-                                Some(_) => Err(OperandError::WrongType),
-                                None => Err(OperandError::Missing),
+                        let operands = operands
+                            .map(|op| match op {
+                                &dr::Operand::IdRef(second) => Ok(second),
+                                _ => Err(OperandError::WrongType),
                             })
                             .collect::<Result<Vec<_>, _>>()?;
                         Some((*value, operands))
@@ -4158,12 +4118,10 @@ impl LiftContext {
                 .ok_or(OperandError::Missing)?,
                 image_operands: (match operands.next() {
                     Some(&dr::Operand::ImageOperands(ref value)) => {
-                        let num_operands = value.bits().count_ones();
-                        let operands = (0..num_operands)
-                            .map(|_| match operands.next() {
-                                Some(&dr::Operand::IdRef(second)) => Ok(second),
-                                Some(_) => Err(OperandError::WrongType),
-                                None => Err(OperandError::Missing),
+                        let operands = operands
+                            .map(|op| match op {
+                                &dr::Operand::IdRef(second) => Ok(second),
+                                _ => Err(OperandError::WrongType),
                             })
                             .collect::<Result<Vec<_>, _>>()?;
                         Some((*value, operands))
@@ -4188,12 +4146,10 @@ impl LiftContext {
                 .ok_or(OperandError::Missing)?,
                 image_operands: match operands.next() {
                     Some(&dr::Operand::ImageOperands(ref value)) => {
-                        let num_operands = value.bits().count_ones();
-                        let operands = (0..num_operands)
-                            .map(|_| match operands.next() {
-                                Some(&dr::Operand::IdRef(second)) => Ok(second),
-                                Some(_) => Err(OperandError::WrongType),
-                                None => Err(OperandError::Missing),
+                        let operands = operands
+                            .map(|op| match op {
+                                &dr::Operand::IdRef(second) => Ok(second),
+                                _ => Err(OperandError::WrongType),
                             })
                             .collect::<Result<Vec<_>, _>>()?;
                         Some((*value, operands))
@@ -4223,12 +4179,10 @@ impl LiftContext {
                 .ok_or(OperandError::Missing)?,
                 image_operands: match operands.next() {
                     Some(&dr::Operand::ImageOperands(ref value)) => {
-                        let num_operands = value.bits().count_ones();
-                        let operands = (0..num_operands)
-                            .map(|_| match operands.next() {
-                                Some(&dr::Operand::IdRef(second)) => Ok(second),
-                                Some(_) => Err(OperandError::WrongType),
-                                None => Err(OperandError::Missing),
+                        let operands = operands
+                            .map(|op| match op {
+                                &dr::Operand::IdRef(second) => Ok(second),
+                                _ => Err(OperandError::WrongType),
                             })
                             .collect::<Result<Vec<_>, _>>()?;
                         Some((*value, operands))
@@ -4258,12 +4212,10 @@ impl LiftContext {
                 .ok_or(OperandError::Missing)?,
                 image_operands: match operands.next() {
                     Some(&dr::Operand::ImageOperands(ref value)) => {
-                        let num_operands = value.bits().count_ones();
-                        let operands = (0..num_operands)
-                            .map(|_| match operands.next() {
-                                Some(&dr::Operand::IdRef(second)) => Ok(second),
-                                Some(_) => Err(OperandError::WrongType),
-                                None => Err(OperandError::Missing),
+                        let operands = operands
+                            .map(|op| match op {
+                                &dr::Operand::IdRef(second) => Ok(second),
+                                _ => Err(OperandError::WrongType),
                             })
                             .collect::<Result<Vec<_>, _>>()?;
                         Some((*value, operands))
@@ -4336,12 +4288,10 @@ impl LiftContext {
                 .ok_or(OperandError::Missing)?,
                 image_operands: match operands.next() {
                     Some(&dr::Operand::ImageOperands(ref value)) => {
-                        let num_operands = value.bits().count_ones();
-                        let operands = (0..num_operands)
-                            .map(|_| match operands.next() {
-                                Some(&dr::Operand::IdRef(second)) => Ok(second),
-                                Some(_) => Err(OperandError::WrongType),
-                                None => Err(OperandError::Missing),
+                        let operands = operands
+                            .map(|op| match op {
+                                &dr::Operand::IdRef(second) => Ok(second),
+                                _ => Err(OperandError::WrongType),
                             })
                             .collect::<Result<Vec<_>, _>>()?;
                         Some((*value, operands))
@@ -5720,12 +5670,10 @@ impl LiftContext {
                 .ok_or(OperandError::Missing)?,
                 image_operands: match operands.next() {
                     Some(&dr::Operand::ImageOperands(ref value)) => {
-                        let num_operands = value.bits().count_ones();
-                        let operands = (0..num_operands)
-                            .map(|_| match operands.next() {
-                                Some(&dr::Operand::IdRef(second)) => Ok(second),
-                                Some(_) => Err(OperandError::WrongType),
-                                None => Err(OperandError::Missing),
+                        let operands = operands
+                            .map(|op| match op {
+                                &dr::Operand::IdRef(second) => Ok(second),
+                                _ => Err(OperandError::WrongType),
                             })
                             .collect::<Result<Vec<_>, _>>()?;
                         Some((*value, operands))


### PR DESCRIPTION
The number of id refs per operand is variable instead of one per bitflag.
`Grad` takes 2 and some newer operands from extensions don't have any IdRef associated with them.
This basically requires that ImageOperands kind of a terminator as we consume all trailing operands.