### PR TITLE
Implement partial OpLine support

### DIFF
--- a/rspirv/dr/build/autogen_debug.rs
+++ b/rspirv/dr/build/autogen_debug.rs
@@ -12,7 +12,7 @@ impl Builder {
             None,
             vec![dr::Operand::LiteralString(continued_source.into())],
         );
-        self.module.debugs.push(inst);
+        self.module.debug_string_source.push(inst);
     }
     #[doc = "Appends an OpSource instruction."]
     pub fn source(
@@ -40,7 +40,7 @@ impl Builder {
             #[allow(clippy::identity_conversion)]
             inst.operands.push(dr::Operand::LiteralString(v.into()));
         }
-        self.module.debugs.push(inst);
+        self.module.debug_string_source.push(inst);
     }
     #[doc = "Appends an OpSourceExtension instruction."]
     pub fn source_extension(&mut self, extension: impl Into<String>) {
@@ -51,7 +51,7 @@ impl Builder {
             None,
             vec![dr::Operand::LiteralString(extension.into())],
         );
-        self.module.debugs.push(inst);
+        self.module.debug_string_source.push(inst);
     }
     #[doc = "Appends an OpName instruction."]
     pub fn name(&mut self, target: spirv::Word, name: impl Into<String>) {
@@ -65,7 +65,7 @@ impl Builder {
                 dr::Operand::LiteralString(name.into()),
             ],
         );
-        self.module.debugs.push(inst);
+        self.module.debug_names.push(inst);
     }
     #[doc = "Appends an OpMemberName instruction."]
     pub fn member_name(&mut self, ty: spirv::Word, member: u32, name: impl Into<String>) {
@@ -80,28 +80,7 @@ impl Builder {
                 dr::Operand::LiteralString(name.into()),
             ],
         );
-        self.module.debugs.push(inst);
-    }
-    #[doc = "Appends an OpLine instruction."]
-    pub fn line(&mut self, file: spirv::Word, line: u32, column: u32) {
-        #[allow(unused_mut)]
-        let mut inst = dr::Instruction::new(
-            spirv::Op::Line,
-            None,
-            None,
-            vec![
-                dr::Operand::IdRef(file),
-                dr::Operand::LiteralInt32(line),
-                dr::Operand::LiteralInt32(column),
-            ],
-        );
-        self.module.debugs.push(inst);
-    }
-    #[doc = "Appends an OpNoLine instruction."]
-    pub fn no_line(&mut self) {
-        #[allow(unused_mut)]
-        let mut inst = dr::Instruction::new(spirv::Op::NoLine, None, None, vec![]);
-        self.module.debugs.push(inst);
+        self.module.debug_names.push(inst);
     }
     #[doc = "Appends an OpModuleProcessed instruction."]
     pub fn module_processed(&mut self, process: impl Into<String>) {
@@ -112,6 +91,6 @@ impl Builder {
             None,
             vec![dr::Operand::LiteralString(process.into())],
         );
-        self.module.debugs.push(inst);
+        self.module.debug_module_processed.push(inst);
     }
 }

--- a/rspirv/dr/build/mod.rs
+++ b/rspirv/dr/build/mod.rs
@@ -603,10 +603,10 @@ impl Builder {
         Ok(_id)
     }
 
-    /// Appends an OpLine instruction.
+    /// Appends an `OpLine` instruction.
     ///
