### PR TITLE
Add support for generating OpTypeAccelerationStructureKHR

### DIFF
--- a/autogen/src/main.rs
+++ b/autogen/src/main.rs
@@ -44,7 +44,9 @@ fn map_reserved_instructions(grammar: &mut structs::Grammar) {
         .filter(|i| i.class == Some(structs::Class::Reserved))
     {
         match &*instruction.opname {
-            "OpTypeAccelerationStructureKHR" => instruction.class = Some(structs::Class::Type),
+            | "OpTypeAccelerationStructureKHR"
+            | "OpTypeRayQueryKHR"
+                => instruction.class = Some(structs::Class::Type),
             _ => {}
         }
     }

--- a/rspirv/dr/build/autogen_type.rs
+++ b/rspirv/dr/build/autogen_type.rs
@@ -345,4 +345,17 @@ impl Builder {
             new_id
         }
     }
+    #[doc = "Appends an OpTypeAccelerationStructureKHR instruction and returns the result id, or return the existing id if the instruction was already present."]
+    pub fn type_acceleration_structure_khr(&mut self) -> spirv::Word {
+        let mut inst =
+            dr::Instruction::new(spirv::Op::TypeAccelerationStructureKHR, None, None, vec![]);
+        if let Some(id) = self.dedup_insert_type(&inst) {
+            id
+        } else {
+            let new_id = self.id();
+            inst.result_id = Some(new_id);
+            self.module.types_global_values.push(inst);
+            new_id
+        }
+    }
 }

--- a/rspirv/dr/build/autogen_type.rs
+++ b/rspirv/dr/build/autogen_type.rs
@@ -345,6 +345,18 @@ impl Builder {
             new_id
         }
     }
+    #[doc = "Appends an OpTypeRayQueryKHR instruction and returns the result id, or return the existing id if the instruction was already present."]
+    pub fn type_ray_query_khr(&mut self) -> spirv::Word {
+        let mut inst = dr::Instruction::new(spirv::Op::TypeRayQueryKHR, None, None, vec![]);
+        if let Some(id) = self.dedup_insert_type(&inst) {
+            id
+        } else {
+            let new_id = self.id();
+            inst.result_id = Some(new_id);
+            self.module.types_global_values.push(inst);
+            new_id
+        }
+    }
     #[doc = "Appends an OpTypeAccelerationStructureKHR instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_acceleration_structure_khr(&mut self) -> spirv::Word {
         let mut inst =

--- a/rspirv/lift/autogen_context.rs
+++ b/rspirv/lift/autogen_context.rs
@@ -5338,7 +5338,6 @@ impl LiftContext {
                 })
                 .ok_or(OperandError::Missing)?,
             }),
-            4472u32 => Ok(ops::Op::TypeRayQueryKHR),
             4473u32 => Ok(ops::Op::RayQueryInitializeKHR {
                 ray_query: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
@@ -8576,6 +8575,7 @@ impl LiftContext {
             }),
             322u32 => Ok(Type::PipeStorage),
             327u32 => Ok(Type::NamedBarrier),
+            4472u32 => Ok(Type::RayQueryKHR),
             5341u32 => Ok(Type::AccelerationStructureKHR),
             _ => Err(InstructionError::WrongOpcode),
         }

--- a/rspirv/lift/autogen_context.rs
+++ b/rspirv/lift/autogen_context.rs
@@ -5803,7 +5803,6 @@ impl LiftContext {
                 .ok_or(OperandError::Missing)?,
             }),
             5341u32 => Ok(ops::Op::TypeAccelerationStructureNV),
-            5341u32 => Ok(ops::Op::TypeAccelerationStructureKHR),
             5344u32 => Ok(ops::Op::ExecuteCallableNV {
                 sbt_index: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
@@ -8577,6 +8576,7 @@ impl LiftContext {
             }),
             322u32 => Ok(Type::PipeStorage),
             327u32 => Ok(Type::NamedBarrier),
+            5341u32 => Ok(Type::AccelerationStructureKHR),
             _ => Err(InstructionError::WrongOpcode),
         }
     }

--- a/rspirv/sr/autogen_ops.rs
+++ b/rspirv/sr/autogen_ops.rs
@@ -1363,7 +1363,6 @@ pub enum Op {
     ConvertUToAccelerationStructureKHR {
         accel: spirv::Word,
     },
-    TypeRayQueryKHR,
     RayQueryInitializeKHR {
         ray_query: spirv::Word,
         accel: spirv::Word,

--- a/rspirv/sr/autogen_ops.rs
+++ b/rspirv/sr/autogen_ops.rs
@@ -1481,7 +1481,6 @@ pub enum Op {
         payload_id: spirv::Word,
     },
     TypeAccelerationStructureNV,
-    TypeAccelerationStructureKHR,
     ExecuteCallableNV {
         sbt_index: spirv::Word,
         callable_data_id: spirv::Word,

--- a/rspirv/sr/autogen_types.rs
+++ b/rspirv/sr/autogen_types.rs
@@ -69,5 +69,6 @@ pub enum Type {
     },
     PipeStorage,
     NamedBarrier,
+    RayQueryKHR,
     AccelerationStructureKHR,
 }

--- a/rspirv/sr/autogen_types.rs
+++ b/rspirv/sr/autogen_types.rs
@@ -69,4 +69,5 @@ pub enum Type {
     },
     PipeStorage,
     NamedBarrier,
+    AccelerationStructureKHR,
 }


### PR DESCRIPTION
This PR adds support for `OpTypeAccelerationStructureKHR` by adding a small pass to manually map reserved functions into another class, so that the methods for those ops can be properly generated.

See also https://github.com/EmbarkStudios/rust-gpu/pull/563 which uses this change.