-    /// If a block is currently selected, the OpLine is inserted into that block. If no block is
-    /// currently selected, the OpLine is inserted into types_global_values.
+    /// If a block is currently selected, the `OpLine` is inserted into that block. If no block is
+    /// currently selected, the `OpLine` is inserted into `types_global_values`.
     pub fn line(&mut self, file: spirv::Word, line: u32, column: u32) {
         let inst = dr::Instruction::new(
             spirv::Op::Line,
@@ -628,10 +628,10 @@ impl Builder {
         }
     }
 
-    /// Appends an OpNoLine instruction.
+    /// Appends an `OpNoLine` instruction.
     ///
-    /// If a block is currently selected, the OpLine is inserted into that block. If no block is
-    /// currently selected, the OpLine is inserted into types_global_values.
+    /// If a block is currently selected, the `OpNoLine` is inserted into that block. If no block
+    /// is currently selected, the `OpNoLine` is inserted into `types_global_values`.
     pub fn no_line(&mut self) {
         let inst = dr::Instruction::new(spirv::Op::NoLine, None, None, vec![]);
         if self.selected_block.is_some() {

--- a/rspirv/dr/build/mod.rs
+++ b/rspirv/dr/build/mod.rs
@@ -954,7 +954,9 @@ mod tests {
             + module.entry_points.len()
             + module.types_global_values.len()
             + module.execution_modes.len()
-            + module.debugs.len()
+            + module.debug_string_source.len()
+            + module.debug_names.len()
+            + module.debug_module_processed.len()
             + module.annotations.len())
             + (if module.memory_model.is_some() { 1 } else { 0 })
             == 1

--- a/rspirv/dr/constructs.rs
+++ b/rspirv/dr/constructs.rs
@@ -34,8 +34,12 @@ pub struct Module {
     pub entry_points: Vec<Instruction>,
     /// All execution mode declarations, using OpExecutionMode.
     pub execution_modes: Vec<Instruction>,
-    /// All non-location debug instructions.
-    pub debugs: Vec<Instruction>,
+    /// Debug subsection: All OpString, OpSourceExtension, OpSource, and OpSourceContinued.
+    pub debug_string_source: Vec<Instruction>,
+    /// Debug subsection: All OpName and all OpMemberName.
+    pub debug_names: Vec<Instruction>,
+    /// Debug subsection: All OpModuleProcessed instructions.
+    pub debug_module_processed: Vec<Instruction>,
     /// All annotation instructions.
     pub annotations: Vec<Instruction>,
     /// All types, constants, and global variables.
@@ -112,7 +116,9 @@ impl Module {
             memory_model: None,
             entry_points: vec![],
             execution_modes: vec![],
-            debugs: vec![],
+            debug_string_source: vec![],
+            debug_names: vec![],
+            debug_module_processed: vec![],
             annotations: vec![],
             types_global_values: vec![],
             functions: vec![],
@@ -128,7 +134,9 @@ impl Module {
             .chain(&self.memory_model)
             .chain(&self.entry_points)
             .chain(&self.execution_modes)
-            .chain(&self.debugs)
+            .chain(&self.debug_string_source)
+            .chain(&self.debug_names)
+            .chain(&self.debug_module_processed)
             .chain(&self.annotations)
             .chain(&self.types_global_values)
     }
@@ -142,7 +150,9 @@ impl Module {
             .chain(&mut self.memory_model)
             .chain(&mut self.entry_points)
             .chain(&mut self.execution_modes)
-            .chain(&mut self.debugs)
+            .chain(&mut self.debug_string_source)
+            .chain(&mut self.debug_names)
+            .chain(&mut self.debug_module_processed)
             .chain(&mut self.annotations)
             .chain(&mut self.types_global_values)
     }
@@ -156,7 +166,9 @@ impl Module {
             .chain(&self.memory_model)
             .chain(&self.entry_points)
             .chain(&self.execution_modes)
-            .chain(&self.debugs)
+            .chain(&self.debug_string_source)
+            .chain(&self.debug_names)
+            .chain(&self.debug_module_processed)
             .chain(&self.annotations)
             .chain(&self.types_global_values)
             .chain(self.functions.iter().flat_map(|f| f.all_inst_iter()))
@@ -171,7 +183,9 @@ impl Module {
             .chain(&mut self.memory_model)
             .chain(&mut self.entry_points)
             .chain(&mut self.execution_modes)
-            .chain(&mut self.debugs)
+            .chain(&mut self.debug_string_source)
+            .chain(&mut self.debug_names)
+            .chain(&mut self.debug_module_processed)
             .chain(&mut self.annotations)
             .chain(&mut self.types_global_values)
             .chain(


### PR DESCRIPTION
This implements partial OpLine support. "Partial" because this only supports OpLine in two places: in types_global_values, and inside basic blocks. In reality, OpLine is allowed in types_global_values, inside basic blocks, but also between basic blocks, in the OpFunctionParameter header, between functions, after all functions, and all sorts of other wacky locations. Supporting all those wacky locations would take a fairly significant refactor (for example, adding a `Vec<Instruction>` in basic blocks for "OpLine/OpNoLines preceding the OpLabel instruction" - because yes, there can be multiple, if we want to faithfully represent all valid spir-v modules)

Turns out, though, this partial support is kind of all that we need in rust-gpu, we don't need to represent wacky shenanigans, so I'll leave the full refactor work up to whoever needs that functionality in the future :)

Additionally, the debug section needs to be split up into its three component subsections to not intermix OpString and OpName instructions (which, OpString is relevant to OpLine because that's how the source file is specified). The spec states:

> 7. These debug instructions, which must be grouped **in the following order**:
>    a. All OpString, OpSourceExtension, OpSource, and OpSourceContinued, without forward references.
>    b. All OpName and all OpMemberName.
>    c. All OpModuleProcessed instructions.

I don't know why they didn't just make it three distinct "top-level" sections, because that's essentially what these subsections are, and it just causes a lot of confusion. Anyway, unfortunately, splitting up the subsections is a breaking change, so reviewers should be aware of that and consider alternatives (but I think a breaking change is the right way to go here).