### PR TITLE
Make cargo clippy be clean

### DIFF
--- a/autogen/src/binary.rs
+++ b/autogen/src/binary.rs
@@ -49,11 +49,11 @@ pub fn gen_operand_decode_errors(grammar: &[structs::OperandKind]) -> TokenStrea
     });
 
     quote! {
-        use spirv;
         use std::{error, fmt};
 
         #[doc = "Decoder Error"]
         #[derive(Debug, PartialEq)]
+        #[allow(clippy::upper_case_acronyms)]
         pub enum Error {
             StreamExpected(usize),
             LimitReached(usize),

--- a/autogen/src/dr.rs
+++ b/autogen/src/dr.rs
@@ -131,10 +131,17 @@ fn get_push_extras(
                 structs::Quantifier::One => None,
                 structs::Quantifier::ZeroOrOne => {
                     let kind = get_dr_operand_kind(&param.kind);
-                    Some(quote! {
-                        if let Some(v) = #name {
-                            #[allow(clippy::identity_conversion)]
-                            #container.push(dr::Operand::#kind(v.into()));
+                    Some(if kind == "LiteralString" {
+                        quote! {
+                            if let Some(v) = #name {
+                                #container.push(dr::Operand::LiteralString(v.into()));
+                            }
+                        }
+                    } else {
+                        quote! {
+                            if let Some(v) = #name {
+                                #container.push(dr::Operand::#kind(v));
+                            }
                         }
                     })
                 }
@@ -270,6 +277,7 @@ pub fn gen_dr_operand_kinds(grammar: &[structs::OperandKind]) -> TokenStream {
         quote! {
             #[doc = "Data representation of a SPIR-V operand."]
             #[derive(Clone, Debug, PartialEq, From)]
+            #[allow(clippy::upper_case_acronyms)]
             pub enum Operand {
                 #(#kinds,)*
             }
@@ -479,68 +487,66 @@ pub fn gen_dr_operand_kinds(grammar: &[structs::OperandKind]) -> TokenStream {
 
                 let operands = if operand_clauses.is_empty() {
                     quote! {}
-                }else {
-                    if category == &structs::Category::BitEnum {
-                        let operands = operand_clauses
-                            .into_iter()
-                            .map(|(k, v)| {
-                                let operands = k.iter().map(|op| {
-                                    let kind = as_ident(&op.kind);
-                                    let quant = translate_quant(op.quantifier);
-
-                                    quote! {
-                                        crate::grammar::LogicalOperand {
-                                            kind: crate::grammar::OperandKind::#kind,
-                                            quantifier: #quant
-                                        }
-                                    }
-                                });
-
-                                let kinds = std::iter::repeat(quote! { s::#kind });
+                } else if category == &structs::Category::BitEnum {
+                    let operands = operand_clauses
+                        .into_iter()
+                        .map(|(k, v)| {
+                            let operands = k.iter().map(|op| {
+                                let kind = as_ident(&op.kind);
+                                let quant = translate_quant(op.quantifier);
 
                                 quote! {
-                                    result.extend([#(#kinds::#v,)*].iter().filter(|arg| {
-                                        v.contains(**arg)
-                                    }).flat_map(|_| { [#( #operands ),*].iter().cloned() }))
+                                    crate::grammar::LogicalOperand {
+                                        kind: crate::grammar::OperandKind::#kind,
+                                        quantifier: #quant
+                                    }
                                 }
                             });
 
-                        quote! {
-                            Self::#kind(v) => {
-                                let mut result = vec![];
-                                #( #operands );*;
-                                result
+                            let kinds = std::iter::repeat(quote! { s::#kind });
+
+                            quote! {
+                                result.extend([#(#kinds::#v,)*].iter().filter(|arg| {
+                                    v.contains(**arg)
+                                }).flat_map(|_| { [#( #operands ),*].iter().cloned() }))
                             }
+                        });
+
+                    quote! {
+                        Self::#kind(v) => {
+                            let mut result = vec![];
+                            #( #operands );*;
+                            result
                         }
-                    } else {
-                        let operands = operand_clauses
-                            .into_iter()
-                            .map(|(k, v)| {
-                                let operands = k.iter().map(|op| {
-                                    let kind = as_ident(&op.kind);
-                                    let quant = translate_quant(op.quantifier);
-
-                                    quote! {
-                                        crate::grammar::LogicalOperand {
-                                            kind: crate::grammar::OperandKind::#kind,
-                                            quantifier: #quant
-                                        }
-                                    }
-                                });
-
-                                let kinds = std::iter::repeat(quote! { s::#kind });
+                    }
+                } else {
+                    let operands = operand_clauses
+                        .into_iter()
+                        .map(|(k, v)| {
+                            let operands = k.iter().map(|op| {
+                                let kind = as_ident(&op.kind);
+                                let quant = translate_quant(op.quantifier);
 
                                 quote! {
-                                    #( #kinds::#v )|* => vec![#( #operands ),*]
+                                    crate::grammar::LogicalOperand {
+                                        kind: crate::grammar::OperandKind::#kind,
+                                        quantifier: #quant
+                                    }
                                 }
                             });
 
-                        quote! {
-                            Self::#kind(v) => match v {
-                                #( #operands ),*,
-                                _ => vec![]
-                            },
-                        }
+                            let kinds = std::iter::repeat(quote! { s::#kind });
+
+                            quote! {
+                                #( #kinds::#v )|* => vec![#( #operands ),*]
+                            }
+                        });
+
+                    quote! {
+                        Self::#kind(v) => match v {
+                            #( #operands ),*,
+                            _ => vec![]
+                        },
                     }
                 };
 

--- a/autogen/src/dr.rs
+++ b/autogen/src/dr.rs
@@ -104,11 +104,12 @@ fn get_init_list(params: &[structs::Operand]) -> Vec<TokenStream> {
                 } else {
                     let name = get_param_name(params, param_index);
                     let kind = get_dr_operand_kind(&param.kind);
-                    Some(if kind == "LiteralString" {
-                        quote! { dr::Operand::LiteralString(#name.into()) }
+                    let value = if kind == "LiteralString" {
+                        quote! { #name.into() }
                     } else {
-                        quote! { dr::Operand::#kind(#name) }
-                    })
+                        quote! { #name }
+                    };
+                    Some(quote! { dr::Operand::#kind(#value) })
                 }
             } else {
                 None
@@ -131,17 +132,14 @@ fn get_push_extras(
                 structs::Quantifier::One => None,
                 structs::Quantifier::ZeroOrOne => {
                     let kind = get_dr_operand_kind(&param.kind);
-                    Some(if kind == "LiteralString" {
-                        quote! {
-                            if let Some(v) = #name {
-                                #container.push(dr::Operand::LiteralString(v.into()));
-                            }
-                        }
+                    let value = if kind == "LiteralString" {
+                        quote! { v.into() }
                     } else {
-                        quote! {
-                            if let Some(v) = #name {
-                                #container.push(dr::Operand::#kind(v));
-                            }
+                        quote! { v }
+                    };
+                    Some(quote! {
+                        if let Some(v) = #name {
+                            #container.push(dr::Operand::#kind(#value));
                         }
                     })
                 }

--- a/autogen/src/header.rs
+++ b/autogen/src/header.rs
@@ -201,6 +201,7 @@ fn gen_value_enum_operand_kind(grammar: &structs::OperandKind) -> TokenStream {
     quote! {
         #[doc = #comment]
         #attribute
+        #[allow(clippy::upper_case_acronyms)]
         pub enum #kind {
             #(#enumerants),*
         }
@@ -288,10 +289,12 @@ pub fn gen_spirv_header(grammar: &structs::Grammar) -> TokenStream {
 
         #[doc = #comment]
         #attribute
+        #[allow(clippy::upper_case_acronyms)]
         pub enum Op {
             #(#opcodes),*
         }
 
+        #[allow(clippy::upper_case_acronyms)]
         #[allow(non_upper_case_globals)]
         impl Op {
             #(#aliases)*
@@ -331,6 +334,7 @@ pub fn gen_glsl_std_450_opcodes(grammar: &structs::ExtInstSetGrammar) -> TokenSt
     quote! {
         #[doc = #comment]
         #attribute
+        #[allow(clippy::upper_case_acronyms)]
         pub enum GLOp {
             #(#opcodes),*
         }
@@ -369,6 +373,7 @@ pub fn gen_opencl_std_opcodes(grammar: &structs::ExtInstSetGrammar) -> TokenStre
     quote! {
         #[doc = #comment]
         #attribute
+        #[allow(clippy::upper_case_acronyms)]
         pub enum CLOp {
             #(#opcodes),*
         }

--- a/autogen/src/main.rs
+++ b/autogen/src/main.rs
@@ -11,18 +11,18 @@ mod utils;
 use std::{
     env, fs,
     io::{Read, Write},
-    path::PathBuf,
+    path::{Path, PathBuf},
     process,
 };
 use utils::write_autogen_comment;
 
-fn write(path: &PathBuf, contents: impl ToString) {
+fn write(path: &Path, contents: impl ToString) {
     let mut f = fs::File::create(path).unwrap_or_else(|_| panic!("cannot open file: {:?}", path));
     write_autogen_comment(&mut f);
     write!(f, "{}", contents.to_string()).unwrap()
 }
 
-fn write_formatted(path: &PathBuf, contents: impl ToString) {
+fn write_formatted(path: &Path, contents: impl ToString) {
     write(path, contents);
     match process::Command::new("rustfmt").arg(path).status() {
         Ok(status) if !status.success() => {

--- a/autogen/src/sr.rs
+++ b/autogen/src/sr.rs
@@ -176,7 +176,7 @@ impl OperandTokens {
                 quote! {
                     match #iter.next() {
                         Some(&dr::Operand::#key(ref value)) => Some(#lift_value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     }
                 }
@@ -189,7 +189,7 @@ impl OperandTokens {
                     match (#iter.next(), #iter.next()) {
                         (Some(&dr::Operand::#first_key(first)), Some(&dr::Operand::#second_key(second))) => Some(#lift_value),
                         (None, None) => None,
-                        _ => Err(OperandError::WrongType)?,
+                        _ => return Err(OperandError::WrongType.into()),
                     }
                 }
             }
@@ -201,14 +201,14 @@ impl OperandTokens {
                     match #iter.next() {
                         Some(&dr::Operand::#first_key(ref value)) => {
                             let operands = #iter.map(|op| {
-                                match op {
-                                    &dr::Operand::#second_key(second) => Ok(second),
+                                match *op {
+                                    dr::Operand::#second_key(second) => Ok(second),
                                     _ => Err(OperandError::WrongType),
                                 }
                             }).collect::<Result<Vec<_>, _>>()?;
                             Some((*value, operands))
                         },
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     }
                 }
@@ -274,7 +274,7 @@ pub fn gen_sr_code_from_operand_kind_grammar(
         })
         .collect();
     let tokens = quote! {
-        use spirv;
+        #![allow(clippy::upper_case_acronyms)]
 
         /// SPIR-V decorations.
         #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
@@ -481,6 +481,7 @@ pub fn gen_sr_code_from_instruction_grammar(
     }
 
     let types = quote! {
+        #[allow(clippy::upper_case_acronyms)]
         #[derive(Clone, Debug)]
         pub enum Type {
             #( #type_variants ),*
@@ -500,12 +501,14 @@ pub fn gen_sr_code_from_instruction_grammar(
         }
 
         #[derive(Clone, Debug, Eq, PartialEq)]
+        #[allow(clippy::upper_case_acronyms)]
         pub enum Terminator {
             Branch(Branch),
             #( #terminator_variants ),*
         }
 
         #[derive(Clone, Debug, Eq, PartialEq)]
+        #[allow(clippy::upper_case_acronyms)]
         pub enum Op {
             #( #op_variants ),*
         }

--- a/autogen/src/table.rs
+++ b/autogen/src/table.rs
@@ -74,6 +74,7 @@ pub fn gen_grammar_inst_table_operand_kinds(grammar: &structs::Grammar) -> Token
     quote! {
         #[doc = "All operand kinds in the SPIR-V grammar."]
         #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+        #[allow(clippy::upper_case_acronyms)]
         pub enum OperandKind {
             #(#elements),*
         }

--- a/autogen/src/utils.rs
+++ b/autogen/src/utils.rs
@@ -27,7 +27,7 @@ pub fn as_ident(ident: &str) -> Ident {
 /// given operand `kind` in the grammar.
 pub fn get_dr_operand_kind(kind: &str) -> Ident {
     as_ident(
-        if kind == "LiteralInteger" || kind == "LiteralContextDependentNumber" {
+        if matches!(kind, "LiteralInteger" | "LiteralContextDependentNumber") {
             // TODO: LiteralContextDependentNumber should use the correct type to decode
             "LiteralInt32"
         } else {

--- a/autogen/src/utils.rs
+++ b/autogen/src/utils.rs
@@ -26,14 +26,14 @@ pub fn as_ident(ident: &str) -> Ident {
 /// Returns the corresponding operand kind in data representation for the
 /// given operand `kind` in the grammar.
 pub fn get_dr_operand_kind(kind: &str) -> Ident {
-    as_ident(if kind == "LiteralInteger" {
-        "LiteralInt32"
-    } else if kind == "LiteralContextDependentNumber" {
-        // TODO: should use the correct type to decode
-        "LiteralInt32"
-    } else {
-        kind
-    })
+    as_ident(
+        if kind == "LiteralInteger" || kind == "LiteralContextDependentNumber" {
+            // TODO: LiteralContextDependentNumber should use the correct type to decode
+            "LiteralInt32"
+        } else {
+            kind
+        },
+    )
 }
 
 /// Returns the underlying type used in operand kind enums for the operand

--- a/rspirv/binary/assemble.rs
+++ b/rspirv/binary/assemble.rs
@@ -138,10 +138,9 @@ impl Assemble for dr::Function {
 
 impl Assemble for dr::Module {
     fn assemble_into(&self, result: &mut Vec<u32>) {
-        match self.header {
-            Some(ref h) => h.assemble_into(result),
-            None => {}
-        };
+        if let Some(ref h) = self.header {
+            h.assemble_into(result);
+        }
 
         for inst in self.global_inst_iter() {
             inst.assemble_into(result);

--- a/rspirv/binary/autogen_error.rs
+++ b/rspirv/binary/autogen_error.rs
@@ -2,10 +2,10 @@
 //   external/spirv.core.grammar.json.
 // DO NOT MODIFY!
 
-use spirv;
 use std::{error, fmt};
 #[doc = "Decoder Error"]
 #[derive(Debug, PartialEq)]
+#[allow(clippy::upper_case_acronyms)]
 pub enum Error {
     StreamExpected(usize),
     LimitReached(usize),

--- a/rspirv/binary/disassemble.rs
+++ b/rspirv/binary/disassemble.rs
@@ -187,9 +187,7 @@ fn disas_ext_inst(
             return inst.disassemble();
         }
         if let Some(grammar) = ext_inst_set_tracker.resolve(id, opcode) {
-            let mut operands = vec![];
-            operands.push(inst.operands[0].disassemble());
-            operands.push(grammar.opname.to_string());
+            let mut operands = vec![inst.operands[0].disassemble(), grammar.opname.to_string()];
             for operand in &inst.operands[2..] {
                 operands.push(operand.disassemble())
             }

--- a/rspirv/binary/parser.rs
+++ b/rspirv/binary/parser.rs
@@ -445,7 +445,7 @@ mod tests {
     // TODO: It's unfortunate that we have these numbers directly coded here
     // and repeat them in the following tests. Should have a better way.
     #[rustfmt::skip]
-    static ZERO_BOUND_HEADER: &'static [u8] = &[
+    static ZERO_BOUND_HEADER: &[u8] = &[
         // Magic number.           Version number: 1.0.
         0x03, 0x02, 0x23, 0x07,    0x00, 0x00, 0x01, 0x00,
         // Generator number: 0.    Bound: 0.

--- a/rspirv/binary/tracker.rs
+++ b/rspirv/binary/tracker.rs
@@ -70,6 +70,7 @@ impl TypeTracker {
     }
 }
 
+#[allow(clippy::upper_case_acronyms)]
 enum ExtInstSet {
     GlslStd450,
     OpenCLStd100,

--- a/rspirv/dr/autogen_operand.rs
+++ b/rspirv/dr/autogen_operand.rs
@@ -4,6 +4,7 @@
 
 #[doc = "Data representation of a SPIR-V operand."]
 #[derive(Clone, Debug, PartialEq, From)]
+#[allow(clippy::upper_case_acronyms)]
 pub enum Operand {
     ImageOperands(spirv::ImageOperands),
     FPFastMathMode(spirv::FPFastMathMode),

--- a/rspirv/dr/build/autogen_debug.rs
+++ b/rspirv/dr/build/autogen_debug.rs
@@ -33,11 +33,9 @@ impl Builder {
             ],
         );
         if let Some(v) = file {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::IdRef(v.into()));
+            inst.operands.push(dr::Operand::IdRef(v));
         }
         if let Some(v) = source {
-            #[allow(clippy::identity_conversion)]
             inst.operands.push(dr::Operand::LiteralString(v.into()));
         }
         self.module.debugs.push(inst);

--- a/rspirv/dr/build/autogen_norm_insts.rs
+++ b/rspirv/dr/build/autogen_norm_insts.rs
@@ -128,8 +128,7 @@ impl Builder {
             vec![dr::Operand::IdRef(pointer)],
         );
         if let Some(v) = memory_access {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::MemoryAccess(v.into()));
+            inst.operands.push(dr::Operand::MemoryAccess(v));
         }
         inst.operands.extend(additional_params);
         self.insert_into_block(InsertPoint::End, inst)?;
@@ -154,8 +153,7 @@ impl Builder {
             vec![dr::Operand::IdRef(pointer)],
         );
         if let Some(v) = memory_access {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::MemoryAccess(v.into()));
+            inst.operands.push(dr::Operand::MemoryAccess(v));
         }
         inst.operands.extend(additional_params);
         self.insert_into_block(insert_point, inst)?;
@@ -177,8 +175,7 @@ impl Builder {
             vec![dr::Operand::IdRef(pointer), dr::Operand::IdRef(object)],
         );
         if let Some(v) = memory_access {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::MemoryAccess(v.into()));
+            inst.operands.push(dr::Operand::MemoryAccess(v));
         }
         inst.operands.extend(additional_params);
         self.insert_into_block(InsertPoint::End, inst)?;
@@ -201,8 +198,7 @@ impl Builder {
             vec![dr::Operand::IdRef(pointer), dr::Operand::IdRef(object)],
         );
         if let Some(v) = memory_access {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::MemoryAccess(v.into()));
+            inst.operands.push(dr::Operand::MemoryAccess(v));
         }
         inst.operands.extend(additional_params);
         self.insert_into_block(insert_point, inst)?;
@@ -225,12 +221,10 @@ impl Builder {
             vec![dr::Operand::IdRef(target), dr::Operand::IdRef(source)],
         );
         if let Some(v) = memory_access {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::MemoryAccess(v.into()));
+            inst.operands.push(dr::Operand::MemoryAccess(v));
         }
         if let Some(v) = memory_access_2 {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::MemoryAccess(v.into()));
+            inst.operands.push(dr::Operand::MemoryAccess(v));
         }
         inst.operands.extend(additional_params);
         self.insert_into_block(InsertPoint::End, inst)?;
@@ -254,12 +248,10 @@ impl Builder {
             vec![dr::Operand::IdRef(target), dr::Operand::IdRef(source)],
         );
         if let Some(v) = memory_access {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::MemoryAccess(v.into()));
+            inst.operands.push(dr::Operand::MemoryAccess(v));
         }
         if let Some(v) = memory_access_2 {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::MemoryAccess(v.into()));
+            inst.operands.push(dr::Operand::MemoryAccess(v));
         }
         inst.operands.extend(additional_params);
         self.insert_into_block(insert_point, inst)?;
@@ -287,12 +279,10 @@ impl Builder {
             ],
         );
         if let Some(v) = memory_access {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::MemoryAccess(v.into()));
+            inst.operands.push(dr::Operand::MemoryAccess(v));
         }
         if let Some(v) = memory_access_2 {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::MemoryAccess(v.into()));
+            inst.operands.push(dr::Operand::MemoryAccess(v));
         }
         inst.operands.extend(additional_params);
         self.insert_into_block(InsertPoint::End, inst)?;
@@ -321,12 +311,10 @@ impl Builder {
             ],
         );
         if let Some(v) = memory_access {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::MemoryAccess(v.into()));
+            inst.operands.push(dr::Operand::MemoryAccess(v));
         }
         if let Some(v) = memory_access_2 {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::MemoryAccess(v.into()));
+            inst.operands.push(dr::Operand::MemoryAccess(v));
         }
         inst.operands.extend(additional_params);
         self.insert_into_block(insert_point, inst)?;
@@ -987,8 +975,7 @@ impl Builder {
             ],
         );
         if let Some(v) = image_operands {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::ImageOperands(v.into()));
+            inst.operands.push(dr::Operand::ImageOperands(v));
         }
         inst.operands.extend(additional_params);
         self.insert_into_block(InsertPoint::End, inst)?;
@@ -1017,8 +1004,7 @@ impl Builder {
             ],
         );
         if let Some(v) = image_operands {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::ImageOperands(v.into()));
+            inst.operands.push(dr::Operand::ImageOperands(v));
         }
         inst.operands.extend(additional_params);
         self.insert_into_block(insert_point, inst)?;
@@ -1101,8 +1087,7 @@ impl Builder {
             ],
         );
         if let Some(v) = image_operands {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::ImageOperands(v.into()));
+            inst.operands.push(dr::Operand::ImageOperands(v));
         }
         inst.operands.extend(additional_params);
         self.insert_into_block(InsertPoint::End, inst)?;
@@ -1133,8 +1118,7 @@ impl Builder {
             ],
         );
         if let Some(v) = image_operands {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::ImageOperands(v.into()));
+            inst.operands.push(dr::Operand::ImageOperands(v));
         }
         inst.operands.extend(additional_params);
         self.insert_into_block(insert_point, inst)?;
@@ -1219,8 +1203,7 @@ impl Builder {
             ],
         );
         if let Some(v) = image_operands {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::ImageOperands(v.into()));
+            inst.operands.push(dr::Operand::ImageOperands(v));
         }
         inst.operands.extend(additional_params);
         self.insert_into_block(InsertPoint::End, inst)?;
@@ -1249,8 +1232,7 @@ impl Builder {
             ],
         );
         if let Some(v) = image_operands {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::ImageOperands(v.into()));
+            inst.operands.push(dr::Operand::ImageOperands(v));
         }
         inst.operands.extend(additional_params);
         self.insert_into_block(insert_point, inst)?;
@@ -1333,8 +1315,7 @@ impl Builder {
             ],
         );
         if let Some(v) = image_operands {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::ImageOperands(v.into()));
+            inst.operands.push(dr::Operand::ImageOperands(v));
         }
         inst.operands.extend(additional_params);
         self.insert_into_block(InsertPoint::End, inst)?;
@@ -1365,8 +1346,7 @@ impl Builder {
             ],
         );
         if let Some(v) = image_operands {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::ImageOperands(v.into()));
+            inst.operands.push(dr::Operand::ImageOperands(v));
         }
         inst.operands.extend(additional_params);
         self.insert_into_block(insert_point, inst)?;
@@ -1448,8 +1428,7 @@ impl Builder {
             vec![dr::Operand::IdRef(image), dr::Operand::IdRef(coordinate)],
         );
         if let Some(v) = image_operands {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::ImageOperands(v.into()));
+            inst.operands.push(dr::Operand::ImageOperands(v));
         }
         inst.operands.extend(additional_params);
         self.insert_into_block(InsertPoint::End, inst)?;
@@ -1475,8 +1454,7 @@ impl Builder {
             vec![dr::Operand::IdRef(image), dr::Operand::IdRef(coordinate)],
         );
         if let Some(v) = image_operands {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::ImageOperands(v.into()));
+            inst.operands.push(dr::Operand::ImageOperands(v));
         }
         inst.operands.extend(additional_params);
         self.insert_into_block(insert_point, inst)?;
@@ -1506,8 +1484,7 @@ impl Builder {
             ],
         );
         if let Some(v) = image_operands {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::ImageOperands(v.into()));
+            inst.operands.push(dr::Operand::ImageOperands(v));
         }
         inst.operands.extend(additional_params);
         self.insert_into_block(InsertPoint::End, inst)?;
@@ -1538,8 +1515,7 @@ impl Builder {
             ],
         );
         if let Some(v) = image_operands {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::ImageOperands(v.into()));
+            inst.operands.push(dr::Operand::ImageOperands(v));
         }
         inst.operands.extend(additional_params);
         self.insert_into_block(insert_point, inst)?;
@@ -1569,8 +1545,7 @@ impl Builder {
             ],
         );
         if let Some(v) = image_operands {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::ImageOperands(v.into()));
+            inst.operands.push(dr::Operand::ImageOperands(v));
         }
         inst.operands.extend(additional_params);
         self.insert_into_block(InsertPoint::End, inst)?;
@@ -1601,8 +1576,7 @@ impl Builder {
             ],
         );
         if let Some(v) = image_operands {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::ImageOperands(v.into()));
+            inst.operands.push(dr::Operand::ImageOperands(v));
         }
         inst.operands.extend(additional_params);
         self.insert_into_block(insert_point, inst)?;
@@ -1627,8 +1601,7 @@ impl Builder {
             vec![dr::Operand::IdRef(image), dr::Operand::IdRef(coordinate)],
         );
         if let Some(v) = image_operands {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::ImageOperands(v.into()));
+            inst.operands.push(dr::Operand::ImageOperands(v));
         }
         inst.operands.extend(additional_params);
         self.insert_into_block(InsertPoint::End, inst)?;
@@ -1654,8 +1627,7 @@ impl Builder {
             vec![dr::Operand::IdRef(image), dr::Operand::IdRef(coordinate)],
         );
         if let Some(v) = image_operands {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::ImageOperands(v.into()));
+            inst.operands.push(dr::Operand::ImageOperands(v));
         }
         inst.operands.extend(additional_params);
         self.insert_into_block(insert_point, inst)?;
@@ -1682,8 +1654,7 @@ impl Builder {
             ],
         );
         if let Some(v) = image_operands {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::ImageOperands(v.into()));
+            inst.operands.push(dr::Operand::ImageOperands(v));
         }
         inst.operands.extend(additional_params);
         self.insert_into_block(InsertPoint::End, inst)?;
@@ -1711,8 +1682,7 @@ impl Builder {
             ],
         );
         if let Some(v) = image_operands {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::ImageOperands(v.into()));
+            inst.operands.push(dr::Operand::ImageOperands(v));
         }
         inst.operands.extend(additional_params);
         self.insert_into_block(insert_point, inst)?;
@@ -9117,8 +9087,7 @@ impl Builder {
             ],
         );
         if let Some(v) = image_operands {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::ImageOperands(v.into()));
+            inst.operands.push(dr::Operand::ImageOperands(v));
         }
         inst.operands.extend(additional_params);
         self.insert_into_block(InsertPoint::End, inst)?;
@@ -9147,8 +9116,7 @@ impl Builder {
             ],
         );
         if let Some(v) = image_operands {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::ImageOperands(v.into()));
+            inst.operands.push(dr::Operand::ImageOperands(v));
         }
         inst.operands.extend(additional_params);
         self.insert_into_block(insert_point, inst)?;
@@ -9231,8 +9199,7 @@ impl Builder {
             ],
         );
         if let Some(v) = image_operands {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::ImageOperands(v.into()));
+            inst.operands.push(dr::Operand::ImageOperands(v));
         }
         inst.operands.extend(additional_params);
         self.insert_into_block(InsertPoint::End, inst)?;
@@ -9263,8 +9230,7 @@ impl Builder {
             ],
         );
         if let Some(v) = image_operands {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::ImageOperands(v.into()));
+            inst.operands.push(dr::Operand::ImageOperands(v));
         }
         inst.operands.extend(additional_params);
         self.insert_into_block(insert_point, inst)?;
@@ -9349,8 +9315,7 @@ impl Builder {
             ],
         );
         if let Some(v) = image_operands {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::ImageOperands(v.into()));
+            inst.operands.push(dr::Operand::ImageOperands(v));
         }
         inst.operands.extend(additional_params);
         self.insert_into_block(InsertPoint::End, inst)?;
@@ -9379,8 +9344,7 @@ impl Builder {
             ],
         );
         if let Some(v) = image_operands {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::ImageOperands(v.into()));
+            inst.operands.push(dr::Operand::ImageOperands(v));
         }
         inst.operands.extend(additional_params);
         self.insert_into_block(insert_point, inst)?;
@@ -9463,8 +9427,7 @@ impl Builder {
             ],
         );
         if let Some(v) = image_operands {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::ImageOperands(v.into()));
+            inst.operands.push(dr::Operand::ImageOperands(v));
         }
         inst.operands.extend(additional_params);
         self.insert_into_block(InsertPoint::End, inst)?;
@@ -9495,8 +9458,7 @@ impl Builder {
             ],
         );
         if let Some(v) = image_operands {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::ImageOperands(v.into()));
+            inst.operands.push(dr::Operand::ImageOperands(v));
         }
         inst.operands.extend(additional_params);
         self.insert_into_block(insert_point, inst)?;
@@ -9578,8 +9540,7 @@ impl Builder {
             vec![dr::Operand::IdRef(image), dr::Operand::IdRef(coordinate)],
         );
         if let Some(v) = image_operands {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::ImageOperands(v.into()));
+            inst.operands.push(dr::Operand::ImageOperands(v));
         }
         inst.operands.extend(additional_params);
         self.insert_into_block(InsertPoint::End, inst)?;
@@ -9605,8 +9566,7 @@ impl Builder {
             vec![dr::Operand::IdRef(image), dr::Operand::IdRef(coordinate)],
         );
         if let Some(v) = image_operands {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::ImageOperands(v.into()));
+            inst.operands.push(dr::Operand::ImageOperands(v));
         }
         inst.operands.extend(additional_params);
         self.insert_into_block(insert_point, inst)?;
@@ -9636,8 +9596,7 @@ impl Builder {
             ],
         );
         if let Some(v) = image_operands {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::ImageOperands(v.into()));
+            inst.operands.push(dr::Operand::ImageOperands(v));
         }
         inst.operands.extend(additional_params);
         self.insert_into_block(InsertPoint::End, inst)?;
@@ -9668,8 +9627,7 @@ impl Builder {
             ],
         );
         if let Some(v) = image_operands {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::ImageOperands(v.into()));
+            inst.operands.push(dr::Operand::ImageOperands(v));
         }
         inst.operands.extend(additional_params);
         self.insert_into_block(insert_point, inst)?;
@@ -9699,8 +9657,7 @@ impl Builder {
             ],
         );
         if let Some(v) = image_operands {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::ImageOperands(v.into()));
+            inst.operands.push(dr::Operand::ImageOperands(v));
         }
         inst.operands.extend(additional_params);
         self.insert_into_block(InsertPoint::End, inst)?;
@@ -9731,8 +9688,7 @@ impl Builder {
             ],
         );
         if let Some(v) = image_operands {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::ImageOperands(v.into()));
+            inst.operands.push(dr::Operand::ImageOperands(v));
         }
         inst.operands.extend(additional_params);
         self.insert_into_block(insert_point, inst)?;
@@ -9886,8 +9842,7 @@ impl Builder {
             vec![dr::Operand::IdRef(image), dr::Operand::IdRef(coordinate)],
         );
         if let Some(v) = image_operands {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::ImageOperands(v.into()));
+            inst.operands.push(dr::Operand::ImageOperands(v));
         }
         inst.operands.extend(additional_params);
         self.insert_into_block(InsertPoint::End, inst)?;
@@ -9913,8 +9868,7 @@ impl Builder {
             vec![dr::Operand::IdRef(image), dr::Operand::IdRef(coordinate)],
         );
         if let Some(v) = image_operands {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::ImageOperands(v.into()));
+            inst.operands.push(dr::Operand::ImageOperands(v));
         }
         inst.operands.extend(additional_params);
         self.insert_into_block(insert_point, inst)?;
@@ -10966,8 +10920,7 @@ impl Builder {
             ],
         );
         if let Some(v) = cluster_size {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::IdRef(v.into()));
+            inst.operands.push(dr::Operand::IdRef(v));
         }
         self.insert_into_block(InsertPoint::End, inst)?;
         Ok(_id)
@@ -10996,8 +10949,7 @@ impl Builder {
             ],
         );
         if let Some(v) = cluster_size {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::IdRef(v.into()));
+            inst.operands.push(dr::Operand::IdRef(v));
         }
         self.insert_into_block(insert_point, inst)?;
         Ok(_id)
@@ -11025,8 +10977,7 @@ impl Builder {
             ],
         );
         if let Some(v) = cluster_size {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::IdRef(v.into()));
+            inst.operands.push(dr::Operand::IdRef(v));
         }
         self.insert_into_block(InsertPoint::End, inst)?;
         Ok(_id)
@@ -11055,8 +11006,7 @@ impl Builder {
             ],
         );
         if let Some(v) = cluster_size {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::IdRef(v.into()));
+            inst.operands.push(dr::Operand::IdRef(v));
         }
         self.insert_into_block(insert_point, inst)?;
         Ok(_id)
@@ -11084,8 +11034,7 @@ impl Builder {
             ],
         );
         if let Some(v) = cluster_size {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::IdRef(v.into()));
+            inst.operands.push(dr::Operand::IdRef(v));
         }
         self.insert_into_block(InsertPoint::End, inst)?;
         Ok(_id)
@@ -11114,8 +11063,7 @@ impl Builder {
             ],
         );
         if let Some(v) = cluster_size {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::IdRef(v.into()));
+            inst.operands.push(dr::Operand::IdRef(v));
         }
         self.insert_into_block(insert_point, inst)?;
         Ok(_id)
@@ -11143,8 +11091,7 @@ impl Builder {
             ],
         );
         if let Some(v) = cluster_size {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::IdRef(v.into()));
+            inst.operands.push(dr::Operand::IdRef(v));
         }
         self.insert_into_block(InsertPoint::End, inst)?;
         Ok(_id)
@@ -11173,8 +11120,7 @@ impl Builder {
             ],
         );
         if let Some(v) = cluster_size {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::IdRef(v.into()));
+            inst.operands.push(dr::Operand::IdRef(v));
         }
         self.insert_into_block(insert_point, inst)?;
         Ok(_id)
@@ -11202,8 +11148,7 @@ impl Builder {
             ],
         );
         if let Some(v) = cluster_size {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::IdRef(v.into()));
+            inst.operands.push(dr::Operand::IdRef(v));
         }
         self.insert_into_block(InsertPoint::End, inst)?;
         Ok(_id)
@@ -11232,8 +11177,7 @@ impl Builder {
             ],
         );
         if let Some(v) = cluster_size {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::IdRef(v.into()));
+            inst.operands.push(dr::Operand::IdRef(v));
         }
         self.insert_into_block(insert_point, inst)?;
         Ok(_id)
@@ -11261,8 +11205,7 @@ impl Builder {
             ],
         );
         if let Some(v) = cluster_size {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::IdRef(v.into()));
+            inst.operands.push(dr::Operand::IdRef(v));
         }
         self.insert_into_block(InsertPoint::End, inst)?;
         Ok(_id)
@@ -11291,8 +11234,7 @@ impl Builder {
             ],
         );
         if let Some(v) = cluster_size {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::IdRef(v.into()));
+            inst.operands.push(dr::Operand::IdRef(v));
         }
         self.insert_into_block(insert_point, inst)?;
         Ok(_id)
@@ -11320,8 +11262,7 @@ impl Builder {
             ],
         );
         if let Some(v) = cluster_size {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::IdRef(v.into()));
+            inst.operands.push(dr::Operand::IdRef(v));
         }
         self.insert_into_block(InsertPoint::End, inst)?;
         Ok(_id)
@@ -11350,8 +11291,7 @@ impl Builder {
             ],
         );
         if let Some(v) = cluster_size {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::IdRef(v.into()));
+            inst.operands.push(dr::Operand::IdRef(v));
         }
         self.insert_into_block(insert_point, inst)?;
         Ok(_id)
@@ -11379,8 +11319,7 @@ impl Builder {
             ],
         );
         if let Some(v) = cluster_size {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::IdRef(v.into()));
+            inst.operands.push(dr::Operand::IdRef(v));
         }
         self.insert_into_block(InsertPoint::End, inst)?;
         Ok(_id)
@@ -11409,8 +11348,7 @@ impl Builder {
             ],
         );
         if let Some(v) = cluster_size {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::IdRef(v.into()));
+            inst.operands.push(dr::Operand::IdRef(v));
         }
         self.insert_into_block(insert_point, inst)?;
         Ok(_id)
@@ -11438,8 +11376,7 @@ impl Builder {
             ],
         );
         if let Some(v) = cluster_size {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::IdRef(v.into()));
+            inst.operands.push(dr::Operand::IdRef(v));
         }
         self.insert_into_block(InsertPoint::End, inst)?;
         Ok(_id)
@@ -11468,8 +11405,7 @@ impl Builder {
             ],
         );
         if let Some(v) = cluster_size {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::IdRef(v.into()));
+            inst.operands.push(dr::Operand::IdRef(v));
         }
         self.insert_into_block(insert_point, inst)?;
         Ok(_id)
@@ -11497,8 +11433,7 @@ impl Builder {
             ],
         );
         if let Some(v) = cluster_size {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::IdRef(v.into()));
+            inst.operands.push(dr::Operand::IdRef(v));
         }
         self.insert_into_block(InsertPoint::End, inst)?;
         Ok(_id)
@@ -11527,8 +11462,7 @@ impl Builder {
             ],
         );
         if let Some(v) = cluster_size {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::IdRef(v.into()));
+            inst.operands.push(dr::Operand::IdRef(v));
         }
         self.insert_into_block(insert_point, inst)?;
         Ok(_id)
@@ -11556,8 +11490,7 @@ impl Builder {
             ],
         );
         if let Some(v) = cluster_size {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::IdRef(v.into()));
+            inst.operands.push(dr::Operand::IdRef(v));
         }
         self.insert_into_block(InsertPoint::End, inst)?;
         Ok(_id)
@@ -11586,8 +11519,7 @@ impl Builder {
             ],
         );
         if let Some(v) = cluster_size {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::IdRef(v.into()));
+            inst.operands.push(dr::Operand::IdRef(v));
         }
         self.insert_into_block(insert_point, inst)?;
         Ok(_id)
@@ -11615,8 +11547,7 @@ impl Builder {
             ],
         );
         if let Some(v) = cluster_size {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::IdRef(v.into()));
+            inst.operands.push(dr::Operand::IdRef(v));
         }
         self.insert_into_block(InsertPoint::End, inst)?;
         Ok(_id)
@@ -11645,8 +11576,7 @@ impl Builder {
             ],
         );
         if let Some(v) = cluster_size {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::IdRef(v.into()));
+            inst.operands.push(dr::Operand::IdRef(v));
         }
         self.insert_into_block(insert_point, inst)?;
         Ok(_id)
@@ -11674,8 +11604,7 @@ impl Builder {
             ],
         );
         if let Some(v) = cluster_size {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::IdRef(v.into()));
+            inst.operands.push(dr::Operand::IdRef(v));
         }
         self.insert_into_block(InsertPoint::End, inst)?;
         Ok(_id)
@@ -11704,8 +11633,7 @@ impl Builder {
             ],
         );
         if let Some(v) = cluster_size {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::IdRef(v.into()));
+            inst.operands.push(dr::Operand::IdRef(v));
         }
         self.insert_into_block(insert_point, inst)?;
         Ok(_id)
@@ -11733,8 +11661,7 @@ impl Builder {
             ],
         );
         if let Some(v) = cluster_size {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::IdRef(v.into()));
+            inst.operands.push(dr::Operand::IdRef(v));
         }
         self.insert_into_block(InsertPoint::End, inst)?;
         Ok(_id)
@@ -11763,8 +11690,7 @@ impl Builder {
             ],
         );
         if let Some(v) = cluster_size {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::IdRef(v.into()));
+            inst.operands.push(dr::Operand::IdRef(v));
         }
         self.insert_into_block(insert_point, inst)?;
         Ok(_id)
@@ -11792,8 +11718,7 @@ impl Builder {
             ],
         );
         if let Some(v) = cluster_size {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::IdRef(v.into()));
+            inst.operands.push(dr::Operand::IdRef(v));
         }
         self.insert_into_block(InsertPoint::End, inst)?;
         Ok(_id)
@@ -11822,8 +11747,7 @@ impl Builder {
             ],
         );
         if let Some(v) = cluster_size {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::IdRef(v.into()));
+            inst.operands.push(dr::Operand::IdRef(v));
         }
         self.insert_into_block(insert_point, inst)?;
         Ok(_id)
@@ -11851,8 +11775,7 @@ impl Builder {
             ],
         );
         if let Some(v) = cluster_size {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::IdRef(v.into()));
+            inst.operands.push(dr::Operand::IdRef(v));
         }
         self.insert_into_block(InsertPoint::End, inst)?;
         Ok(_id)
@@ -11881,8 +11804,7 @@ impl Builder {
             ],
         );
         if let Some(v) = cluster_size {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::IdRef(v.into()));
+            inst.operands.push(dr::Operand::IdRef(v));
         }
         self.insert_into_block(insert_point, inst)?;
         Ok(_id)
@@ -13294,8 +13216,7 @@ impl Builder {
             ],
         );
         if let Some(v) = image_operands {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::ImageOperands(v.into()));
+            inst.operands.push(dr::Operand::ImageOperands(v));
         }
         inst.operands.extend(additional_params);
         self.insert_into_block(InsertPoint::End, inst)?;
@@ -13328,8 +13249,7 @@ impl Builder {
             ],
         );
         if let Some(v) = image_operands {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::ImageOperands(v.into()));
+            inst.operands.push(dr::Operand::ImageOperands(v));
         }
         inst.operands.extend(additional_params);
         self.insert_into_block(insert_point, inst)?;
@@ -13655,8 +13575,7 @@ impl Builder {
             ],
         );
         if let Some(v) = memory_access {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::MemoryAccess(v.into()));
+            inst.operands.push(dr::Operand::MemoryAccess(v));
         }
         inst.operands.extend(additional_params);
         self.insert_into_block(InsertPoint::End, inst)?;
@@ -13687,8 +13606,7 @@ impl Builder {
             ],
         );
         if let Some(v) = memory_access {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::MemoryAccess(v.into()));
+            inst.operands.push(dr::Operand::MemoryAccess(v));
         }
         inst.operands.extend(additional_params);
         self.insert_into_block(insert_point, inst)?;
@@ -13717,8 +13635,7 @@ impl Builder {
             ],
         );
         if let Some(v) = memory_access {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::MemoryAccess(v.into()));
+            inst.operands.push(dr::Operand::MemoryAccess(v));
         }
         inst.operands.extend(additional_params);
         self.insert_into_block(InsertPoint::End, inst)?;
@@ -13748,8 +13665,7 @@ impl Builder {
             ],
         );
         if let Some(v) = memory_access {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::MemoryAccess(v.into()));
+            inst.operands.push(dr::Operand::MemoryAccess(v));
         }
         inst.operands.extend(additional_params);
         self.insert_into_block(insert_point, inst)?;

--- a/rspirv/dr/build/autogen_type.rs
+++ b/rspirv/dr/build/autogen_type.rs
@@ -135,8 +135,7 @@ impl Builder {
             ],
         );
         if let Some(v) = access_qualifier {
-            #[allow(clippy::identity_conversion)]
-            inst.operands.push(dr::Operand::AccessQualifier(v.into()));
+            inst.operands.push(dr::Operand::AccessQualifier(v));
         }
         if let Some(id) = self.dedup_insert_type(&inst) {
             id

--- a/rspirv/dr/build/mod.rs
+++ b/rspirv/dr/build/mod.rs
@@ -175,10 +175,7 @@ impl Builder {
 
         let block = &mut self.module.functions[selected_function].blocks[selected_block];
 
-        block
-            .instructions
-            .pop()
-            .ok_or_else(|| Error::EmptyInstructionList)
+        block.instructions.pop().ok_or(Error::EmptyInstructionList)
     }
 
     /// Sets the SPIR-V version to the given major.minor version.

--- a/rspirv/grammar/autogen_table.rs
+++ b/rspirv/grammar/autogen_table.rs
@@ -4,6 +4,7 @@
 
 #[doc = "All operand kinds in the SPIR-V grammar."]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[allow(clippy::upper_case_acronyms)]
 pub enum OperandKind {
     ImageOperands,
     FPFastMathMode,

--- a/rspirv/grammar/reflect.rs
+++ b/rspirv/grammar/reflect.rs
@@ -4,23 +4,20 @@ use crate::spirv;
 
 /// Returns true if the given opcode is for a location debug instruction.
 pub fn is_location_debug(opcode: spirv::Op) -> bool {
-    match opcode {
-        spirv::Op::Line | spirv::Op::NoLine => true,
-        _ => false,
-    }
+    matches!(opcode, spirv::Op::Line | spirv::Op::NoLine)
 }
 
 /// Returns true if the given opcode is for a non-location debug instruction.
 pub fn is_nonlocation_debug(opcode: spirv::Op) -> bool {
-    match opcode {
+    matches!(
+        opcode,
         spirv::Op::SourceContinued
-        | spirv::Op::Source
-        | spirv::Op::SourceExtension
-        | spirv::Op::Name
-        | spirv::Op::MemberName
-        | spirv::Op::String => true,
-        _ => false,
-    }
+            | spirv::Op::Source
+            | spirv::Op::SourceExtension
+            | spirv::Op::Name
+            | spirv::Op::MemberName
+            | spirv::Op::String
+    )
 }
 
 /// Returns true if the given opcode is for a debug instruction.
@@ -30,64 +27,64 @@ pub fn is_debug(opcode: spirv::Op) -> bool {
 
 /// Returns true if the given opcode is for an annotation instruction.
 pub fn is_annotation(opcode: spirv::Op) -> bool {
-    match opcode {
+    matches!(
+        opcode,
         spirv::Op::Decorate
-        | spirv::Op::MemberDecorate
-        | spirv::Op::DecorationGroup
-        | spirv::Op::GroupDecorate
-        | spirv::Op::GroupMemberDecorate
-        | spirv::Op::DecorateString
-        | spirv::Op::MemberDecorateStringGOOGLE => true,
-        _ => false,
-    }
+            | spirv::Op::MemberDecorate
+            | spirv::Op::DecorationGroup
+            | spirv::Op::GroupDecorate
+            | spirv::Op::GroupMemberDecorate
+            | spirv::Op::DecorateString
+            | spirv::Op::MemberDecorateStringGOOGLE
+    )
 }
 
 /// Returns true if the given opcode is for a type-declaring instruction.
 pub fn is_type(opcode: spirv::Op) -> bool {
-    match opcode {
+    matches!(
+        opcode,
         spirv::Op::TypeVoid
-        | spirv::Op::TypeBool
-        | spirv::Op::TypeInt
-        | spirv::Op::TypeFloat
-        | spirv::Op::TypeVector
-        | spirv::Op::TypeMatrix
-        | spirv::Op::TypeImage
-        | spirv::Op::TypeSampler
-        | spirv::Op::TypeSampledImage
-        | spirv::Op::TypeArray
-        | spirv::Op::TypeRuntimeArray
-        | spirv::Op::TypeStruct
-        | spirv::Op::TypeOpaque
-        | spirv::Op::TypePointer
-        | spirv::Op::TypeFunction
-        | spirv::Op::TypeEvent
-        | spirv::Op::TypeDeviceEvent
-        | spirv::Op::TypeReserveId
-        | spirv::Op::TypeQueue
-        | spirv::Op::TypePipe
-        | spirv::Op::TypeAccelerationStructureKHR
-        | spirv::Op::TypeRayQueryKHR
-        | spirv::Op::TypeForwardPointer => true,
-        _ => false,
-    }
+            | spirv::Op::TypeBool
+            | spirv::Op::TypeInt
+            | spirv::Op::TypeFloat
+            | spirv::Op::TypeVector
+            | spirv::Op::TypeMatrix
+            | spirv::Op::TypeImage
+            | spirv::Op::TypeSampler
+            | spirv::Op::TypeSampledImage
+            | spirv::Op::TypeArray
+            | spirv::Op::TypeRuntimeArray
+            | spirv::Op::TypeStruct
+            | spirv::Op::TypeOpaque
+            | spirv::Op::TypePointer
+            | spirv::Op::TypeFunction
+            | spirv::Op::TypeEvent
+            | spirv::Op::TypeDeviceEvent
+            | spirv::Op::TypeReserveId
+            | spirv::Op::TypeQueue
+            | spirv::Op::TypePipe
+            | spirv::Op::TypeAccelerationStructureKHR
+            | spirv::Op::TypeRayQueryKHR
+            | spirv::Op::TypeForwardPointer
+    )
 }
 
 /// Returns true if the given opcode is for a constant-defining instruction.
 pub fn is_constant(opcode: spirv::Op) -> bool {
-    match opcode {
+    matches!(
+        opcode,
         spirv::Op::ConstantTrue
-        | spirv::Op::ConstantFalse
-        | spirv::Op::Constant
-        | spirv::Op::ConstantComposite
-        | spirv::Op::ConstantSampler
-        | spirv::Op::ConstantNull
-        | spirv::Op::SpecConstantTrue
-        | spirv::Op::SpecConstantFalse
-        | spirv::Op::SpecConstant
-        | spirv::Op::SpecConstantComposite
-        | spirv::Op::SpecConstantOp => true,
-        _ => false,
-    }
+            | spirv::Op::ConstantFalse
+            | spirv::Op::Constant
+            | spirv::Op::ConstantComposite
+            | spirv::Op::ConstantSampler
+            | spirv::Op::ConstantNull
+            | spirv::Op::SpecConstantTrue
+            | spirv::Op::SpecConstantFalse
+            | spirv::Op::SpecConstant
+            | spirv::Op::SpecConstantComposite
+            | spirv::Op::SpecConstantOp
+    )
 }
 
 /// Returns true if the given opcode is for a variable-defining instruction.

--- a/rspirv/grammar/syntax.rs
+++ b/rspirv/grammar/syntax.rs
@@ -159,6 +159,7 @@ include!("autogen_glsl_std_450.rs");
 /// The table for all `OpenCLstd100` extended instructions.
 ///
 /// This table is staic data stored in the library.
+#[allow(clippy::upper_case_acronyms)]
 pub struct OpenCLStd100InstructionTable;
 
 impl OpenCLStd100InstructionTable {

--- a/rspirv/lift/autogen_context.rs
+++ b/rspirv/lift/autogen_context.rs
@@ -14,7 +14,7 @@ impl LiftContext {
                             Some((first, second))
                         }
                         (None, None) => None,
-                        _ => Err(OperandError::WrongType)?,
+                        _ => return Err(OperandError::WrongType.into()),
                     } {
                         vec.push(item);
                     }
@@ -24,19 +24,19 @@ impl LiftContext {
             246u32 => Ok(ops::Branch::LoopMerge {
                 merge_block: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 continue_target: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 loop_control: (match operands.next() {
                     Some(&dr::Operand::LoopControl(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -44,13 +44,13 @@ impl LiftContext {
             247u32 => Ok(ops::Branch::SelectionMerge {
                 merge_block: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 selection_control: (match operands.next() {
                     Some(&dr::Operand::SelectionControl(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -59,7 +59,7 @@ impl LiftContext {
             249u32 => Ok(ops::Branch::Branch {
                 target_label: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -67,19 +67,19 @@ impl LiftContext {
             250u32 => Ok(ops::Branch::BranchConditional {
                 condition: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 true_label: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 false_label: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -87,7 +87,7 @@ impl LiftContext {
                     let mut vec = Vec::new();
                     while let Some(item) = match operands.next() {
                         Some(&dr::Operand::LiteralInt32(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     } {
                         vec.push(item);
@@ -98,13 +98,13 @@ impl LiftContext {
             251u32 => Ok(ops::Branch::Switch {
                 selector: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 default: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -116,7 +116,7 @@ impl LiftContext {
                             Some(&dr::Operand::IdRef(second)),
                         ) => Some((first, self.lookup_jump(second))),
                         (None, None) => None,
-                        _ => Err(OperandError::WrongType)?,
+                        _ => return Err(OperandError::WrongType.into()),
                     } {
                         vec.push(item);
                     }
@@ -128,7 +128,7 @@ impl LiftContext {
             254u32 => Ok(ops::Branch::ReturnValue {
                 value: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -137,13 +137,13 @@ impl LiftContext {
             256u32 => Ok(ops::Branch::LifetimeStart {
                 pointer: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 size: (match operands.next() {
                     Some(&dr::Operand::LiteralInt32(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -151,13 +151,13 @@ impl LiftContext {
             257u32 => Ok(ops::Branch::LifetimeStop {
                 pointer: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 size: (match operands.next() {
                     Some(&dr::Operand::LiteralInt32(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -185,7 +185,7 @@ impl LiftContext {
             2u32 => Ok(ops::Op::SourceContinued {
                 continued_source: (match operands.next() {
                     Some(&dr::Operand::LiteralString(ref value)) => Some(value.clone()),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -193,31 +193,31 @@ impl LiftContext {
             3u32 => Ok(ops::Op::Source {
                 source_language: (match operands.next() {
                     Some(&dr::Operand::SourceLanguage(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 version: (match operands.next() {
                     Some(&dr::Operand::LiteralInt32(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 file: match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 },
                 source: match operands.next() {
                     Some(&dr::Operand::LiteralString(ref value)) => Some(value.clone()),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 },
             }),
             4u32 => Ok(ops::Op::SourceExtension {
                 extension: (match operands.next() {
                     Some(&dr::Operand::LiteralString(ref value)) => Some(value.clone()),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -225,13 +225,13 @@ impl LiftContext {
             5u32 => Ok(ops::Op::Name {
                 target: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 name: (match operands.next() {
                     Some(&dr::Operand::LiteralString(ref value)) => Some(value.clone()),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -239,19 +239,19 @@ impl LiftContext {
             6u32 => Ok(ops::Op::MemberName {
                 ty: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(self.types.lookup_token(*value)),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 member: (match operands.next() {
                     Some(&dr::Operand::LiteralInt32(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 name: (match operands.next() {
                     Some(&dr::Operand::LiteralString(ref value)) => Some(value.clone()),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -259,7 +259,7 @@ impl LiftContext {
             7u32 => Ok(ops::Op::String {
                 string: (match operands.next() {
                     Some(&dr::Operand::LiteralString(ref value)) => Some(value.clone()),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -267,19 +267,19 @@ impl LiftContext {
             8u32 => Ok(ops::Op::Line {
                 file: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 line: (match operands.next() {
                     Some(&dr::Operand::LiteralInt32(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 column: (match operands.next() {
                     Some(&dr::Operand::LiteralInt32(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -287,32 +287,32 @@ impl LiftContext {
             59u32 => Ok(ops::Op::Variable {
                 storage_class: (match operands.next() {
                     Some(&dr::Operand::StorageClass(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 initializer: match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 },
             }),
             60u32 => Ok(ops::Op::ImageTexelPointer {
                 image: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 coordinate: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 sample: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -320,93 +320,93 @@ impl LiftContext {
             61u32 => Ok(ops::Op::Load {
                 pointer: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 memory_access: match operands.next() {
                     Some(&dr::Operand::MemoryAccess(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 },
             }),
             62u32 => Ok(ops::Op::Store {
                 pointer: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 object: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 memory_access: match operands.next() {
                     Some(&dr::Operand::MemoryAccess(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 },
             }),
             63u32 => Ok(ops::Op::CopyMemory {
                 target: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 source: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 memory_access: match operands.next() {
                     Some(&dr::Operand::MemoryAccess(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 },
                 memory_access_2: match operands.next() {
                     Some(&dr::Operand::MemoryAccess(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 },
             }),
             64u32 => Ok(ops::Op::CopyMemorySized {
                 target: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 source: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 size: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 memory_access: match operands.next() {
                     Some(&dr::Operand::MemoryAccess(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 },
                 memory_access_2: match operands.next() {
                     Some(&dr::Operand::MemoryAccess(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 },
             }),
             65u32 => Ok(ops::Op::AccessChain {
                 base: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -414,7 +414,7 @@ impl LiftContext {
                     let mut vec = Vec::new();
                     while let Some(item) = match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     } {
                         vec.push(item);
@@ -425,7 +425,7 @@ impl LiftContext {
             66u32 => Ok(ops::Op::InBoundsAccessChain {
                 base: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -433,7 +433,7 @@ impl LiftContext {
                     let mut vec = Vec::new();
                     while let Some(item) = match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     } {
                         vec.push(item);
@@ -444,13 +444,13 @@ impl LiftContext {
             67u32 => Ok(ops::Op::PtrAccessChain {
                 base: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 element: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -458,7 +458,7 @@ impl LiftContext {
                     let mut vec = Vec::new();
                     while let Some(item) = match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     } {
                         vec.push(item);
@@ -469,13 +469,13 @@ impl LiftContext {
             68u32 => Ok(ops::Op::ArrayLength {
                 structure: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 array_member: (match operands.next() {
                     Some(&dr::Operand::LiteralInt32(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -483,7 +483,7 @@ impl LiftContext {
             69u32 => Ok(ops::Op::GenericPtrMemSemantics {
                 pointer: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -491,13 +491,13 @@ impl LiftContext {
             70u32 => Ok(ops::Op::InBoundsPtrAccessChain {
                 base: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 element: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -505,7 +505,7 @@ impl LiftContext {
                     let mut vec = Vec::new();
                     while let Some(item) = match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     } {
                         vec.push(item);
@@ -516,13 +516,13 @@ impl LiftContext {
             71u32 => Ok(ops::Op::Decorate {
                 target: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 decoration: (match operands.next() {
                     Some(&dr::Operand::Decoration(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -530,19 +530,19 @@ impl LiftContext {
             72u32 => Ok(ops::Op::MemberDecorate {
                 structure_type: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(self.types.lookup_token(*value)),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 member: (match operands.next() {
                     Some(&dr::Operand::LiteralInt32(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 decoration: (match operands.next() {
                     Some(&dr::Operand::Decoration(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -551,7 +551,7 @@ impl LiftContext {
             74u32 => Ok(ops::Op::GroupDecorate {
                 decoration_group: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -559,7 +559,7 @@ impl LiftContext {
                     let mut vec = Vec::new();
                     while let Some(item) = match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     } {
                         vec.push(item);
@@ -570,7 +570,7 @@ impl LiftContext {
             75u32 => Ok(ops::Op::GroupMemberDecorate {
                 decoration_group: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -582,7 +582,7 @@ impl LiftContext {
                             Some(&dr::Operand::LiteralInt32(second)),
                         ) => Some((self.lookup_jump(first), second)),
                         (None, None) => None,
-                        _ => Err(OperandError::WrongType)?,
+                        _ => return Err(OperandError::WrongType.into()),
                     } {
                         vec.push(item);
                     }
@@ -592,13 +592,13 @@ impl LiftContext {
             77u32 => Ok(ops::Op::VectorExtractDynamic {
                 vector: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 index: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -606,19 +606,19 @@ impl LiftContext {
             78u32 => Ok(ops::Op::VectorInsertDynamic {
                 vector: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 component: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 index: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -626,13 +626,13 @@ impl LiftContext {
             79u32 => Ok(ops::Op::VectorShuffle {
                 vector_1: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 vector_2: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -640,7 +640,7 @@ impl LiftContext {
                     let mut vec = Vec::new();
                     while let Some(item) = match operands.next() {
                         Some(&dr::Operand::LiteralInt32(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     } {
                         vec.push(item);
@@ -653,7 +653,7 @@ impl LiftContext {
                     let mut vec = Vec::new();
                     while let Some(item) = match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     } {
                         vec.push(item);
@@ -664,7 +664,7 @@ impl LiftContext {
             81u32 => Ok(ops::Op::CompositeExtract {
                 composite: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -672,7 +672,7 @@ impl LiftContext {
                     let mut vec = Vec::new();
                     while let Some(item) = match operands.next() {
                         Some(&dr::Operand::LiteralInt32(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     } {
                         vec.push(item);
@@ -683,13 +683,13 @@ impl LiftContext {
             82u32 => Ok(ops::Op::CompositeInsert {
                 object: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 composite: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -697,7 +697,7 @@ impl LiftContext {
                     let mut vec = Vec::new();
                     while let Some(item) = match operands.next() {
                         Some(&dr::Operand::LiteralInt32(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     } {
                         vec.push(item);
@@ -708,7 +708,7 @@ impl LiftContext {
             83u32 => Ok(ops::Op::CopyObject {
                 operand: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -716,7 +716,7 @@ impl LiftContext {
             84u32 => Ok(ops::Op::Transpose {
                 matrix: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -724,13 +724,13 @@ impl LiftContext {
             86u32 => Ok(ops::Op::SampledImage {
                 image: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 sampler: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -738,54 +738,54 @@ impl LiftContext {
             87u32 => Ok(ops::Op::ImageSampleImplicitLod {
                 sampled_image: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 coordinate: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 image_operands: match operands.next() {
                     Some(&dr::Operand::ImageOperands(ref value)) => {
                         let operands = operands
-                            .map(|op| match op {
-                                &dr::Operand::IdRef(second) => Ok(second),
+                            .map(|op| match *op {
+                                dr::Operand::IdRef(second) => Ok(second),
                                 _ => Err(OperandError::WrongType),
                             })
                             .collect::<Result<Vec<_>, _>>()?;
                         Some((*value, operands))
                     }
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 },
             }),
             88u32 => Ok(ops::Op::ImageSampleExplicitLod {
                 sampled_image: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 coordinate: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 image_operands: (match operands.next() {
                     Some(&dr::Operand::ImageOperands(ref value)) => {
                         let operands = operands
-                            .map(|op| match op {
-                                &dr::Operand::IdRef(second) => Ok(second),
+                            .map(|op| match *op {
+                                dr::Operand::IdRef(second) => Ok(second),
                                 _ => Err(OperandError::WrongType),
                             })
                             .collect::<Result<Vec<_>, _>>()?;
                         Some((*value, operands))
                     }
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -793,66 +793,66 @@ impl LiftContext {
             89u32 => Ok(ops::Op::ImageSampleDrefImplicitLod {
                 sampled_image: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 coordinate: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 d_ref: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 image_operands: match operands.next() {
                     Some(&dr::Operand::ImageOperands(ref value)) => {
                         let operands = operands
-                            .map(|op| match op {
-                                &dr::Operand::IdRef(second) => Ok(second),
+                            .map(|op| match *op {
+                                dr::Operand::IdRef(second) => Ok(second),
                                 _ => Err(OperandError::WrongType),
                             })
                             .collect::<Result<Vec<_>, _>>()?;
                         Some((*value, operands))
                     }
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 },
             }),
             90u32 => Ok(ops::Op::ImageSampleDrefExplicitLod {
                 sampled_image: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 coordinate: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 d_ref: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 image_operands: (match operands.next() {
                     Some(&dr::Operand::ImageOperands(ref value)) => {
                         let operands = operands
-                            .map(|op| match op {
-                                &dr::Operand::IdRef(second) => Ok(second),
+                            .map(|op| match *op {
+                                dr::Operand::IdRef(second) => Ok(second),
                                 _ => Err(OperandError::WrongType),
                             })
                             .collect::<Result<Vec<_>, _>>()?;
                         Some((*value, operands))
                     }
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -860,54 +860,54 @@ impl LiftContext {
             91u32 => Ok(ops::Op::ImageSampleProjImplicitLod {
                 sampled_image: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 coordinate: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 image_operands: match operands.next() {
                     Some(&dr::Operand::ImageOperands(ref value)) => {
                         let operands = operands
-                            .map(|op| match op {
-                                &dr::Operand::IdRef(second) => Ok(second),
+                            .map(|op| match *op {
+                                dr::Operand::IdRef(second) => Ok(second),
                                 _ => Err(OperandError::WrongType),
                             })
                             .collect::<Result<Vec<_>, _>>()?;
                         Some((*value, operands))
                     }
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 },
             }),
             92u32 => Ok(ops::Op::ImageSampleProjExplicitLod {
                 sampled_image: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 coordinate: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 image_operands: (match operands.next() {
                     Some(&dr::Operand::ImageOperands(ref value)) => {
                         let operands = operands
-                            .map(|op| match op {
-                                &dr::Operand::IdRef(second) => Ok(second),
+                            .map(|op| match *op {
+                                dr::Operand::IdRef(second) => Ok(second),
                                 _ => Err(OperandError::WrongType),
                             })
                             .collect::<Result<Vec<_>, _>>()?;
                         Some((*value, operands))
                     }
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -915,66 +915,66 @@ impl LiftContext {
             93u32 => Ok(ops::Op::ImageSampleProjDrefImplicitLod {
                 sampled_image: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 coordinate: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 d_ref: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 image_operands: match operands.next() {
                     Some(&dr::Operand::ImageOperands(ref value)) => {
                         let operands = operands
-                            .map(|op| match op {
-                                &dr::Operand::IdRef(second) => Ok(second),
+                            .map(|op| match *op {
+                                dr::Operand::IdRef(second) => Ok(second),
                                 _ => Err(OperandError::WrongType),
                             })
                             .collect::<Result<Vec<_>, _>>()?;
                         Some((*value, operands))
                     }
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 },
             }),
             94u32 => Ok(ops::Op::ImageSampleProjDrefExplicitLod {
                 sampled_image: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 coordinate: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 d_ref: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 image_operands: (match operands.next() {
                     Some(&dr::Operand::ImageOperands(ref value)) => {
                         let operands = operands
-                            .map(|op| match op {
-                                &dr::Operand::IdRef(second) => Ok(second),
+                            .map(|op| match *op {
+                                dr::Operand::IdRef(second) => Ok(second),
                                 _ => Err(OperandError::WrongType),
                             })
                             .collect::<Result<Vec<_>, _>>()?;
                         Some((*value, operands))
                     }
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -982,160 +982,160 @@ impl LiftContext {
             95u32 => Ok(ops::Op::ImageFetch {
                 image: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 coordinate: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 image_operands: match operands.next() {
                     Some(&dr::Operand::ImageOperands(ref value)) => {
                         let operands = operands
-                            .map(|op| match op {
-                                &dr::Operand::IdRef(second) => Ok(second),
+                            .map(|op| match *op {
+                                dr::Operand::IdRef(second) => Ok(second),
                                 _ => Err(OperandError::WrongType),
                             })
                             .collect::<Result<Vec<_>, _>>()?;
                         Some((*value, operands))
                     }
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 },
             }),
             96u32 => Ok(ops::Op::ImageGather {
                 sampled_image: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 coordinate: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 component: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 image_operands: match operands.next() {
                     Some(&dr::Operand::ImageOperands(ref value)) => {
                         let operands = operands
-                            .map(|op| match op {
-                                &dr::Operand::IdRef(second) => Ok(second),
+                            .map(|op| match *op {
+                                dr::Operand::IdRef(second) => Ok(second),
                                 _ => Err(OperandError::WrongType),
                             })
                             .collect::<Result<Vec<_>, _>>()?;
                         Some((*value, operands))
                     }
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 },
             }),
             97u32 => Ok(ops::Op::ImageDrefGather {
                 sampled_image: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 coordinate: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 d_ref: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 image_operands: match operands.next() {
                     Some(&dr::Operand::ImageOperands(ref value)) => {
                         let operands = operands
-                            .map(|op| match op {
-                                &dr::Operand::IdRef(second) => Ok(second),
+                            .map(|op| match *op {
+                                dr::Operand::IdRef(second) => Ok(second),
                                 _ => Err(OperandError::WrongType),
                             })
                             .collect::<Result<Vec<_>, _>>()?;
                         Some((*value, operands))
                     }
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 },
             }),
             98u32 => Ok(ops::Op::ImageRead {
                 image: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 coordinate: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 image_operands: match operands.next() {
                     Some(&dr::Operand::ImageOperands(ref value)) => {
                         let operands = operands
-                            .map(|op| match op {
-                                &dr::Operand::IdRef(second) => Ok(second),
+                            .map(|op| match *op {
+                                dr::Operand::IdRef(second) => Ok(second),
                                 _ => Err(OperandError::WrongType),
                             })
                             .collect::<Result<Vec<_>, _>>()?;
                         Some((*value, operands))
                     }
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 },
             }),
             99u32 => Ok(ops::Op::ImageWrite {
                 image: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 coordinate: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 texel: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 image_operands: match operands.next() {
                     Some(&dr::Operand::ImageOperands(ref value)) => {
                         let operands = operands
-                            .map(|op| match op {
-                                &dr::Operand::IdRef(second) => Ok(second),
+                            .map(|op| match *op {
+                                dr::Operand::IdRef(second) => Ok(second),
                                 _ => Err(OperandError::WrongType),
                             })
                             .collect::<Result<Vec<_>, _>>()?;
                         Some((*value, operands))
                     }
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 },
             }),
             100u32 => Ok(ops::Op::Image {
                 sampled_image: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -1143,7 +1143,7 @@ impl LiftContext {
             101u32 => Ok(ops::Op::ImageQueryFormat {
                 image: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -1151,7 +1151,7 @@ impl LiftContext {
             102u32 => Ok(ops::Op::ImageQueryOrder {
                 image: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -1159,13 +1159,13 @@ impl LiftContext {
             103u32 => Ok(ops::Op::ImageQuerySizeLod {
                 image: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 level_of_detail: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -1173,7 +1173,7 @@ impl LiftContext {
             104u32 => Ok(ops::Op::ImageQuerySize {
                 image: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -1181,13 +1181,13 @@ impl LiftContext {
             105u32 => Ok(ops::Op::ImageQueryLod {
                 sampled_image: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 coordinate: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -1195,7 +1195,7 @@ impl LiftContext {
             106u32 => Ok(ops::Op::ImageQueryLevels {
                 image: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -1203,7 +1203,7 @@ impl LiftContext {
             107u32 => Ok(ops::Op::ImageQuerySamples {
                 image: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -1211,7 +1211,7 @@ impl LiftContext {
             109u32 => Ok(ops::Op::ConvertFToU {
                 float_value: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -1219,7 +1219,7 @@ impl LiftContext {
             110u32 => Ok(ops::Op::ConvertFToS {
                 float_value: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -1227,7 +1227,7 @@ impl LiftContext {
             111u32 => Ok(ops::Op::ConvertSToF {
                 signed_value: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -1235,7 +1235,7 @@ impl LiftContext {
             112u32 => Ok(ops::Op::ConvertUToF {
                 unsigned_value: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -1243,7 +1243,7 @@ impl LiftContext {
             113u32 => Ok(ops::Op::UConvert {
                 unsigned_value: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -1251,7 +1251,7 @@ impl LiftContext {
             114u32 => Ok(ops::Op::SConvert {
                 signed_value: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -1259,7 +1259,7 @@ impl LiftContext {
             115u32 => Ok(ops::Op::FConvert {
                 float_value: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -1267,7 +1267,7 @@ impl LiftContext {
             116u32 => Ok(ops::Op::QuantizeToF16 {
                 value: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -1275,7 +1275,7 @@ impl LiftContext {
             117u32 => Ok(ops::Op::ConvertPtrToU {
                 pointer: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -1283,7 +1283,7 @@ impl LiftContext {
             118u32 => Ok(ops::Op::SatConvertSToU {
                 signed_value: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -1291,7 +1291,7 @@ impl LiftContext {
             119u32 => Ok(ops::Op::SatConvertUToS {
                 unsigned_value: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -1299,7 +1299,7 @@ impl LiftContext {
             120u32 => Ok(ops::Op::ConvertUToPtr {
                 integer_value: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -1307,7 +1307,7 @@ impl LiftContext {
             121u32 => Ok(ops::Op::PtrCastToGeneric {
                 pointer: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -1315,7 +1315,7 @@ impl LiftContext {
             122u32 => Ok(ops::Op::GenericCastToPtr {
                 pointer: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -1323,13 +1323,13 @@ impl LiftContext {
             123u32 => Ok(ops::Op::GenericCastToPtrExplicit {
                 pointer: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 storage: (match operands.next() {
                     Some(&dr::Operand::StorageClass(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -1337,7 +1337,7 @@ impl LiftContext {
             124u32 => Ok(ops::Op::Bitcast {
                 operand: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -1345,7 +1345,7 @@ impl LiftContext {
             126u32 => Ok(ops::Op::SNegate {
                 operand: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -1353,7 +1353,7 @@ impl LiftContext {
             127u32 => Ok(ops::Op::FNegate {
                 operand: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -1361,13 +1361,13 @@ impl LiftContext {
             128u32 => Ok(ops::Op::IAdd {
                 operand_1: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operand_2: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -1375,13 +1375,13 @@ impl LiftContext {
             129u32 => Ok(ops::Op::FAdd {
                 operand_1: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operand_2: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -1389,13 +1389,13 @@ impl LiftContext {
             130u32 => Ok(ops::Op::ISub {
                 operand_1: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operand_2: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -1403,13 +1403,13 @@ impl LiftContext {
             131u32 => Ok(ops::Op::FSub {
                 operand_1: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operand_2: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -1417,13 +1417,13 @@ impl LiftContext {
             132u32 => Ok(ops::Op::IMul {
                 operand_1: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operand_2: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -1431,13 +1431,13 @@ impl LiftContext {
             133u32 => Ok(ops::Op::FMul {
                 operand_1: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operand_2: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -1445,13 +1445,13 @@ impl LiftContext {
             134u32 => Ok(ops::Op::UDiv {
                 operand_1: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operand_2: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -1459,13 +1459,13 @@ impl LiftContext {
             135u32 => Ok(ops::Op::SDiv {
                 operand_1: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operand_2: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -1473,13 +1473,13 @@ impl LiftContext {
             136u32 => Ok(ops::Op::FDiv {
                 operand_1: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operand_2: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -1487,13 +1487,13 @@ impl LiftContext {
             137u32 => Ok(ops::Op::UMod {
                 operand_1: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operand_2: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -1501,13 +1501,13 @@ impl LiftContext {
             138u32 => Ok(ops::Op::SRem {
                 operand_1: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operand_2: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -1515,13 +1515,13 @@ impl LiftContext {
             139u32 => Ok(ops::Op::SMod {
                 operand_1: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operand_2: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -1529,13 +1529,13 @@ impl LiftContext {
             140u32 => Ok(ops::Op::FRem {
                 operand_1: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operand_2: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -1543,13 +1543,13 @@ impl LiftContext {
             141u32 => Ok(ops::Op::FMod {
                 operand_1: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operand_2: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -1557,13 +1557,13 @@ impl LiftContext {
             142u32 => Ok(ops::Op::VectorTimesScalar {
                 vector: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 scalar: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -1571,13 +1571,13 @@ impl LiftContext {
             143u32 => Ok(ops::Op::MatrixTimesScalar {
                 matrix: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 scalar: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -1585,13 +1585,13 @@ impl LiftContext {
             144u32 => Ok(ops::Op::VectorTimesMatrix {
                 vector: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 matrix: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -1599,13 +1599,13 @@ impl LiftContext {
             145u32 => Ok(ops::Op::MatrixTimesVector {
                 matrix: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 vector: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -1613,13 +1613,13 @@ impl LiftContext {
             146u32 => Ok(ops::Op::MatrixTimesMatrix {
                 left_matrix: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 right_matrix: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -1627,13 +1627,13 @@ impl LiftContext {
             147u32 => Ok(ops::Op::OuterProduct {
                 vector_1: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 vector_2: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -1641,13 +1641,13 @@ impl LiftContext {
             148u32 => Ok(ops::Op::Dot {
                 vector_1: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 vector_2: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -1655,13 +1655,13 @@ impl LiftContext {
             149u32 => Ok(ops::Op::IAddCarry {
                 operand_1: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operand_2: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -1669,13 +1669,13 @@ impl LiftContext {
             150u32 => Ok(ops::Op::ISubBorrow {
                 operand_1: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operand_2: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -1683,13 +1683,13 @@ impl LiftContext {
             151u32 => Ok(ops::Op::UMulExtended {
                 operand_1: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operand_2: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -1697,13 +1697,13 @@ impl LiftContext {
             152u32 => Ok(ops::Op::SMulExtended {
                 operand_1: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operand_2: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -1711,7 +1711,7 @@ impl LiftContext {
             154u32 => Ok(ops::Op::Any {
                 vector: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -1719,7 +1719,7 @@ impl LiftContext {
             155u32 => Ok(ops::Op::All {
                 vector: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -1727,7 +1727,7 @@ impl LiftContext {
             156u32 => Ok(ops::Op::IsNan {
                 x: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -1735,7 +1735,7 @@ impl LiftContext {
             157u32 => Ok(ops::Op::IsInf {
                 x: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -1743,7 +1743,7 @@ impl LiftContext {
             158u32 => Ok(ops::Op::IsFinite {
                 x: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -1751,7 +1751,7 @@ impl LiftContext {
             159u32 => Ok(ops::Op::IsNormal {
                 x: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -1759,7 +1759,7 @@ impl LiftContext {
             160u32 => Ok(ops::Op::SignBitSet {
                 x: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -1767,13 +1767,13 @@ impl LiftContext {
             161u32 => Ok(ops::Op::LessOrGreater {
                 x: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 y: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -1781,13 +1781,13 @@ impl LiftContext {
             162u32 => Ok(ops::Op::Ordered {
                 x: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 y: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -1795,13 +1795,13 @@ impl LiftContext {
             163u32 => Ok(ops::Op::Unordered {
                 x: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 y: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -1809,13 +1809,13 @@ impl LiftContext {
             164u32 => Ok(ops::Op::LogicalEqual {
                 operand_1: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operand_2: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -1823,13 +1823,13 @@ impl LiftContext {
             165u32 => Ok(ops::Op::LogicalNotEqual {
                 operand_1: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operand_2: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -1837,13 +1837,13 @@ impl LiftContext {
             166u32 => Ok(ops::Op::LogicalOr {
                 operand_1: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operand_2: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -1851,13 +1851,13 @@ impl LiftContext {
             167u32 => Ok(ops::Op::LogicalAnd {
                 operand_1: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operand_2: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -1865,7 +1865,7 @@ impl LiftContext {
             168u32 => Ok(ops::Op::LogicalNot {
                 operand: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -1873,19 +1873,19 @@ impl LiftContext {
             169u32 => Ok(ops::Op::Select {
                 condition: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 object_1: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 object_2: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -1893,13 +1893,13 @@ impl LiftContext {
             170u32 => Ok(ops::Op::IEqual {
                 operand_1: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operand_2: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -1907,13 +1907,13 @@ impl LiftContext {
             171u32 => Ok(ops::Op::INotEqual {
                 operand_1: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operand_2: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -1921,13 +1921,13 @@ impl LiftContext {
             172u32 => Ok(ops::Op::UGreaterThan {
                 operand_1: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operand_2: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -1935,13 +1935,13 @@ impl LiftContext {
             173u32 => Ok(ops::Op::SGreaterThan {
                 operand_1: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operand_2: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -1949,13 +1949,13 @@ impl LiftContext {
             174u32 => Ok(ops::Op::UGreaterThanEqual {
                 operand_1: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operand_2: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -1963,13 +1963,13 @@ impl LiftContext {
             175u32 => Ok(ops::Op::SGreaterThanEqual {
                 operand_1: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operand_2: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -1977,13 +1977,13 @@ impl LiftContext {
             176u32 => Ok(ops::Op::ULessThan {
                 operand_1: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operand_2: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -1991,13 +1991,13 @@ impl LiftContext {
             177u32 => Ok(ops::Op::SLessThan {
                 operand_1: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operand_2: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -2005,13 +2005,13 @@ impl LiftContext {
             178u32 => Ok(ops::Op::ULessThanEqual {
                 operand_1: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operand_2: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -2019,13 +2019,13 @@ impl LiftContext {
             179u32 => Ok(ops::Op::SLessThanEqual {
                 operand_1: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operand_2: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -2033,13 +2033,13 @@ impl LiftContext {
             180u32 => Ok(ops::Op::FOrdEqual {
                 operand_1: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operand_2: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -2047,13 +2047,13 @@ impl LiftContext {
             181u32 => Ok(ops::Op::FUnordEqual {
                 operand_1: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operand_2: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -2061,13 +2061,13 @@ impl LiftContext {
             182u32 => Ok(ops::Op::FOrdNotEqual {
                 operand_1: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operand_2: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -2075,13 +2075,13 @@ impl LiftContext {
             183u32 => Ok(ops::Op::FUnordNotEqual {
                 operand_1: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operand_2: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -2089,13 +2089,13 @@ impl LiftContext {
             184u32 => Ok(ops::Op::FOrdLessThan {
                 operand_1: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operand_2: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -2103,13 +2103,13 @@ impl LiftContext {
             185u32 => Ok(ops::Op::FUnordLessThan {
                 operand_1: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operand_2: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -2117,13 +2117,13 @@ impl LiftContext {
             186u32 => Ok(ops::Op::FOrdGreaterThan {
                 operand_1: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operand_2: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -2131,13 +2131,13 @@ impl LiftContext {
             187u32 => Ok(ops::Op::FUnordGreaterThan {
                 operand_1: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operand_2: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -2145,13 +2145,13 @@ impl LiftContext {
             188u32 => Ok(ops::Op::FOrdLessThanEqual {
                 operand_1: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operand_2: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -2159,13 +2159,13 @@ impl LiftContext {
             189u32 => Ok(ops::Op::FUnordLessThanEqual {
                 operand_1: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operand_2: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -2173,13 +2173,13 @@ impl LiftContext {
             190u32 => Ok(ops::Op::FOrdGreaterThanEqual {
                 operand_1: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operand_2: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -2187,13 +2187,13 @@ impl LiftContext {
             191u32 => Ok(ops::Op::FUnordGreaterThanEqual {
                 operand_1: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operand_2: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -2201,13 +2201,13 @@ impl LiftContext {
             194u32 => Ok(ops::Op::ShiftRightLogical {
                 base: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 shift: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -2215,13 +2215,13 @@ impl LiftContext {
             195u32 => Ok(ops::Op::ShiftRightArithmetic {
                 base: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 shift: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -2229,13 +2229,13 @@ impl LiftContext {
             196u32 => Ok(ops::Op::ShiftLeftLogical {
                 base: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 shift: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -2243,13 +2243,13 @@ impl LiftContext {
             197u32 => Ok(ops::Op::BitwiseOr {
                 operand_1: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operand_2: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -2257,13 +2257,13 @@ impl LiftContext {
             198u32 => Ok(ops::Op::BitwiseXor {
                 operand_1: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operand_2: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -2271,13 +2271,13 @@ impl LiftContext {
             199u32 => Ok(ops::Op::BitwiseAnd {
                 operand_1: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operand_2: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -2285,7 +2285,7 @@ impl LiftContext {
             200u32 => Ok(ops::Op::Not {
                 operand: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -2293,25 +2293,25 @@ impl LiftContext {
             201u32 => Ok(ops::Op::BitFieldInsert {
                 base: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 insert: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 offset: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 count: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -2319,19 +2319,19 @@ impl LiftContext {
             202u32 => Ok(ops::Op::BitFieldSExtract {
                 base: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 offset: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 count: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -2339,19 +2339,19 @@ impl LiftContext {
             203u32 => Ok(ops::Op::BitFieldUExtract {
                 base: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 offset: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 count: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -2359,7 +2359,7 @@ impl LiftContext {
             204u32 => Ok(ops::Op::BitReverse {
                 base: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -2367,7 +2367,7 @@ impl LiftContext {
             205u32 => Ok(ops::Op::BitCount {
                 base: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -2375,7 +2375,7 @@ impl LiftContext {
             207u32 => Ok(ops::Op::DPdx {
                 p: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -2383,7 +2383,7 @@ impl LiftContext {
             208u32 => Ok(ops::Op::DPdy {
                 p: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -2391,7 +2391,7 @@ impl LiftContext {
             209u32 => Ok(ops::Op::Fwidth {
                 p: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -2399,7 +2399,7 @@ impl LiftContext {
             210u32 => Ok(ops::Op::DPdxFine {
                 p: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -2407,7 +2407,7 @@ impl LiftContext {
             211u32 => Ok(ops::Op::DPdyFine {
                 p: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -2415,7 +2415,7 @@ impl LiftContext {
             212u32 => Ok(ops::Op::FwidthFine {
                 p: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -2423,7 +2423,7 @@ impl LiftContext {
             213u32 => Ok(ops::Op::DPdxCoarse {
                 p: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -2431,7 +2431,7 @@ impl LiftContext {
             214u32 => Ok(ops::Op::DPdyCoarse {
                 p: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -2439,7 +2439,7 @@ impl LiftContext {
             215u32 => Ok(ops::Op::FwidthCoarse {
                 p: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -2449,7 +2449,7 @@ impl LiftContext {
             220u32 => Ok(ops::Op::EmitStreamVertex {
                 stream: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -2457,7 +2457,7 @@ impl LiftContext {
             221u32 => Ok(ops::Op::EndStreamPrimitive {
                 stream: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -2465,19 +2465,19 @@ impl LiftContext {
             224u32 => Ok(ops::Op::ControlBarrier {
                 execution: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 memory: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 semantics: (match operands.next() {
                     Some(&dr::Operand::IdMemorySemantics(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -2485,13 +2485,13 @@ impl LiftContext {
             225u32 => Ok(ops::Op::MemoryBarrier {
                 memory: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 semantics: (match operands.next() {
                     Some(&dr::Operand::IdMemorySemantics(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -2499,19 +2499,19 @@ impl LiftContext {
             227u32 => Ok(ops::Op::AtomicLoad {
                 pointer: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 memory: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 semantics: (match operands.next() {
                     Some(&dr::Operand::IdMemorySemantics(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -2519,25 +2519,25 @@ impl LiftContext {
             228u32 => Ok(ops::Op::AtomicStore {
                 pointer: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 memory: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 semantics: (match operands.next() {
                     Some(&dr::Operand::IdMemorySemantics(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 value: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -2545,25 +2545,25 @@ impl LiftContext {
             229u32 => Ok(ops::Op::AtomicExchange {
                 pointer: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 memory: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 semantics: (match operands.next() {
                     Some(&dr::Operand::IdMemorySemantics(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 value: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -2571,37 +2571,37 @@ impl LiftContext {
             230u32 => Ok(ops::Op::AtomicCompareExchange {
                 pointer: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 memory: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 equal: (match operands.next() {
                     Some(&dr::Operand::IdMemorySemantics(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 unequal: (match operands.next() {
                     Some(&dr::Operand::IdMemorySemantics(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 value: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 comparator: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -2609,37 +2609,37 @@ impl LiftContext {
             231u32 => Ok(ops::Op::AtomicCompareExchangeWeak {
                 pointer: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 memory: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 equal: (match operands.next() {
                     Some(&dr::Operand::IdMemorySemantics(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 unequal: (match operands.next() {
                     Some(&dr::Operand::IdMemorySemantics(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 value: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 comparator: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -2647,19 +2647,19 @@ impl LiftContext {
             232u32 => Ok(ops::Op::AtomicIIncrement {
                 pointer: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 memory: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 semantics: (match operands.next() {
                     Some(&dr::Operand::IdMemorySemantics(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -2667,19 +2667,19 @@ impl LiftContext {
             233u32 => Ok(ops::Op::AtomicIDecrement {
                 pointer: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 memory: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 semantics: (match operands.next() {
                     Some(&dr::Operand::IdMemorySemantics(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -2687,25 +2687,25 @@ impl LiftContext {
             234u32 => Ok(ops::Op::AtomicIAdd {
                 pointer: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 memory: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 semantics: (match operands.next() {
                     Some(&dr::Operand::IdMemorySemantics(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 value: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -2713,25 +2713,25 @@ impl LiftContext {
             235u32 => Ok(ops::Op::AtomicISub {
                 pointer: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 memory: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 semantics: (match operands.next() {
                     Some(&dr::Operand::IdMemorySemantics(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 value: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -2739,25 +2739,25 @@ impl LiftContext {
             236u32 => Ok(ops::Op::AtomicSMin {
                 pointer: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 memory: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 semantics: (match operands.next() {
                     Some(&dr::Operand::IdMemorySemantics(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 value: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -2765,25 +2765,25 @@ impl LiftContext {
             237u32 => Ok(ops::Op::AtomicUMin {
                 pointer: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 memory: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 semantics: (match operands.next() {
                     Some(&dr::Operand::IdMemorySemantics(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 value: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -2791,25 +2791,25 @@ impl LiftContext {
             238u32 => Ok(ops::Op::AtomicSMax {
                 pointer: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 memory: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 semantics: (match operands.next() {
                     Some(&dr::Operand::IdMemorySemantics(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 value: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -2817,25 +2817,25 @@ impl LiftContext {
             239u32 => Ok(ops::Op::AtomicUMax {
                 pointer: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 memory: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 semantics: (match operands.next() {
                     Some(&dr::Operand::IdMemorySemantics(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 value: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -2843,25 +2843,25 @@ impl LiftContext {
             240u32 => Ok(ops::Op::AtomicAnd {
                 pointer: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 memory: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 semantics: (match operands.next() {
                     Some(&dr::Operand::IdMemorySemantics(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 value: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -2869,25 +2869,25 @@ impl LiftContext {
             241u32 => Ok(ops::Op::AtomicOr {
                 pointer: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 memory: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 semantics: (match operands.next() {
                     Some(&dr::Operand::IdMemorySemantics(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 value: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -2895,25 +2895,25 @@ impl LiftContext {
             242u32 => Ok(ops::Op::AtomicXor {
                 pointer: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 memory: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 semantics: (match operands.next() {
                     Some(&dr::Operand::IdMemorySemantics(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 value: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -2921,37 +2921,37 @@ impl LiftContext {
             259u32 => Ok(ops::Op::GroupAsyncCopy {
                 execution: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 destination: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 source: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 num_elements: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 stride: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 event: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -2959,19 +2959,19 @@ impl LiftContext {
             260u32 => Ok(ops::Op::GroupWaitEvents {
                 execution: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 num_events: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 events_list: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -2979,13 +2979,13 @@ impl LiftContext {
             261u32 => Ok(ops::Op::GroupAll {
                 execution: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 predicate: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -2993,13 +2993,13 @@ impl LiftContext {
             262u32 => Ok(ops::Op::GroupAny {
                 execution: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 predicate: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -3007,19 +3007,19 @@ impl LiftContext {
             263u32 => Ok(ops::Op::GroupBroadcast {
                 execution: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 value: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 local_id: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -3027,19 +3027,19 @@ impl LiftContext {
             264u32 => Ok(ops::Op::GroupIAdd {
                 execution: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operation: (match operands.next() {
                     Some(&dr::Operand::GroupOperation(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 x: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -3047,19 +3047,19 @@ impl LiftContext {
             265u32 => Ok(ops::Op::GroupFAdd {
                 execution: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operation: (match operands.next() {
                     Some(&dr::Operand::GroupOperation(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 x: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -3067,19 +3067,19 @@ impl LiftContext {
             266u32 => Ok(ops::Op::GroupFMin {
                 execution: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operation: (match operands.next() {
                     Some(&dr::Operand::GroupOperation(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 x: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -3087,19 +3087,19 @@ impl LiftContext {
             267u32 => Ok(ops::Op::GroupUMin {
                 execution: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operation: (match operands.next() {
                     Some(&dr::Operand::GroupOperation(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 x: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -3107,19 +3107,19 @@ impl LiftContext {
             268u32 => Ok(ops::Op::GroupSMin {
                 execution: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operation: (match operands.next() {
                     Some(&dr::Operand::GroupOperation(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 x: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -3127,19 +3127,19 @@ impl LiftContext {
             269u32 => Ok(ops::Op::GroupFMax {
                 execution: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operation: (match operands.next() {
                     Some(&dr::Operand::GroupOperation(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 x: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -3147,19 +3147,19 @@ impl LiftContext {
             270u32 => Ok(ops::Op::GroupUMax {
                 execution: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operation: (match operands.next() {
                     Some(&dr::Operand::GroupOperation(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 x: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -3167,19 +3167,19 @@ impl LiftContext {
             271u32 => Ok(ops::Op::GroupSMax {
                 execution: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operation: (match operands.next() {
                     Some(&dr::Operand::GroupOperation(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 x: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -3187,25 +3187,25 @@ impl LiftContext {
             274u32 => Ok(ops::Op::ReadPipe {
                 pipe: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 pointer: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 packet_size: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 packet_alignment: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -3213,25 +3213,25 @@ impl LiftContext {
             275u32 => Ok(ops::Op::WritePipe {
                 pipe: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 pointer: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 packet_size: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 packet_alignment: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -3239,37 +3239,37 @@ impl LiftContext {
             276u32 => Ok(ops::Op::ReservedReadPipe {
                 pipe: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 reserve_id: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 index: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 pointer: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 packet_size: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 packet_alignment: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -3277,37 +3277,37 @@ impl LiftContext {
             277u32 => Ok(ops::Op::ReservedWritePipe {
                 pipe: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 reserve_id: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 index: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 pointer: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 packet_size: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 packet_alignment: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -3315,25 +3315,25 @@ impl LiftContext {
             278u32 => Ok(ops::Op::ReserveReadPipePackets {
                 pipe: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 num_packets: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 packet_size: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 packet_alignment: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -3341,25 +3341,25 @@ impl LiftContext {
             279u32 => Ok(ops::Op::ReserveWritePipePackets {
                 pipe: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 num_packets: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 packet_size: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 packet_alignment: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -3367,25 +3367,25 @@ impl LiftContext {
             280u32 => Ok(ops::Op::CommitReadPipe {
                 pipe: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 reserve_id: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 packet_size: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 packet_alignment: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -3393,25 +3393,25 @@ impl LiftContext {
             281u32 => Ok(ops::Op::CommitWritePipe {
                 pipe: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 reserve_id: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 packet_size: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 packet_alignment: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -3419,7 +3419,7 @@ impl LiftContext {
             282u32 => Ok(ops::Op::IsValidReserveId {
                 reserve_id: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -3427,19 +3427,19 @@ impl LiftContext {
             283u32 => Ok(ops::Op::GetNumPipePackets {
                 pipe: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 packet_size: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 packet_alignment: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -3447,19 +3447,19 @@ impl LiftContext {
             284u32 => Ok(ops::Op::GetMaxPipePackets {
                 pipe: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 packet_size: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 packet_alignment: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -3467,31 +3467,31 @@ impl LiftContext {
             285u32 => Ok(ops::Op::GroupReserveReadPipePackets {
                 execution: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 pipe: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 num_packets: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 packet_size: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 packet_alignment: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -3499,31 +3499,31 @@ impl LiftContext {
             286u32 => Ok(ops::Op::GroupReserveWritePipePackets {
                 execution: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 pipe: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 num_packets: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 packet_size: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 packet_alignment: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -3531,31 +3531,31 @@ impl LiftContext {
             287u32 => Ok(ops::Op::GroupCommitReadPipe {
                 execution: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 pipe: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 reserve_id: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 packet_size: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 packet_alignment: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -3563,31 +3563,31 @@ impl LiftContext {
             288u32 => Ok(ops::Op::GroupCommitWritePipe {
                 execution: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 pipe: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 reserve_id: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 packet_size: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 packet_alignment: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -3595,25 +3595,25 @@ impl LiftContext {
             291u32 => Ok(ops::Op::EnqueueMarker {
                 queue: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 num_events: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 wait_events: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 ret_event: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -3621,61 +3621,61 @@ impl LiftContext {
             292u32 => Ok(ops::Op::EnqueueKernel {
                 queue: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 flags: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 nd_range: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 num_events: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 wait_events: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 ret_event: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 invoke: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 param: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 param_size: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 param_align: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -3683,7 +3683,7 @@ impl LiftContext {
                     let mut vec = Vec::new();
                     while let Some(item) = match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     } {
                         vec.push(item);
@@ -3694,31 +3694,31 @@ impl LiftContext {
             293u32 => Ok(ops::Op::GetKernelNDrangeSubGroupCount {
                 nd_range: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 invoke: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 param: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 param_size: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 param_align: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -3726,31 +3726,31 @@ impl LiftContext {
             294u32 => Ok(ops::Op::GetKernelNDrangeMaxSubGroupSize {
                 nd_range: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 invoke: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 param: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 param_size: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 param_align: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -3758,25 +3758,25 @@ impl LiftContext {
             295u32 => Ok(ops::Op::GetKernelWorkGroupSize {
                 invoke: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 param: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 param_size: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 param_align: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -3784,25 +3784,25 @@ impl LiftContext {
             296u32 => Ok(ops::Op::GetKernelPreferredWorkGroupSizeMultiple {
                 invoke: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 param: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 param_size: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 param_align: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -3810,7 +3810,7 @@ impl LiftContext {
             297u32 => Ok(ops::Op::RetainEvent {
                 event: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -3818,7 +3818,7 @@ impl LiftContext {
             298u32 => Ok(ops::Op::ReleaseEvent {
                 event: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -3827,7 +3827,7 @@ impl LiftContext {
             300u32 => Ok(ops::Op::IsValidEvent {
                 event: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -3835,13 +3835,13 @@ impl LiftContext {
             301u32 => Ok(ops::Op::SetUserEventStatus {
                 event: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 status: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -3849,19 +3849,19 @@ impl LiftContext {
             302u32 => Ok(ops::Op::CaptureEventProfilingInfo {
                 event: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 profiling_info: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 value: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -3870,19 +3870,19 @@ impl LiftContext {
             304u32 => Ok(ops::Op::BuildNDRange {
                 global_work_size: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 local_work_size: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 global_work_offset: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -3890,54 +3890,54 @@ impl LiftContext {
             305u32 => Ok(ops::Op::ImageSparseSampleImplicitLod {
                 sampled_image: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 coordinate: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 image_operands: match operands.next() {
                     Some(&dr::Operand::ImageOperands(ref value)) => {
                         let operands = operands
-                            .map(|op| match op {
-                                &dr::Operand::IdRef(second) => Ok(second),
+                            .map(|op| match *op {
+                                dr::Operand::IdRef(second) => Ok(second),
                                 _ => Err(OperandError::WrongType),
                             })
                             .collect::<Result<Vec<_>, _>>()?;
                         Some((*value, operands))
                     }
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 },
             }),
             306u32 => Ok(ops::Op::ImageSparseSampleExplicitLod {
                 sampled_image: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 coordinate: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 image_operands: (match operands.next() {
                     Some(&dr::Operand::ImageOperands(ref value)) => {
                         let operands = operands
-                            .map(|op| match op {
-                                &dr::Operand::IdRef(second) => Ok(second),
+                            .map(|op| match *op {
+                                dr::Operand::IdRef(second) => Ok(second),
                                 _ => Err(OperandError::WrongType),
                             })
                             .collect::<Result<Vec<_>, _>>()?;
                         Some((*value, operands))
                     }
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -3945,66 +3945,66 @@ impl LiftContext {
             307u32 => Ok(ops::Op::ImageSparseSampleDrefImplicitLod {
                 sampled_image: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 coordinate: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 d_ref: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 image_operands: match operands.next() {
                     Some(&dr::Operand::ImageOperands(ref value)) => {
                         let operands = operands
-                            .map(|op| match op {
-                                &dr::Operand::IdRef(second) => Ok(second),
+                            .map(|op| match *op {
+                                dr::Operand::IdRef(second) => Ok(second),
                                 _ => Err(OperandError::WrongType),
                             })
                             .collect::<Result<Vec<_>, _>>()?;
                         Some((*value, operands))
                     }
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 },
             }),
             308u32 => Ok(ops::Op::ImageSparseSampleDrefExplicitLod {
                 sampled_image: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 coordinate: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 d_ref: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 image_operands: (match operands.next() {
                     Some(&dr::Operand::ImageOperands(ref value)) => {
                         let operands = operands
-                            .map(|op| match op {
-                                &dr::Operand::IdRef(second) => Ok(second),
+                            .map(|op| match *op {
+                                dr::Operand::IdRef(second) => Ok(second),
                                 _ => Err(OperandError::WrongType),
                             })
                             .collect::<Result<Vec<_>, _>>()?;
                         Some((*value, operands))
                     }
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -4012,54 +4012,54 @@ impl LiftContext {
             309u32 => Ok(ops::Op::ImageSparseSampleProjImplicitLod {
                 sampled_image: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 coordinate: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 image_operands: match operands.next() {
                     Some(&dr::Operand::ImageOperands(ref value)) => {
                         let operands = operands
-                            .map(|op| match op {
-                                &dr::Operand::IdRef(second) => Ok(second),
+                            .map(|op| match *op {
+                                dr::Operand::IdRef(second) => Ok(second),
                                 _ => Err(OperandError::WrongType),
                             })
                             .collect::<Result<Vec<_>, _>>()?;
                         Some((*value, operands))
                     }
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 },
             }),
             310u32 => Ok(ops::Op::ImageSparseSampleProjExplicitLod {
                 sampled_image: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 coordinate: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 image_operands: (match operands.next() {
                     Some(&dr::Operand::ImageOperands(ref value)) => {
                         let operands = operands
-                            .map(|op| match op {
-                                &dr::Operand::IdRef(second) => Ok(second),
+                            .map(|op| match *op {
+                                dr::Operand::IdRef(second) => Ok(second),
                                 _ => Err(OperandError::WrongType),
                             })
                             .collect::<Result<Vec<_>, _>>()?;
                         Some((*value, operands))
                     }
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -4067,66 +4067,66 @@ impl LiftContext {
             311u32 => Ok(ops::Op::ImageSparseSampleProjDrefImplicitLod {
                 sampled_image: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 coordinate: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 d_ref: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 image_operands: match operands.next() {
                     Some(&dr::Operand::ImageOperands(ref value)) => {
                         let operands = operands
-                            .map(|op| match op {
-                                &dr::Operand::IdRef(second) => Ok(second),
+                            .map(|op| match *op {
+                                dr::Operand::IdRef(second) => Ok(second),
                                 _ => Err(OperandError::WrongType),
                             })
                             .collect::<Result<Vec<_>, _>>()?;
                         Some((*value, operands))
                     }
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 },
             }),
             312u32 => Ok(ops::Op::ImageSparseSampleProjDrefExplicitLod {
                 sampled_image: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 coordinate: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 d_ref: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 image_operands: (match operands.next() {
                     Some(&dr::Operand::ImageOperands(ref value)) => {
                         let operands = operands
-                            .map(|op| match op {
-                                &dr::Operand::IdRef(second) => Ok(second),
+                            .map(|op| match *op {
+                                dr::Operand::IdRef(second) => Ok(second),
                                 _ => Err(OperandError::WrongType),
                             })
                             .collect::<Result<Vec<_>, _>>()?;
                         Some((*value, operands))
                     }
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -4134,100 +4134,100 @@ impl LiftContext {
             313u32 => Ok(ops::Op::ImageSparseFetch {
                 image: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 coordinate: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 image_operands: match operands.next() {
                     Some(&dr::Operand::ImageOperands(ref value)) => {
                         let operands = operands
-                            .map(|op| match op {
-                                &dr::Operand::IdRef(second) => Ok(second),
+                            .map(|op| match *op {
+                                dr::Operand::IdRef(second) => Ok(second),
                                 _ => Err(OperandError::WrongType),
                             })
                             .collect::<Result<Vec<_>, _>>()?;
                         Some((*value, operands))
                     }
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 },
             }),
             314u32 => Ok(ops::Op::ImageSparseGather {
                 sampled_image: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 coordinate: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 component: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 image_operands: match operands.next() {
                     Some(&dr::Operand::ImageOperands(ref value)) => {
                         let operands = operands
-                            .map(|op| match op {
-                                &dr::Operand::IdRef(second) => Ok(second),
+                            .map(|op| match *op {
+                                dr::Operand::IdRef(second) => Ok(second),
                                 _ => Err(OperandError::WrongType),
                             })
                             .collect::<Result<Vec<_>, _>>()?;
                         Some((*value, operands))
                     }
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 },
             }),
             315u32 => Ok(ops::Op::ImageSparseDrefGather {
                 sampled_image: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 coordinate: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 d_ref: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 image_operands: match operands.next() {
                     Some(&dr::Operand::ImageOperands(ref value)) => {
                         let operands = operands
-                            .map(|op| match op {
-                                &dr::Operand::IdRef(second) => Ok(second),
+                            .map(|op| match *op {
+                                dr::Operand::IdRef(second) => Ok(second),
                                 _ => Err(OperandError::WrongType),
                             })
                             .collect::<Result<Vec<_>, _>>()?;
                         Some((*value, operands))
                     }
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 },
             }),
             316u32 => Ok(ops::Op::ImageSparseTexelsResident {
                 resident_code: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -4236,19 +4236,19 @@ impl LiftContext {
             318u32 => Ok(ops::Op::AtomicFlagTestAndSet {
                 pointer: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 memory: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 semantics: (match operands.next() {
                     Some(&dr::Operand::IdMemorySemantics(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -4256,19 +4256,19 @@ impl LiftContext {
             319u32 => Ok(ops::Op::AtomicFlagClear {
                 pointer: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 memory: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 semantics: (match operands.next() {
                     Some(&dr::Operand::IdMemorySemantics(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -4276,34 +4276,34 @@ impl LiftContext {
             320u32 => Ok(ops::Op::ImageSparseRead {
                 image: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 coordinate: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 image_operands: match operands.next() {
                     Some(&dr::Operand::ImageOperands(ref value)) => {
                         let operands = operands
-                            .map(|op| match op {
-                                &dr::Operand::IdRef(second) => Ok(second),
+                            .map(|op| match *op {
+                                dr::Operand::IdRef(second) => Ok(second),
                                 _ => Err(OperandError::WrongType),
                             })
                             .collect::<Result<Vec<_>, _>>()?;
                         Some((*value, operands))
                     }
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 },
             }),
             321u32 => Ok(ops::Op::SizeOf {
                 pointer: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -4311,19 +4311,19 @@ impl LiftContext {
             323u32 => Ok(ops::Op::ConstantPipeStorage {
                 packet_size: (match operands.next() {
                     Some(&dr::Operand::LiteralInt32(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 packet_alignment: (match operands.next() {
                     Some(&dr::Operand::LiteralInt32(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 capacity: (match operands.next() {
                     Some(&dr::Operand::LiteralInt32(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -4331,7 +4331,7 @@ impl LiftContext {
             324u32 => Ok(ops::Op::CreatePipeFromPipeStorage {
                 pipe_storage: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -4339,31 +4339,31 @@ impl LiftContext {
             325u32 => Ok(ops::Op::GetKernelLocalSizeForSubgroupCount {
                 subgroup_count: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 invoke: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 param: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 param_size: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 param_align: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -4371,25 +4371,25 @@ impl LiftContext {
             326u32 => Ok(ops::Op::GetKernelMaxNumSubgroups {
                 invoke: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 param: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 param_size: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 param_align: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -4397,7 +4397,7 @@ impl LiftContext {
             328u32 => Ok(ops::Op::NamedBarrierInitialize {
                 subgroup_count: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -4405,19 +4405,19 @@ impl LiftContext {
             329u32 => Ok(ops::Op::MemoryNamedBarrier {
                 named_barrier: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 memory: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 semantics: (match operands.next() {
                     Some(&dr::Operand::IdMemorySemantics(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -4425,7 +4425,7 @@ impl LiftContext {
             330u32 => Ok(ops::Op::ModuleProcessed {
                 process: (match operands.next() {
                     Some(&dr::Operand::LiteralString(ref value)) => Some(value.clone()),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -4433,13 +4433,13 @@ impl LiftContext {
             332u32 => Ok(ops::Op::DecorateId {
                 target: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 decoration: (match operands.next() {
                     Some(&dr::Operand::Decoration(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -4447,7 +4447,7 @@ impl LiftContext {
             333u32 => Ok(ops::Op::GroupNonUniformElect {
                 execution: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -4455,13 +4455,13 @@ impl LiftContext {
             334u32 => Ok(ops::Op::GroupNonUniformAll {
                 execution: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 predicate: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -4469,13 +4469,13 @@ impl LiftContext {
             335u32 => Ok(ops::Op::GroupNonUniformAny {
                 execution: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 predicate: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -4483,13 +4483,13 @@ impl LiftContext {
             336u32 => Ok(ops::Op::GroupNonUniformAllEqual {
                 execution: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 value: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -4497,19 +4497,19 @@ impl LiftContext {
             337u32 => Ok(ops::Op::GroupNonUniformBroadcast {
                 execution: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 value: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 id: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -4517,13 +4517,13 @@ impl LiftContext {
             338u32 => Ok(ops::Op::GroupNonUniformBroadcastFirst {
                 execution: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 value: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -4531,13 +4531,13 @@ impl LiftContext {
             339u32 => Ok(ops::Op::GroupNonUniformBallot {
                 execution: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 predicate: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -4545,13 +4545,13 @@ impl LiftContext {
             340u32 => Ok(ops::Op::GroupNonUniformInverseBallot {
                 execution: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 value: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -4559,19 +4559,19 @@ impl LiftContext {
             341u32 => Ok(ops::Op::GroupNonUniformBallotBitExtract {
                 execution: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 value: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 index: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -4579,19 +4579,19 @@ impl LiftContext {
             342u32 => Ok(ops::Op::GroupNonUniformBallotBitCount {
                 execution: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operation: (match operands.next() {
                     Some(&dr::Operand::GroupOperation(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 value: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -4599,13 +4599,13 @@ impl LiftContext {
             343u32 => Ok(ops::Op::GroupNonUniformBallotFindLSB {
                 execution: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 value: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -4613,13 +4613,13 @@ impl LiftContext {
             344u32 => Ok(ops::Op::GroupNonUniformBallotFindMSB {
                 execution: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 value: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -4627,19 +4627,19 @@ impl LiftContext {
             345u32 => Ok(ops::Op::GroupNonUniformShuffle {
                 execution: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 value: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 id: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -4647,19 +4647,19 @@ impl LiftContext {
             346u32 => Ok(ops::Op::GroupNonUniformShuffleXor {
                 execution: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 value: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 mask: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -4667,19 +4667,19 @@ impl LiftContext {
             347u32 => Ok(ops::Op::GroupNonUniformShuffleUp {
                 execution: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 value: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 delta: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -4687,19 +4687,19 @@ impl LiftContext {
             348u32 => Ok(ops::Op::GroupNonUniformShuffleDown {
                 execution: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 value: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 delta: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -4707,419 +4707,419 @@ impl LiftContext {
             349u32 => Ok(ops::Op::GroupNonUniformIAdd {
                 execution: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operation: (match operands.next() {
                     Some(&dr::Operand::GroupOperation(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 value: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 cluster_size: match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 },
             }),
             350u32 => Ok(ops::Op::GroupNonUniformFAdd {
                 execution: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operation: (match operands.next() {
                     Some(&dr::Operand::GroupOperation(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 value: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 cluster_size: match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 },
             }),
             351u32 => Ok(ops::Op::GroupNonUniformIMul {
                 execution: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operation: (match operands.next() {
                     Some(&dr::Operand::GroupOperation(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 value: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 cluster_size: match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 },
             }),
             352u32 => Ok(ops::Op::GroupNonUniformFMul {
                 execution: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operation: (match operands.next() {
                     Some(&dr::Operand::GroupOperation(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 value: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 cluster_size: match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 },
             }),
             353u32 => Ok(ops::Op::GroupNonUniformSMin {
                 execution: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operation: (match operands.next() {
                     Some(&dr::Operand::GroupOperation(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 value: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 cluster_size: match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 },
             }),
             354u32 => Ok(ops::Op::GroupNonUniformUMin {
                 execution: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operation: (match operands.next() {
                     Some(&dr::Operand::GroupOperation(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 value: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 cluster_size: match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 },
             }),
             355u32 => Ok(ops::Op::GroupNonUniformFMin {
                 execution: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operation: (match operands.next() {
                     Some(&dr::Operand::GroupOperation(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 value: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 cluster_size: match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 },
             }),
             356u32 => Ok(ops::Op::GroupNonUniformSMax {
                 execution: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operation: (match operands.next() {
                     Some(&dr::Operand::GroupOperation(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 value: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 cluster_size: match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 },
             }),
             357u32 => Ok(ops::Op::GroupNonUniformUMax {
                 execution: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operation: (match operands.next() {
                     Some(&dr::Operand::GroupOperation(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 value: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 cluster_size: match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 },
             }),
             358u32 => Ok(ops::Op::GroupNonUniformFMax {
                 execution: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operation: (match operands.next() {
                     Some(&dr::Operand::GroupOperation(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 value: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 cluster_size: match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 },
             }),
             359u32 => Ok(ops::Op::GroupNonUniformBitwiseAnd {
                 execution: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operation: (match operands.next() {
                     Some(&dr::Operand::GroupOperation(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 value: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 cluster_size: match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 },
             }),
             360u32 => Ok(ops::Op::GroupNonUniformBitwiseOr {
                 execution: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operation: (match operands.next() {
                     Some(&dr::Operand::GroupOperation(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 value: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 cluster_size: match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 },
             }),
             361u32 => Ok(ops::Op::GroupNonUniformBitwiseXor {
                 execution: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operation: (match operands.next() {
                     Some(&dr::Operand::GroupOperation(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 value: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 cluster_size: match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 },
             }),
             362u32 => Ok(ops::Op::GroupNonUniformLogicalAnd {
                 execution: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operation: (match operands.next() {
                     Some(&dr::Operand::GroupOperation(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 value: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 cluster_size: match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 },
             }),
             363u32 => Ok(ops::Op::GroupNonUniformLogicalOr {
                 execution: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operation: (match operands.next() {
                     Some(&dr::Operand::GroupOperation(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 value: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 cluster_size: match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 },
             }),
             364u32 => Ok(ops::Op::GroupNonUniformLogicalXor {
                 execution: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operation: (match operands.next() {
                     Some(&dr::Operand::GroupOperation(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 value: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 cluster_size: match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 },
             }),
             365u32 => Ok(ops::Op::GroupNonUniformQuadBroadcast {
                 execution: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 value: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 index: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -5127,19 +5127,19 @@ impl LiftContext {
             366u32 => Ok(ops::Op::GroupNonUniformQuadSwap {
                 execution: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 value: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 direction: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -5147,7 +5147,7 @@ impl LiftContext {
             400u32 => Ok(ops::Op::CopyLogical {
                 operand: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -5155,13 +5155,13 @@ impl LiftContext {
             401u32 => Ok(ops::Op::PtrEqual {
                 operand_1: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operand_2: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -5169,13 +5169,13 @@ impl LiftContext {
             402u32 => Ok(ops::Op::PtrNotEqual {
                 operand_1: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operand_2: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -5183,13 +5183,13 @@ impl LiftContext {
             403u32 => Ok(ops::Op::PtrDiff {
                 operand_1: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operand_2: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -5197,7 +5197,7 @@ impl LiftContext {
             4421u32 => Ok(ops::Op::SubgroupBallotKHR {
                 predicate: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -5205,7 +5205,7 @@ impl LiftContext {
             4422u32 => Ok(ops::Op::SubgroupFirstInvocationKHR {
                 value: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -5213,7 +5213,7 @@ impl LiftContext {
             4428u32 => Ok(ops::Op::SubgroupAllKHR {
                 predicate: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -5221,7 +5221,7 @@ impl LiftContext {
             4429u32 => Ok(ops::Op::SubgroupAnyKHR {
                 predicate: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -5229,7 +5229,7 @@ impl LiftContext {
             4430u32 => Ok(ops::Op::SubgroupAllEqualKHR {
                 predicate: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -5237,13 +5237,13 @@ impl LiftContext {
             4432u32 => Ok(ops::Op::SubgroupReadInvocationKHR {
                 value: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 index: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -5251,67 +5251,67 @@ impl LiftContext {
             4445u32 => Ok(ops::Op::TraceRayKHR {
                 accel: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 ray_flags: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 cull_mask: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 sbt_offset: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 sbt_stride: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 miss_index: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 ray_origin: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 ray_tmin: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 ray_direction: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 ray_tmax: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 payload: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -5319,13 +5319,13 @@ impl LiftContext {
             4446u32 => Ok(ops::Op::ExecuteCallableKHR {
                 sbt_index: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 callable_data: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -5333,7 +5333,7 @@ impl LiftContext {
             4447u32 => Ok(ops::Op::ConvertUToAccelerationStructureKHR {
                 accel: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -5341,49 +5341,49 @@ impl LiftContext {
             4473u32 => Ok(ops::Op::RayQueryInitializeKHR {
                 ray_query: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 accel: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 ray_flags: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 cull_mask: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 ray_origin: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 ray_t_min: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 ray_direction: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 ray_t_max: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -5391,7 +5391,7 @@ impl LiftContext {
             4474u32 => Ok(ops::Op::RayQueryTerminateKHR {
                 ray_query: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -5399,13 +5399,13 @@ impl LiftContext {
             4475u32 => Ok(ops::Op::RayQueryGenerateIntersectionKHR {
                 ray_query: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 hit_t: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -5413,7 +5413,7 @@ impl LiftContext {
             4476u32 => Ok(ops::Op::RayQueryConfirmIntersectionKHR {
                 ray_query: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -5421,7 +5421,7 @@ impl LiftContext {
             4477u32 => Ok(ops::Op::RayQueryProceedKHR {
                 ray_query: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -5429,13 +5429,13 @@ impl LiftContext {
             4479u32 => Ok(ops::Op::RayQueryGetIntersectionTypeKHR {
                 ray_query: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 intersection: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -5443,19 +5443,19 @@ impl LiftContext {
             5000u32 => Ok(ops::Op::GroupIAddNonUniformAMD {
                 execution: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operation: (match operands.next() {
                     Some(&dr::Operand::GroupOperation(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 x: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -5463,19 +5463,19 @@ impl LiftContext {
             5001u32 => Ok(ops::Op::GroupFAddNonUniformAMD {
                 execution: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operation: (match operands.next() {
                     Some(&dr::Operand::GroupOperation(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 x: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -5483,19 +5483,19 @@ impl LiftContext {
             5002u32 => Ok(ops::Op::GroupFMinNonUniformAMD {
                 execution: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operation: (match operands.next() {
                     Some(&dr::Operand::GroupOperation(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 x: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -5503,19 +5503,19 @@ impl LiftContext {
             5003u32 => Ok(ops::Op::GroupUMinNonUniformAMD {
                 execution: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operation: (match operands.next() {
                     Some(&dr::Operand::GroupOperation(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 x: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -5523,19 +5523,19 @@ impl LiftContext {
             5004u32 => Ok(ops::Op::GroupSMinNonUniformAMD {
                 execution: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operation: (match operands.next() {
                     Some(&dr::Operand::GroupOperation(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 x: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -5543,19 +5543,19 @@ impl LiftContext {
             5005u32 => Ok(ops::Op::GroupFMaxNonUniformAMD {
                 execution: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operation: (match operands.next() {
                     Some(&dr::Operand::GroupOperation(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 x: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -5563,19 +5563,19 @@ impl LiftContext {
             5006u32 => Ok(ops::Op::GroupUMaxNonUniformAMD {
                 execution: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operation: (match operands.next() {
                     Some(&dr::Operand::GroupOperation(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 x: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -5583,19 +5583,19 @@ impl LiftContext {
             5007u32 => Ok(ops::Op::GroupSMaxNonUniformAMD {
                 execution: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operation: (match operands.next() {
                     Some(&dr::Operand::GroupOperation(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 x: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -5603,13 +5603,13 @@ impl LiftContext {
             5011u32 => Ok(ops::Op::FragmentMaskFetchAMD {
                 image: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 coordinate: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -5617,19 +5617,19 @@ impl LiftContext {
             5012u32 => Ok(ops::Op::FragmentFetchAMD {
                 image: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 coordinate: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 fragment_index: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -5637,7 +5637,7 @@ impl LiftContext {
             5056u32 => Ok(ops::Op::ReadClockKHR {
                 execution: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -5645,46 +5645,46 @@ impl LiftContext {
             5283u32 => Ok(ops::Op::ImageSampleFootprintNV {
                 sampled_image: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 coordinate: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 granularity: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 coarse: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 image_operands: match operands.next() {
                     Some(&dr::Operand::ImageOperands(ref value)) => {
                         let operands = operands
-                            .map(|op| match op {
-                                &dr::Operand::IdRef(second) => Ok(second),
+                            .map(|op| match *op {
+                                dr::Operand::IdRef(second) => Ok(second),
                                 _ => Err(OperandError::WrongType),
                             })
                             .collect::<Result<Vec<_>, _>>()?;
                         Some((*value, operands))
                     }
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 },
             }),
             5296u32 => Ok(ops::Op::GroupNonUniformPartitionNV {
                 value: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -5692,13 +5692,13 @@ impl LiftContext {
             5299u32 => Ok(ops::Op::WritePackedPrimitiveIndices4x8NV {
                 index_offset: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 packed_indices: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -5706,13 +5706,13 @@ impl LiftContext {
             5334u32 => Ok(ops::Op::ReportIntersectionNV {
                 hit: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 hit_kind: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -5720,13 +5720,13 @@ impl LiftContext {
             5334u32 => Ok(ops::Op::ReportIntersectionKHR {
                 hit: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 hit_kind: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -5736,67 +5736,67 @@ impl LiftContext {
             5337u32 => Ok(ops::Op::TraceNV {
                 accel: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 ray_flags: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 cull_mask: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 sbt_offset: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 sbt_stride: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 miss_index: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 ray_origin: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 ray_tmin: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 ray_direction: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 ray_tmax: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 payload_id: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -5805,13 +5805,13 @@ impl LiftContext {
             5344u32 => Ok(ops::Op::ExecuteCallableNV {
                 sbt_index: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 callable_data_id: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -5819,75 +5819,75 @@ impl LiftContext {
             5359u32 => Ok(ops::Op::CooperativeMatrixLoadNV {
                 pointer: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 stride: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 column_major: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 memory_access: match operands.next() {
                     Some(&dr::Operand::MemoryAccess(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 },
             }),
             5360u32 => Ok(ops::Op::CooperativeMatrixStoreNV {
                 pointer: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 object: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 stride: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 column_major: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 memory_access: match operands.next() {
                     Some(&dr::Operand::MemoryAccess(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 },
             }),
             5361u32 => Ok(ops::Op::CooperativeMatrixMulAddNV {
                 a: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 b: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 c: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -5895,7 +5895,7 @@ impl LiftContext {
             5362u32 => Ok(ops::Op::CooperativeMatrixLengthNV {
                 ty: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(self.types.lookup_token(*value)),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -5907,13 +5907,13 @@ impl LiftContext {
             5571u32 => Ok(ops::Op::SubgroupShuffleINTEL {
                 data: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 invocation_id: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -5921,19 +5921,19 @@ impl LiftContext {
             5572u32 => Ok(ops::Op::SubgroupShuffleDownINTEL {
                 current: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 next: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 delta: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -5941,19 +5941,19 @@ impl LiftContext {
             5573u32 => Ok(ops::Op::SubgroupShuffleUpINTEL {
                 previous: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 current: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 delta: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -5961,13 +5961,13 @@ impl LiftContext {
             5574u32 => Ok(ops::Op::SubgroupShuffleXorINTEL {
                 data: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 value: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -5975,7 +5975,7 @@ impl LiftContext {
             5575u32 => Ok(ops::Op::SubgroupBlockReadINTEL {
                 ptr: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -5983,13 +5983,13 @@ impl LiftContext {
             5576u32 => Ok(ops::Op::SubgroupBlockWriteINTEL {
                 ptr: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 data: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -5997,13 +5997,13 @@ impl LiftContext {
             5577u32 => Ok(ops::Op::SubgroupImageBlockReadINTEL {
                 image: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 coordinate: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -6011,19 +6011,19 @@ impl LiftContext {
             5578u32 => Ok(ops::Op::SubgroupImageBlockWriteINTEL {
                 image: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 coordinate: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 data: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -6031,25 +6031,25 @@ impl LiftContext {
             5580u32 => Ok(ops::Op::SubgroupImageMediaBlockReadINTEL {
                 image: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 coordinate: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 width: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 height: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -6057,31 +6057,31 @@ impl LiftContext {
             5581u32 => Ok(ops::Op::SubgroupImageMediaBlockWriteINTEL {
                 image: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 coordinate: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 width: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 height: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 data: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -6089,7 +6089,7 @@ impl LiftContext {
             5585u32 => Ok(ops::Op::UCountLeadingZerosINTEL {
                 operand: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -6097,7 +6097,7 @@ impl LiftContext {
             5586u32 => Ok(ops::Op::UCountTrailingZerosINTEL {
                 operand: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -6105,13 +6105,13 @@ impl LiftContext {
             5587u32 => Ok(ops::Op::AbsISubINTEL {
                 operand_1: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operand_2: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -6119,13 +6119,13 @@ impl LiftContext {
             5588u32 => Ok(ops::Op::AbsUSubINTEL {
                 operand_1: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operand_2: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -6133,13 +6133,13 @@ impl LiftContext {
             5589u32 => Ok(ops::Op::IAddSatINTEL {
                 operand_1: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operand_2: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -6147,13 +6147,13 @@ impl LiftContext {
             5590u32 => Ok(ops::Op::UAddSatINTEL {
                 operand_1: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operand_2: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -6161,13 +6161,13 @@ impl LiftContext {
             5591u32 => Ok(ops::Op::IAverageINTEL {
                 operand_1: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operand_2: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -6175,13 +6175,13 @@ impl LiftContext {
             5592u32 => Ok(ops::Op::UAverageINTEL {
                 operand_1: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operand_2: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -6189,13 +6189,13 @@ impl LiftContext {
             5593u32 => Ok(ops::Op::IAverageRoundedINTEL {
                 operand_1: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operand_2: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -6203,13 +6203,13 @@ impl LiftContext {
             5594u32 => Ok(ops::Op::UAverageRoundedINTEL {
                 operand_1: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operand_2: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -6217,13 +6217,13 @@ impl LiftContext {
             5595u32 => Ok(ops::Op::ISubSatINTEL {
                 operand_1: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operand_2: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -6231,13 +6231,13 @@ impl LiftContext {
             5596u32 => Ok(ops::Op::USubSatINTEL {
                 operand_1: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operand_2: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -6245,13 +6245,13 @@ impl LiftContext {
             5597u32 => Ok(ops::Op::IMul32x16INTEL {
                 operand_1: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operand_2: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -6259,13 +6259,13 @@ impl LiftContext {
             5598u32 => Ok(ops::Op::UMul32x16INTEL {
                 operand_1: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 operand_2: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -6273,7 +6273,7 @@ impl LiftContext {
             5600u32 => Ok(ops::Op::FunctionPointerINTEL {
                 function: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -6283,7 +6283,7 @@ impl LiftContext {
                     let mut vec = Vec::new();
                     while let Some(item) = match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     } {
                         vec.push(item);
@@ -6294,13 +6294,13 @@ impl LiftContext {
             5632u32 => Ok(ops::Op::DecorateString {
                 target: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 decoration: (match operands.next() {
                     Some(&dr::Operand::Decoration(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -6308,13 +6308,13 @@ impl LiftContext {
             5632u32 => Ok(ops::Op::DecorateStringGOOGLE {
                 target: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 decoration: (match operands.next() {
                     Some(&dr::Operand::Decoration(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -6322,19 +6322,19 @@ impl LiftContext {
             5633u32 => Ok(ops::Op::MemberDecorateString {
                 struct_type: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(self.types.lookup_token(*value)),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 member: (match operands.next() {
                     Some(&dr::Operand::LiteralInt32(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 decoration: (match operands.next() {
                     Some(&dr::Operand::Decoration(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -6342,19 +6342,19 @@ impl LiftContext {
             5633u32 => Ok(ops::Op::MemberDecorateStringGOOGLE {
                 struct_type: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(self.types.lookup_token(*value)),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 member: (match operands.next() {
                     Some(&dr::Operand::LiteralInt32(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 decoration: (match operands.next() {
                     Some(&dr::Operand::Decoration(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -6362,13 +6362,13 @@ impl LiftContext {
             5699u32 => Ok(ops::Op::VmeImageINTEL {
                 image_type: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(self.types.lookup_token(*value)),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 sampler: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -6376,7 +6376,7 @@ impl LiftContext {
             5700u32 => Ok(ops::Op::TypeVmeImageINTEL {
                 image_type: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(self.types.lookup_token(*value)),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -6399,13 +6399,13 @@ impl LiftContext {
                         Some(&dr::Operand::IdRef(ref value)) => {
                             Some(self.types.lookup_token(*value))
                         }
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     })
                     .ok_or(OperandError::Missing)?,
                     qp: (match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     })
                     .ok_or(OperandError::Missing)?,
@@ -6415,13 +6415,13 @@ impl LiftContext {
                 ops::Op::SubgroupAvcMceSetInterBaseMultiReferencePenaltyINTEL {
                     reference_base_penalty: (match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     })
                     .ok_or(OperandError::Missing)?,
                     payload: (match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     })
                     .ok_or(OperandError::Missing)?,
@@ -6430,13 +6430,13 @@ impl LiftContext {
             5715u32 => Ok(ops::Op::SubgroupAvcMceGetDefaultInterShapePenaltyINTEL {
                 slice_type: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(self.types.lookup_token(*value)),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 qp: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -6444,13 +6444,13 @@ impl LiftContext {
             5716u32 => Ok(ops::Op::SubgroupAvcMceSetInterShapePenaltyINTEL {
                 packed_shape_penalty: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 payload: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -6461,13 +6461,13 @@ impl LiftContext {
                         Some(&dr::Operand::IdRef(ref value)) => {
                             Some(self.types.lookup_token(*value))
                         }
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     })
                     .ok_or(OperandError::Missing)?,
                     qp: (match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     })
                     .ok_or(OperandError::Missing)?,
@@ -6476,13 +6476,13 @@ impl LiftContext {
             5718u32 => Ok(ops::Op::SubgroupAvcMceSetInterDirectionPenaltyINTEL {
                 direction_cost: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 payload: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -6493,13 +6493,13 @@ impl LiftContext {
                         Some(&dr::Operand::IdRef(ref value)) => {
                             Some(self.types.lookup_token(*value))
                         }
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     })
                     .ok_or(OperandError::Missing)?,
                     qp: (match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     })
                     .ok_or(OperandError::Missing)?,
@@ -6511,13 +6511,13 @@ impl LiftContext {
                         Some(&dr::Operand::IdRef(ref value)) => {
                             Some(self.types.lookup_token(*value))
                         }
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     })
                     .ok_or(OperandError::Missing)?,
                     qp: (match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     })
                     .ok_or(OperandError::Missing)?,
@@ -6529,25 +6529,25 @@ impl LiftContext {
             5724u32 => Ok(ops::Op::SubgroupAvcMceSetMotionVectorCostFunctionINTEL {
                 packed_cost_center_delta: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 packed_cost_table: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 cost_precision: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 payload: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -6555,13 +6555,13 @@ impl LiftContext {
             5725u32 => Ok(ops::Op::SubgroupAvcMceGetDefaultIntraLumaModePenaltyINTEL {
                 slice_type: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(self.types.lookup_token(*value)),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 qp: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -6571,7 +6571,7 @@ impl LiftContext {
             5728u32 => Ok(ops::Op::SubgroupAvcMceSetAcOnlyHaarINTEL {
                 payload: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -6580,13 +6580,13 @@ impl LiftContext {
                 ops::Op::SubgroupAvcMceSetSourceInterlacedFieldPolarityINTEL {
                     source_field_polarity: (match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     })
                     .ok_or(OperandError::Missing)?,
                     payload: (match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     })
                     .ok_or(OperandError::Missing)?,
@@ -6596,13 +6596,13 @@ impl LiftContext {
                 ops::Op::SubgroupAvcMceSetSingleReferenceInterlacedFieldPolarityINTEL {
                     reference_field_polarity: (match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     })
                     .ok_or(OperandError::Missing)?,
                     payload: (match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     })
                     .ok_or(OperandError::Missing)?,
@@ -6612,19 +6612,19 @@ impl LiftContext {
                 ops::Op::SubgroupAvcMceSetDualReferenceInterlacedFieldPolaritiesINTEL {
                     forward_reference_field_polarity: (match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     })
                     .ok_or(OperandError::Missing)?,
                     backward_reference_field_polarity: (match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     })
                     .ok_or(OperandError::Missing)?,
                     payload: (match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     })
                     .ok_or(OperandError::Missing)?,
@@ -6633,7 +6633,7 @@ impl LiftContext {
             5732u32 => Ok(ops::Op::SubgroupAvcMceConvertToImePayloadINTEL {
                 payload: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -6641,7 +6641,7 @@ impl LiftContext {
             5733u32 => Ok(ops::Op::SubgroupAvcMceConvertToImeResultINTEL {
                 payload: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -6649,7 +6649,7 @@ impl LiftContext {
             5734u32 => Ok(ops::Op::SubgroupAvcMceConvertToRefPayloadINTEL {
                 payload: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -6657,7 +6657,7 @@ impl LiftContext {
             5735u32 => Ok(ops::Op::SubgroupAvcMceConvertToRefResultINTEL {
                 payload: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -6665,7 +6665,7 @@ impl LiftContext {
             5736u32 => Ok(ops::Op::SubgroupAvcMceConvertToSicPayloadINTEL {
                 payload: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -6673,7 +6673,7 @@ impl LiftContext {
             5737u32 => Ok(ops::Op::SubgroupAvcMceConvertToSicResultINTEL {
                 payload: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -6681,7 +6681,7 @@ impl LiftContext {
             5738u32 => Ok(ops::Op::SubgroupAvcMceGetMotionVectorsINTEL {
                 payload: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -6689,7 +6689,7 @@ impl LiftContext {
             5739u32 => Ok(ops::Op::SubgroupAvcMceGetInterDistortionsINTEL {
                 payload: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -6697,7 +6697,7 @@ impl LiftContext {
             5740u32 => Ok(ops::Op::SubgroupAvcMceGetBestInterDistortionsINTEL {
                 payload: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -6705,7 +6705,7 @@ impl LiftContext {
             5741u32 => Ok(ops::Op::SubgroupAvcMceGetInterMajorShapeINTEL {
                 payload: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -6713,7 +6713,7 @@ impl LiftContext {
             5742u32 => Ok(ops::Op::SubgroupAvcMceGetInterMinorShapeINTEL {
                 payload: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -6721,7 +6721,7 @@ impl LiftContext {
             5743u32 => Ok(ops::Op::SubgroupAvcMceGetInterDirectionsINTEL {
                 payload: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -6729,7 +6729,7 @@ impl LiftContext {
             5744u32 => Ok(ops::Op::SubgroupAvcMceGetInterMotionVectorCountINTEL {
                 payload: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -6737,7 +6737,7 @@ impl LiftContext {
             5745u32 => Ok(ops::Op::SubgroupAvcMceGetInterReferenceIdsINTEL {
                 payload: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -6746,19 +6746,19 @@ impl LiftContext {
                 ops::Op::SubgroupAvcMceGetInterReferenceInterlacedFieldPolaritiesINTEL {
                     packed_reference_ids: (match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     })
                     .ok_or(OperandError::Missing)?,
                     packed_reference_parameter_field_polarities: (match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     })
                     .ok_or(OperandError::Missing)?,
                     payload: (match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     })
                     .ok_or(OperandError::Missing)?,
@@ -6767,19 +6767,19 @@ impl LiftContext {
             5747u32 => Ok(ops::Op::SubgroupAvcImeInitializeINTEL {
                 src_coord: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 partition_mask: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 sad_adjustment: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -6787,19 +6787,19 @@ impl LiftContext {
             5748u32 => Ok(ops::Op::SubgroupAvcImeSetSingleReferenceINTEL {
                 ref_offset: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 search_window_config: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 payload: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -6807,25 +6807,25 @@ impl LiftContext {
             5749u32 => Ok(ops::Op::SubgroupAvcImeSetDualReferenceINTEL {
                 fwd_ref_offset: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 bwd_ref_offset: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 id_search_window_config: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 payload: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -6833,13 +6833,13 @@ impl LiftContext {
             5750u32 => Ok(ops::Op::SubgroupAvcImeRefWindowSizeINTEL {
                 search_window_config: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 dual_ref: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -6847,25 +6847,25 @@ impl LiftContext {
             5751u32 => Ok(ops::Op::SubgroupAvcImeAdjustRefOffsetINTEL {
                 ref_offset: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 src_coord: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 ref_window_size: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 image_size: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -6873,7 +6873,7 @@ impl LiftContext {
             5752u32 => Ok(ops::Op::SubgroupAvcImeConvertToMcePayloadINTEL {
                 payload: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -6881,13 +6881,13 @@ impl LiftContext {
             5753u32 => Ok(ops::Op::SubgroupAvcImeSetMaxMotionVectorCountINTEL {
                 max_motion_vector_count: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 payload: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -6895,7 +6895,7 @@ impl LiftContext {
             5754u32 => Ok(ops::Op::SubgroupAvcImeSetUnidirectionalMixDisableINTEL {
                 payload: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -6904,13 +6904,13 @@ impl LiftContext {
                 ops::Op::SubgroupAvcImeSetEarlySearchTerminationThresholdINTEL {
                     threshold: (match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     })
                     .ok_or(OperandError::Missing)?,
                     payload: (match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     })
                     .ok_or(OperandError::Missing)?,
@@ -6919,13 +6919,13 @@ impl LiftContext {
             5756u32 => Ok(ops::Op::SubgroupAvcImeSetWeightedSadINTEL {
                 packed_sad_weights: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 payload: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -6933,19 +6933,19 @@ impl LiftContext {
             5757u32 => Ok(ops::Op::SubgroupAvcImeEvaluateWithSingleReferenceINTEL {
                 src_image: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 ref_image: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 payload: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -6953,25 +6953,25 @@ impl LiftContext {
             5758u32 => Ok(ops::Op::SubgroupAvcImeEvaluateWithDualReferenceINTEL {
                 src_image: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 fwd_ref_image: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 bwd_ref_image: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 payload: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -6980,25 +6980,25 @@ impl LiftContext {
                 ops::Op::SubgroupAvcImeEvaluateWithSingleReferenceStreaminINTEL {
                     src_image: (match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     })
                     .ok_or(OperandError::Missing)?,
                     ref_image: (match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     })
                     .ok_or(OperandError::Missing)?,
                     payload: (match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     })
                     .ok_or(OperandError::Missing)?,
                     streamin_components: (match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     })
                     .ok_or(OperandError::Missing)?,
@@ -7008,31 +7008,31 @@ impl LiftContext {
                 ops::Op::SubgroupAvcImeEvaluateWithDualReferenceStreaminINTEL {
                     src_image: (match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     })
                     .ok_or(OperandError::Missing)?,
                     fwd_ref_image: (match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     })
                     .ok_or(OperandError::Missing)?,
                     bwd_ref_image: (match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     })
                     .ok_or(OperandError::Missing)?,
                     payload: (match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     })
                     .ok_or(OperandError::Missing)?,
                     streamin_components: (match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     })
                     .ok_or(OperandError::Missing)?,
@@ -7042,19 +7042,19 @@ impl LiftContext {
                 ops::Op::SubgroupAvcImeEvaluateWithSingleReferenceStreamoutINTEL {
                     src_image: (match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     })
                     .ok_or(OperandError::Missing)?,
                     ref_image: (match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     })
                     .ok_or(OperandError::Missing)?,
                     payload: (match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     })
                     .ok_or(OperandError::Missing)?,
@@ -7064,25 +7064,25 @@ impl LiftContext {
                 ops::Op::SubgroupAvcImeEvaluateWithDualReferenceStreamoutINTEL {
                     src_image: (match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     })
                     .ok_or(OperandError::Missing)?,
                     fwd_ref_image: (match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     })
                     .ok_or(OperandError::Missing)?,
                     bwd_ref_image: (match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     })
                     .ok_or(OperandError::Missing)?,
                     payload: (match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     })
                     .ok_or(OperandError::Missing)?,
@@ -7092,25 +7092,25 @@ impl LiftContext {
                 ops::Op::SubgroupAvcImeEvaluateWithSingleReferenceStreaminoutINTEL {
                     src_image: (match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     })
                     .ok_or(OperandError::Missing)?,
                     ref_image: (match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     })
                     .ok_or(OperandError::Missing)?,
                     payload: (match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     })
                     .ok_or(OperandError::Missing)?,
                     streamin_components: (match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     })
                     .ok_or(OperandError::Missing)?,
@@ -7120,31 +7120,31 @@ impl LiftContext {
                 ops::Op::SubgroupAvcImeEvaluateWithDualReferenceStreaminoutINTEL {
                     src_image: (match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     })
                     .ok_or(OperandError::Missing)?,
                     fwd_ref_image: (match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     })
                     .ok_or(OperandError::Missing)?,
                     bwd_ref_image: (match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     })
                     .ok_or(OperandError::Missing)?,
                     payload: (match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     })
                     .ok_or(OperandError::Missing)?,
                     streamin_components: (match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     })
                     .ok_or(OperandError::Missing)?,
@@ -7153,7 +7153,7 @@ impl LiftContext {
             5765u32 => Ok(ops::Op::SubgroupAvcImeConvertToMceResultINTEL {
                 payload: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -7161,7 +7161,7 @@ impl LiftContext {
             5766u32 => Ok(ops::Op::SubgroupAvcImeGetSingleReferenceStreaminINTEL {
                 payload: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -7169,7 +7169,7 @@ impl LiftContext {
             5767u32 => Ok(ops::Op::SubgroupAvcImeGetDualReferenceStreaminINTEL {
                 payload: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -7177,7 +7177,7 @@ impl LiftContext {
             5768u32 => Ok(ops::Op::SubgroupAvcImeStripSingleReferenceStreamoutINTEL {
                 payload: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -7185,7 +7185,7 @@ impl LiftContext {
             5769u32 => Ok(ops::Op::SubgroupAvcImeStripDualReferenceStreamoutINTEL {
                 payload: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -7194,13 +7194,13 @@ impl LiftContext {
                 ops::Op::SubgroupAvcImeGetStreamoutSingleReferenceMajorShapeMotionVectorsINTEL {
                     payload: (match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     })
                     .ok_or(OperandError::Missing)?,
                     major_shape: (match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     })
                     .ok_or(OperandError::Missing)?,
@@ -7210,13 +7210,13 @@ impl LiftContext {
                 ops::Op::SubgroupAvcImeGetStreamoutSingleReferenceMajorShapeDistortionsINTEL {
                     payload: (match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     })
                     .ok_or(OperandError::Missing)?,
                     major_shape: (match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     })
                     .ok_or(OperandError::Missing)?,
@@ -7226,13 +7226,13 @@ impl LiftContext {
                 ops::Op::SubgroupAvcImeGetStreamoutSingleReferenceMajorShapeReferenceIdsINTEL {
                     payload: (match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     })
                     .ok_or(OperandError::Missing)?,
                     major_shape: (match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     })
                     .ok_or(OperandError::Missing)?,
@@ -7242,19 +7242,19 @@ impl LiftContext {
                 ops::Op::SubgroupAvcImeGetStreamoutDualReferenceMajorShapeMotionVectorsINTEL {
                     payload: (match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     })
                     .ok_or(OperandError::Missing)?,
                     major_shape: (match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     })
                     .ok_or(OperandError::Missing)?,
                     direction: (match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     })
                     .ok_or(OperandError::Missing)?,
@@ -7264,19 +7264,19 @@ impl LiftContext {
                 ops::Op::SubgroupAvcImeGetStreamoutDualReferenceMajorShapeDistortionsINTEL {
                     payload: (match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     })
                     .ok_or(OperandError::Missing)?,
                     major_shape: (match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     })
                     .ok_or(OperandError::Missing)?,
                     direction: (match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     })
                     .ok_or(OperandError::Missing)?,
@@ -7286,19 +7286,19 @@ impl LiftContext {
                 ops::Op::SubgroupAvcImeGetStreamoutDualReferenceMajorShapeReferenceIdsINTEL {
                     payload: (match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     })
                     .ok_or(OperandError::Missing)?,
                     major_shape: (match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     })
                     .ok_or(OperandError::Missing)?,
                     direction: (match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     })
                     .ok_or(OperandError::Missing)?,
@@ -7307,13 +7307,13 @@ impl LiftContext {
             5776u32 => Ok(ops::Op::SubgroupAvcImeGetBorderReachedINTEL {
                 image_select: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 payload: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -7321,7 +7321,7 @@ impl LiftContext {
             5777u32 => Ok(ops::Op::SubgroupAvcImeGetTruncatedSearchIndicationINTEL {
                 payload: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -7330,7 +7330,7 @@ impl LiftContext {
                 ops::Op::SubgroupAvcImeGetUnidirectionalEarlySearchTerminationINTEL {
                     payload: (match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     })
                     .ok_or(OperandError::Missing)?,
@@ -7340,7 +7340,7 @@ impl LiftContext {
                 ops::Op::SubgroupAvcImeGetWeightingPatternMinimumMotionVectorINTEL {
                     payload: (match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     })
                     .ok_or(OperandError::Missing)?,
@@ -7350,7 +7350,7 @@ impl LiftContext {
                 ops::Op::SubgroupAvcImeGetWeightingPatternMinimumDistortionINTEL {
                     payload: (match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     })
                     .ok_or(OperandError::Missing)?,
@@ -7359,43 +7359,43 @@ impl LiftContext {
             5781u32 => Ok(ops::Op::SubgroupAvcFmeInitializeINTEL {
                 src_coord: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 motion_vectors: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 major_shapes: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 minor_shapes: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 direction: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 pixel_resolution: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 sad_adjustment: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -7403,49 +7403,49 @@ impl LiftContext {
             5782u32 => Ok(ops::Op::SubgroupAvcBmeInitializeINTEL {
                 src_coord: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 motion_vectors: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 major_shapes: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 minor_shapes: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 direction: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 pixel_resolution: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 bidirectional_weight: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 sad_adjustment: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -7453,7 +7453,7 @@ impl LiftContext {
             5783u32 => Ok(ops::Op::SubgroupAvcRefConvertToMcePayloadINTEL {
                 payload: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -7461,7 +7461,7 @@ impl LiftContext {
             5784u32 => Ok(ops::Op::SubgroupAvcRefSetBidirectionalMixDisableINTEL {
                 payload: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -7469,7 +7469,7 @@ impl LiftContext {
             5785u32 => Ok(ops::Op::SubgroupAvcRefSetBilinearFilterEnableINTEL {
                 payload: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -7477,19 +7477,19 @@ impl LiftContext {
             5786u32 => Ok(ops::Op::SubgroupAvcRefEvaluateWithSingleReferenceINTEL {
                 src_image: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 ref_image: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 payload: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -7497,25 +7497,25 @@ impl LiftContext {
             5787u32 => Ok(ops::Op::SubgroupAvcRefEvaluateWithDualReferenceINTEL {
                 src_image: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 fwd_ref_image: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 bwd_ref_image: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 payload: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -7523,19 +7523,19 @@ impl LiftContext {
             5788u32 => Ok(ops::Op::SubgroupAvcRefEvaluateWithMultiReferenceINTEL {
                 src_image: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 packed_reference_ids: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 payload: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -7544,25 +7544,25 @@ impl LiftContext {
                 ops::Op::SubgroupAvcRefEvaluateWithMultiReferenceInterlacedINTEL {
                     src_image: (match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     })
                     .ok_or(OperandError::Missing)?,
                     packed_reference_ids: (match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     })
                     .ok_or(OperandError::Missing)?,
                     packed_reference_field_polarities: (match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     })
                     .ok_or(OperandError::Missing)?,
                     payload: (match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     })
                     .ok_or(OperandError::Missing)?,
@@ -7571,7 +7571,7 @@ impl LiftContext {
             5790u32 => Ok(ops::Op::SubgroupAvcRefConvertToMceResultINTEL {
                 payload: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -7579,7 +7579,7 @@ impl LiftContext {
             5791u32 => Ok(ops::Op::SubgroupAvcSicInitializeINTEL {
                 src_coord: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -7587,37 +7587,37 @@ impl LiftContext {
             5792u32 => Ok(ops::Op::SubgroupAvcSicConfigureSkcINTEL {
                 skip_block_partition_type: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(self.types.lookup_token(*value)),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 skip_motion_vector_mask: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 motion_vectors: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 bidirectional_weight: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 sad_adjustment: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 payload: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -7625,49 +7625,49 @@ impl LiftContext {
             5793u32 => Ok(ops::Op::SubgroupAvcSicConfigureIpeLumaINTEL {
                 luma_intra_partition_mask: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 intra_neighbour_availabilty: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 left_edge_luma_pixels: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 upper_left_corner_luma_pixel: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 upper_edge_luma_pixels: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 upper_right_edge_luma_pixels: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 sad_adjustment: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 payload: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -7675,67 +7675,67 @@ impl LiftContext {
             5794u32 => Ok(ops::Op::SubgroupAvcSicConfigureIpeLumaChromaINTEL {
                 luma_intra_partition_mask: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 intra_neighbour_availabilty: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 left_edge_luma_pixels: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 upper_left_corner_luma_pixel: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 upper_edge_luma_pixels: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 upper_right_edge_luma_pixels: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 left_edge_chroma_pixels: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 upper_left_corner_chroma_pixel: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 upper_edge_chroma_pixels: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 sad_adjustment: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 payload: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -7743,13 +7743,13 @@ impl LiftContext {
             5795u32 => Ok(ops::Op::SubgroupAvcSicGetMotionVectorMaskINTEL {
                 skip_block_partition_type: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(self.types.lookup_token(*value)),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 direction: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -7757,7 +7757,7 @@ impl LiftContext {
             5796u32 => Ok(ops::Op::SubgroupAvcSicConvertToMcePayloadINTEL {
                 payload: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -7765,13 +7765,13 @@ impl LiftContext {
             5797u32 => Ok(ops::Op::SubgroupAvcSicSetIntraLumaShapePenaltyINTEL {
                 packed_shape_penalty: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 payload: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -7779,25 +7779,25 @@ impl LiftContext {
             5798u32 => Ok(ops::Op::SubgroupAvcSicSetIntraLumaModeCostFunctionINTEL {
                 luma_mode_penalty: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 luma_packed_neighbor_modes: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 luma_packed_non_dc_penalty: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 payload: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -7805,13 +7805,13 @@ impl LiftContext {
             5799u32 => Ok(ops::Op::SubgroupAvcSicSetIntraChromaModeCostFunctionINTEL {
                 chroma_mode_base_penalty: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 payload: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -7819,7 +7819,7 @@ impl LiftContext {
             5800u32 => Ok(ops::Op::SubgroupAvcSicSetBilinearFilterEnableINTEL {
                 payload: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -7827,13 +7827,13 @@ impl LiftContext {
             5801u32 => Ok(ops::Op::SubgroupAvcSicSetSkcForwardTransformEnableINTEL {
                 packed_sad_coefficients: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 payload: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -7841,13 +7841,13 @@ impl LiftContext {
             5802u32 => Ok(ops::Op::SubgroupAvcSicSetBlockBasedRawSkipSadINTEL {
                 block_based_skip_type: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(self.types.lookup_token(*value)),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 payload: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -7855,13 +7855,13 @@ impl LiftContext {
             5803u32 => Ok(ops::Op::SubgroupAvcSicEvaluateIpeINTEL {
                 src_image: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 payload: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -7869,19 +7869,19 @@ impl LiftContext {
             5804u32 => Ok(ops::Op::SubgroupAvcSicEvaluateWithSingleReferenceINTEL {
                 src_image: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 ref_image: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 payload: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -7889,25 +7889,25 @@ impl LiftContext {
             5805u32 => Ok(ops::Op::SubgroupAvcSicEvaluateWithDualReferenceINTEL {
                 src_image: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 fwd_ref_image: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 bwd_ref_image: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 payload: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -7915,19 +7915,19 @@ impl LiftContext {
             5806u32 => Ok(ops::Op::SubgroupAvcSicEvaluateWithMultiReferenceINTEL {
                 src_image: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 packed_reference_ids: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 payload: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -7936,25 +7936,25 @@ impl LiftContext {
                 ops::Op::SubgroupAvcSicEvaluateWithMultiReferenceInterlacedINTEL {
                     src_image: (match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     })
                     .ok_or(OperandError::Missing)?,
                     packed_reference_ids: (match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     })
                     .ok_or(OperandError::Missing)?,
                     packed_reference_field_polarities: (match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     })
                     .ok_or(OperandError::Missing)?,
                     payload: (match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     })
                     .ok_or(OperandError::Missing)?,
@@ -7963,7 +7963,7 @@ impl LiftContext {
             5808u32 => Ok(ops::Op::SubgroupAvcSicConvertToMceResultINTEL {
                 payload: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -7971,7 +7971,7 @@ impl LiftContext {
             5809u32 => Ok(ops::Op::SubgroupAvcSicGetIpeLumaShapeINTEL {
                 payload: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -7979,7 +7979,7 @@ impl LiftContext {
             5810u32 => Ok(ops::Op::SubgroupAvcSicGetBestIpeLumaDistortionINTEL {
                 payload: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -7987,7 +7987,7 @@ impl LiftContext {
             5811u32 => Ok(ops::Op::SubgroupAvcSicGetBestIpeChromaDistortionINTEL {
                 payload: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -7995,7 +7995,7 @@ impl LiftContext {
             5812u32 => Ok(ops::Op::SubgroupAvcSicGetPackedIpeLumaModesINTEL {
                 payload: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -8003,7 +8003,7 @@ impl LiftContext {
             5813u32 => Ok(ops::Op::SubgroupAvcSicGetIpeChromaModeINTEL {
                 payload: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -8011,7 +8011,7 @@ impl LiftContext {
             5814u32 => Ok(ops::Op::SubgroupAvcSicGetPackedSkcLumaCountThresholdINTEL {
                 payload: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -8019,7 +8019,7 @@ impl LiftContext {
             5815u32 => Ok(ops::Op::SubgroupAvcSicGetPackedSkcLumaSumThresholdINTEL {
                 payload: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -8027,7 +8027,7 @@ impl LiftContext {
             5816u32 => Ok(ops::Op::SubgroupAvcSicGetInterRawSadsINTEL {
                 payload: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -8037,7 +8037,7 @@ impl LiftContext {
                     let mut vec = Vec::new();
                     while let Some(item) = match operands.next() {
                         Some(&dr::Operand::LiteralInt32(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     } {
                         vec.push(item);
@@ -8048,13 +8048,13 @@ impl LiftContext {
             5946u32 => Ok(ops::Op::ReadPipeBlockingINTEL {
                 packet_size: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 packet_alignment: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -8062,13 +8062,13 @@ impl LiftContext {
             5947u32 => Ok(ops::Op::WritePipeBlockingINTEL {
                 packet_size: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 packet_alignment: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -8076,13 +8076,13 @@ impl LiftContext {
             5949u32 => Ok(ops::Op::FPGARegINTEL {
                 result: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 input: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -8090,7 +8090,7 @@ impl LiftContext {
             6016u32 => Ok(ops::Op::RayQueryGetRayTMinKHR {
                 ray_query: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -8098,7 +8098,7 @@ impl LiftContext {
             6017u32 => Ok(ops::Op::RayQueryGetRayFlagsKHR {
                 ray_query: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -8106,13 +8106,13 @@ impl LiftContext {
             6018u32 => Ok(ops::Op::RayQueryGetIntersectionTKHR {
                 ray_query: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 intersection: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -8120,13 +8120,13 @@ impl LiftContext {
             6019u32 => Ok(ops::Op::RayQueryGetIntersectionInstanceCustomIndexKHR {
                 ray_query: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 intersection: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -8134,13 +8134,13 @@ impl LiftContext {
             6020u32 => Ok(ops::Op::RayQueryGetIntersectionInstanceIdKHR {
                 ray_query: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 intersection: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -8149,13 +8149,13 @@ impl LiftContext {
                 ops::Op::RayQueryGetIntersectionInstanceShaderBindingTableRecordOffsetKHR {
                     ray_query: (match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     })
                     .ok_or(OperandError::Missing)?,
                     intersection: (match operands.next() {
                         Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     })
                     .ok_or(OperandError::Missing)?,
@@ -8164,13 +8164,13 @@ impl LiftContext {
             6022u32 => Ok(ops::Op::RayQueryGetIntersectionGeometryIndexKHR {
                 ray_query: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 intersection: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -8178,13 +8178,13 @@ impl LiftContext {
             6023u32 => Ok(ops::Op::RayQueryGetIntersectionPrimitiveIndexKHR {
                 ray_query: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 intersection: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -8192,13 +8192,13 @@ impl LiftContext {
             6024u32 => Ok(ops::Op::RayQueryGetIntersectionBarycentricsKHR {
                 ray_query: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 intersection: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -8206,13 +8206,13 @@ impl LiftContext {
             6025u32 => Ok(ops::Op::RayQueryGetIntersectionFrontFaceKHR {
                 ray_query: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 intersection: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -8220,7 +8220,7 @@ impl LiftContext {
             6026u32 => Ok(ops::Op::RayQueryGetIntersectionCandidateAABBOpaqueKHR {
                 ray_query: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -8228,13 +8228,13 @@ impl LiftContext {
             6027u32 => Ok(ops::Op::RayQueryGetIntersectionObjectRayDirectionKHR {
                 ray_query: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 intersection: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -8242,13 +8242,13 @@ impl LiftContext {
             6028u32 => Ok(ops::Op::RayQueryGetIntersectionObjectRayOriginKHR {
                 ray_query: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 intersection: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -8256,7 +8256,7 @@ impl LiftContext {
             6029u32 => Ok(ops::Op::RayQueryGetWorldRayDirectionKHR {
                 ray_query: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -8264,7 +8264,7 @@ impl LiftContext {
             6030u32 => Ok(ops::Op::RayQueryGetWorldRayOriginKHR {
                 ray_query: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -8272,13 +8272,13 @@ impl LiftContext {
             6031u32 => Ok(ops::Op::RayQueryGetIntersectionObjectToWorldKHR {
                 ray_query: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 intersection: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -8286,13 +8286,13 @@ impl LiftContext {
             6032u32 => Ok(ops::Op::RayQueryGetIntersectionWorldToObjectKHR {
                 ray_query: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 intersection: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -8300,25 +8300,25 @@ impl LiftContext {
             6035u32 => Ok(ops::Op::AtomicFAddEXT {
                 pointer: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 memory: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 semantics: (match operands.next() {
                     Some(&dr::Operand::IdMemorySemantics(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 value: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -8334,13 +8334,13 @@ impl LiftContext {
             21u32 => Ok(Type::Int {
                 width: (match operands.next() {
                     Some(&dr::Operand::LiteralInt32(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 signedness: (match operands.next() {
                     Some(&dr::Operand::LiteralInt32(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -8348,7 +8348,7 @@ impl LiftContext {
             22u32 => Ok(Type::Float {
                 width: (match operands.next() {
                     Some(&dr::Operand::LiteralInt32(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -8356,13 +8356,13 @@ impl LiftContext {
             23u32 => Ok(Type::Vector {
                 component_type: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(self.types.lookup_token(*value)),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 component_count: (match operands.next() {
                     Some(&dr::Operand::LiteralInt32(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -8370,13 +8370,13 @@ impl LiftContext {
             24u32 => Ok(Type::Matrix {
                 column_type: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(self.types.lookup_token(*value)),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 column_count: (match operands.next() {
                     Some(&dr::Operand::LiteralInt32(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -8384,49 +8384,49 @@ impl LiftContext {
             25u32 => Ok(Type::Image {
                 sampled_type: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(self.types.lookup_token(*value)),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 dim: (match operands.next() {
                     Some(&dr::Operand::Dim(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 depth: (match operands.next() {
                     Some(&dr::Operand::LiteralInt32(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 arrayed: (match operands.next() {
                     Some(&dr::Operand::LiteralInt32(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 ms: (match operands.next() {
                     Some(&dr::Operand::LiteralInt32(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 sampled: (match operands.next() {
                     Some(&dr::Operand::LiteralInt32(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 image_format: (match operands.next() {
                     Some(&dr::Operand::ImageFormat(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 access_qualifier: match operands.next() {
                     Some(&dr::Operand::AccessQualifier(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 },
             }),
@@ -8434,7 +8434,7 @@ impl LiftContext {
             27u32 => Ok(Type::SampledImage {
                 image_type: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(self.types.lookup_token(*value)),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -8442,7 +8442,7 @@ impl LiftContext {
             28u32 => Ok(Type::Array {
                 element_type: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(self.types.lookup_token(*value)),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -8450,7 +8450,7 @@ impl LiftContext {
                     Some(&dr::Operand::IdRef(ref value)) => {
                         Some(self.constants.lookup_token(*value))
                     }
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -8458,7 +8458,7 @@ impl LiftContext {
             29u32 => Ok(Type::RuntimeArray {
                 element_type: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(self.types.lookup_token(*value)),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -8470,7 +8470,7 @@ impl LiftContext {
                         Some(&dr::Operand::IdRef(ref value)) => {
                             Some(StructMember::new(self.types.lookup_token(*value)))
                         }
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     } {
                         vec.push(item);
@@ -8481,7 +8481,7 @@ impl LiftContext {
             31u32 => Ok(Type::Opaque {
                 the_name_of_the_opaque_type: (match operands.next() {
                     Some(&dr::Operand::LiteralString(ref value)) => Some(value.clone()),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -8489,13 +8489,13 @@ impl LiftContext {
             32u32 => Ok(Type::Pointer {
                 storage_class: (match operands.next() {
                     Some(&dr::Operand::StorageClass(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 ty: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(self.types.lookup_token(*value)),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -8503,7 +8503,7 @@ impl LiftContext {
             33u32 => Ok(Type::Function {
                 return_type: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(self.types.lookup_token(*value)),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -8513,7 +8513,7 @@ impl LiftContext {
                         Some(&dr::Operand::IdRef(ref value)) => {
                             Some(self.types.lookup_token(*value))
                         }
-                        Some(_) => Err(OperandError::WrongType)?,
+                        Some(_) => return Err(OperandError::WrongType.into()),
                         None => None,
                     } {
                         vec.push(item);
@@ -8528,7 +8528,7 @@ impl LiftContext {
             38u32 => Ok(Type::Pipe {
                 qualifier: (match operands.next() {
                     Some(&dr::Operand::AccessQualifier(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -8536,13 +8536,13 @@ impl LiftContext {
             39u32 => Ok(Type::ForwardPointer {
                 pointer_type: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(self.types.lookup_token(*value)),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 storage_class: (match operands.next() {
                     Some(&dr::Operand::StorageClass(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -8554,25 +8554,25 @@ impl LiftContext {
             5358u32 => Ok(Type::CooperativeMatrixNV {
                 component_type: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(self.types.lookup_token(*value)),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 execution: (match operands.next() {
                     Some(&dr::Operand::IdScope(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 rows: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
                 columns: (match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 })
                 .ok_or(OperandError::Missing)?,
@@ -8592,7 +8592,7 @@ impl LiftContext {
         Ok(instructions::Extension {
             name: (match operands.next() {
                 Some(&dr::Operand::LiteralString(ref value)) => Some(value.clone()),
-                Some(_) => Err(OperandError::WrongType)?,
+                Some(_) => return Err(OperandError::WrongType.into()),
                 None => None,
             })
             .ok_or(OperandError::Missing)?,
@@ -8610,7 +8610,7 @@ impl LiftContext {
         Ok(instructions::ExtInstImport {
             name: (match operands.next() {
                 Some(&dr::Operand::LiteralString(ref value)) => Some(value.clone()),
-                Some(_) => Err(OperandError::WrongType)?,
+                Some(_) => return Err(OperandError::WrongType.into()),
                 None => None,
             })
             .ok_or(OperandError::Missing)?,
@@ -8628,13 +8628,13 @@ impl LiftContext {
         Ok(instructions::ExtInst {
             set: (match operands.next() {
                 Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                Some(_) => Err(OperandError::WrongType)?,
+                Some(_) => return Err(OperandError::WrongType.into()),
                 None => None,
             })
             .ok_or(OperandError::Missing)?,
             instruction: (match operands.next() {
                 Some(&dr::Operand::LiteralExtInstInteger(ref value)) => Some(*value),
-                Some(_) => Err(OperandError::WrongType)?,
+                Some(_) => return Err(OperandError::WrongType.into()),
                 None => None,
             })
             .ok_or(OperandError::Missing)?,
@@ -8642,7 +8642,7 @@ impl LiftContext {
                 let mut vec = Vec::new();
                 while let Some(item) = match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 } {
                     vec.push(item);
@@ -8663,13 +8663,13 @@ impl LiftContext {
         Ok(instructions::MemoryModel {
             addressing_model: (match operands.next() {
                 Some(&dr::Operand::AddressingModel(ref value)) => Some(*value),
-                Some(_) => Err(OperandError::WrongType)?,
+                Some(_) => return Err(OperandError::WrongType.into()),
                 None => None,
             })
             .ok_or(OperandError::Missing)?,
             memory_model: (match operands.next() {
                 Some(&dr::Operand::MemoryModel(ref value)) => Some(*value),
-                Some(_) => Err(OperandError::WrongType)?,
+                Some(_) => return Err(OperandError::WrongType.into()),
                 None => None,
             })
             .ok_or(OperandError::Missing)?,
@@ -8687,19 +8687,19 @@ impl LiftContext {
         Ok(instructions::EntryPoint {
             execution_model: (match operands.next() {
                 Some(&dr::Operand::ExecutionModel(ref value)) => Some(*value),
-                Some(_) => Err(OperandError::WrongType)?,
+                Some(_) => return Err(OperandError::WrongType.into()),
                 None => None,
             })
             .ok_or(OperandError::Missing)?,
             entry_point: (match operands.next() {
                 Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                Some(_) => Err(OperandError::WrongType)?,
+                Some(_) => return Err(OperandError::WrongType.into()),
                 None => None,
             })
             .ok_or(OperandError::Missing)?,
             name: (match operands.next() {
                 Some(&dr::Operand::LiteralString(ref value)) => Some(value.clone()),
-                Some(_) => Err(OperandError::WrongType)?,
+                Some(_) => return Err(OperandError::WrongType.into()),
                 None => None,
             })
             .ok_or(OperandError::Missing)?,
@@ -8707,7 +8707,7 @@ impl LiftContext {
                 let mut vec = Vec::new();
                 while let Some(item) = match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 } {
                     vec.push(item);
@@ -8728,13 +8728,13 @@ impl LiftContext {
         Ok(instructions::ExecutionMode {
             entry_point: (match operands.next() {
                 Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                Some(_) => Err(OperandError::WrongType)?,
+                Some(_) => return Err(OperandError::WrongType.into()),
                 None => None,
             })
             .ok_or(OperandError::Missing)?,
             mode: (match operands.next() {
                 Some(&dr::Operand::ExecutionMode(ref value)) => Some(*value),
-                Some(_) => Err(OperandError::WrongType)?,
+                Some(_) => return Err(OperandError::WrongType.into()),
                 None => None,
             })
             .ok_or(OperandError::Missing)?,
@@ -8752,7 +8752,7 @@ impl LiftContext {
         Ok(instructions::Capability {
             capability: (match operands.next() {
                 Some(&dr::Operand::Capability(ref value)) => Some(*value),
-                Some(_) => Err(OperandError::WrongType)?,
+                Some(_) => return Err(OperandError::WrongType.into()),
                 None => None,
             })
             .ok_or(OperandError::Missing)?,
@@ -8770,13 +8770,13 @@ impl LiftContext {
         Ok(instructions::Function {
             function_control: (match operands.next() {
                 Some(&dr::Operand::FunctionControl(ref value)) => Some(*value),
-                Some(_) => Err(OperandError::WrongType)?,
+                Some(_) => return Err(OperandError::WrongType.into()),
                 None => None,
             })
             .ok_or(OperandError::Missing)?,
             function_type: (match operands.next() {
                 Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                Some(_) => Err(OperandError::WrongType)?,
+                Some(_) => return Err(OperandError::WrongType.into()),
                 None => None,
             })
             .ok_or(OperandError::Missing)?,
@@ -8814,7 +8814,7 @@ impl LiftContext {
         Ok(instructions::FunctionCall {
             function: (match operands.next() {
                 Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                Some(_) => Err(OperandError::WrongType)?,
+                Some(_) => return Err(OperandError::WrongType.into()),
                 None => None,
             })
             .ok_or(OperandError::Missing)?,
@@ -8822,7 +8822,7 @@ impl LiftContext {
                 let mut vec = Vec::new();
                 while let Some(item) = match operands.next() {
                     Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                    Some(_) => Err(OperandError::WrongType)?,
+                    Some(_) => return Err(OperandError::WrongType.into()),
                     None => None,
                 } {
                     vec.push(item);
@@ -8843,13 +8843,13 @@ impl LiftContext {
         Ok(instructions::ExecutionModeId {
             entry_point: (match operands.next() {
                 Some(&dr::Operand::IdRef(ref value)) => Some(*value),
-                Some(_) => Err(OperandError::WrongType)?,
+                Some(_) => return Err(OperandError::WrongType.into()),
                 None => None,
             })
             .ok_or(OperandError::Missing)?,
             mode: (match operands.next() {
                 Some(&dr::Operand::ExecutionMode(ref value)) => Some(*value),
-                Some(_) => Err(OperandError::WrongType)?,
+                Some(_) => return Err(OperandError::WrongType.into()),
                 None => None,
             })
             .ok_or(OperandError::Missing)?,

--- a/rspirv/lift/mod.rs
+++ b/rspirv/lift/mod.rs
@@ -9,8 +9,6 @@ use crate::{
     sr::{instructions, module, ops, storage::Token, Constant, StructMember, Type},
 };
 
-use spirv;
-
 use std::{borrow::Borrow, mem};
 
 /// A structure that we associate an <id> with, containing
@@ -258,7 +256,7 @@ impl LiftContext {
                         }
                         Ok(value)
                     }
-                    _ => return Err(InstructionError::MissingResult),
+                    _ => Err(InstructionError::MissingResult),
                 }
             }
             spirv::Op::ConstantComposite => {

--- a/rspirv/sr/autogen_decoration.rs
+++ b/rspirv/sr/autogen_decoration.rs
@@ -2,7 +2,7 @@
 //   external/spirv.core.grammar.json.
 // DO NOT MODIFY!
 
-use spirv;
+#![allow(clippy::upper_case_acronyms)]
 #[doc = r" SPIR-V decorations."]
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 pub enum Decoration {

--- a/rspirv/sr/autogen_ops.rs
+++ b/rspirv/sr/autogen_ops.rs
@@ -49,12 +49,14 @@ pub enum Branch {
     TerminateInvocation,
 }
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[allow(clippy::upper_case_acronyms)]
 pub enum Terminator {
     Branch(Branch),
     IgnoreIntersectionKHR,
     TerminateRayKHR,
 }
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[allow(clippy::upper_case_acronyms)]
 pub enum Op {
     Nop,
     Undef,

--- a/rspirv/sr/autogen_types.rs
+++ b/rspirv/sr/autogen_types.rs
@@ -2,6 +2,7 @@
 //   external/spirv.core.grammar.json.
 // DO NOT MODIFY!
 
+#[allow(clippy::upper_case_acronyms)]
 #[derive(Clone, Debug)]
 pub enum Type {
     Void,

--- a/rspirv/sr/constants.rs
+++ b/rspirv/sr/constants.rs
@@ -27,70 +27,49 @@ pub enum Constant {
 
 impl Constant {
     pub fn is_bool_constant(&self) -> bool {
-        match self {
-            Constant::Bool { .. } | Constant::SpecBool { .. } => true,
-            _ => false,
-        }
+        matches!(self, Constant::Bool { .. } | Constant::SpecBool { .. })
     }
 
     pub fn is_int_constant(&self) -> bool {
-        match self {
-            Constant::Int { .. } | Constant::SpecInt { .. } => true,
-            _ => false,
-        }
+        matches!(self, Constant::Int { .. } | Constant::SpecInt { .. })
     }
 
     pub fn is_uint_constant(&self) -> bool {
-        match self {
-            Constant::UInt { .. } | Constant::SpecUInt { .. } => true,
-            _ => false,
-        }
+        matches!(self, Constant::UInt { .. } | Constant::SpecUInt { .. })
     }
 
     pub fn is_float_constant(&self) -> bool {
-        match self {
-            Constant::Float { .. } | Constant::SpecFloat { .. } => true,
-            _ => false,
-        }
+        matches!(self, Constant::Float { .. } | Constant::SpecFloat { .. })
     }
 
     pub fn is_composite_constant(&self) -> bool {
-        match self {
-            Constant::Composite { .. } | Constant::SpecComposite { .. } => true,
-            _ => false,
-        }
+        matches!(
+            self,
+            Constant::Composite { .. } | Constant::SpecComposite { .. }
+        )
     }
 
     pub fn is_null_constant(&self) -> bool {
-        match self {
-            Constant::Null { .. } => true,
-            _ => false,
-        }
+        matches!(self, Constant::Null { .. })
     }
 
     pub fn is_sampler_constant(&self) -> bool {
-        match self {
-            Constant::Sampler { .. } => true,
-            _ => false,
-        }
+        matches!(self, Constant::Sampler { .. })
     }
 
     pub fn is_spec_constant(&self) -> bool {
-        match self {
+        matches!(
+            self,
             Constant::SpecBool { .. }
-            | Constant::SpecInt { .. }
-            | Constant::SpecUInt { .. }
-            | Constant::SpecFloat { .. }
-            | Constant::SpecComposite { .. }
-            | Constant::SpecOp { .. } => true,
-            _ => false,
-        }
+                | Constant::SpecInt { .. }
+                | Constant::SpecUInt { .. }
+                | Constant::SpecFloat { .. }
+                | Constant::SpecComposite { .. }
+                | Constant::SpecOp { .. }
+        )
     }
 
     pub fn is_spec_op_constant(&self) -> bool {
-        match self {
-            Constant::SpecOp { .. } => true,
-            _ => false,
-        }
+        matches!(self, Constant::SpecOp { .. })
     }
 }

--- a/rspirv/sr/module.rs
+++ b/rspirv/sr/module.rs
@@ -6,8 +6,6 @@ use crate::{
     sr::types::Type,
 };
 
-use spirv;
-
 #[derive(Debug)]
 pub struct EntryPoint {
     pub execution_model: spirv::ExecutionModel,

--- a/rspirv/sr/storage.rs
+++ b/rspirv/sr/storage.rs
@@ -56,7 +56,7 @@ impl<T> Token<T> {
 
 /// A structure holding some kind of SPIR-V entity (e.g., type, constant,
 /// instruction, etc.) that can be referenced.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct Storage<T> {
     /// Values of this storage.
     data: Vec<T>,

--- a/rspirv/sr/types.rs
+++ b/rspirv/sr/types.rs
@@ -62,10 +62,7 @@ impl PartialEq for Type {
 
 impl Type {
     pub fn is_numerical_type(&self) -> bool {
-        match self {
-            Type::Int { .. } | Type::Float { .. } => true,
-            _ => false,
-        }
+        matches!(self, Type::Int { .. } | Type::Float { .. })
     }
 
     pub fn is_scalar_type(&self) -> bool {
@@ -76,10 +73,10 @@ impl Type {
     }
 
     pub fn is_aggregate_type(&self) -> bool {
-        match self {
-            Type::Struct { .. } | Type::Array { .. } | Type::RuntimeArray { .. } => true,
-            _ => false,
-        }
+        matches!(
+            self,
+            Type::Struct { .. } | Type::Array { .. } | Type::RuntimeArray { .. }
+        )
     }
 
     pub fn is_composite_type(&self) -> bool {

--- a/spirv/autogen_spirv.rs
+++ b/spirv/autogen_spirv.rs
@@ -22,6 +22,7 @@ bitflags! { # [doc = "SPIR-V operand kind: [FragmentShadingRate](https://www.khr
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[allow(clippy::upper_case_acronyms)]
 pub enum SourceLanguage {
     Unknown = 0u32,
     ESSL = 1u32,
@@ -68,6 +69,7 @@ impl core::str::FromStr for SourceLanguage {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[allow(clippy::upper_case_acronyms)]
 pub enum ExecutionModel {
     Vertex = 0u32,
     TessellationControl = 1u32,
@@ -154,6 +156,7 @@ impl core::str::FromStr for ExecutionModel {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[allow(clippy::upper_case_acronyms)]
 pub enum AddressingModel {
     Logical = 0u32,
     Physical32 = 1u32,
@@ -197,6 +200,7 @@ impl core::str::FromStr for AddressingModel {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[allow(clippy::upper_case_acronyms)]
 pub enum MemoryModel {
     Simple = 0u32,
     GLSL450 = 1u32,
@@ -240,6 +244,7 @@ impl core::str::FromStr for MemoryModel {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[allow(clippy::upper_case_acronyms)]
 pub enum ExecutionMode {
     Invocations = 0u32,
     SpacingEqual = 1u32,
@@ -448,6 +453,7 @@ impl core::str::FromStr for ExecutionMode {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[allow(clippy::upper_case_acronyms)]
 pub enum StorageClass {
     UniformConstant = 0u32,
     Input = 1u32,
@@ -554,6 +560,7 @@ impl core::str::FromStr for StorageClass {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[allow(clippy::upper_case_acronyms)]
 pub enum Dim {
     Dim1D = 0u32,
     Dim2D = 1u32,
@@ -603,6 +610,7 @@ impl core::str::FromStr for Dim {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[allow(clippy::upper_case_acronyms)]
 pub enum SamplerAddressingMode {
     None = 0u32,
     ClampToEdge = 1u32,
@@ -646,6 +654,7 @@ impl core::str::FromStr for SamplerAddressingMode {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[allow(clippy::upper_case_acronyms)]
 pub enum SamplerFilterMode {
     Nearest = 0u32,
     Linear = 1u32,
@@ -680,6 +689,7 @@ impl core::str::FromStr for SamplerFilterMode {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[allow(clippy::upper_case_acronyms)]
 pub enum ImageFormat {
     Unknown = 0u32,
     Rgba32f = 1u32,
@@ -834,6 +844,7 @@ impl core::str::FromStr for ImageFormat {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[allow(clippy::upper_case_acronyms)]
 pub enum ImageChannelOrder {
     R = 0u32,
     A = 1u32,
@@ -922,6 +933,7 @@ impl core::str::FromStr for ImageChannelOrder {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[allow(clippy::upper_case_acronyms)]
 pub enum ImageChannelDataType {
     SnormInt8 = 0u32,
     SnormInt16 = 1u32,
@@ -1001,6 +1013,7 @@ impl core::str::FromStr for ImageChannelDataType {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[allow(clippy::upper_case_acronyms)]
 pub enum FPRoundingMode {
     RTE = 0u32,
     RTZ = 1u32,
@@ -1041,6 +1054,7 @@ impl core::str::FromStr for FPRoundingMode {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[allow(clippy::upper_case_acronyms)]
 pub enum LinkageType {
     Export = 0u32,
     Import = 1u32,
@@ -1075,6 +1089,7 @@ impl core::str::FromStr for LinkageType {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[allow(clippy::upper_case_acronyms)]
 pub enum AccessQualifier {
     ReadOnly = 0u32,
     WriteOnly = 1u32,
@@ -1112,6 +1127,7 @@ impl core::str::FromStr for AccessQualifier {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[allow(clippy::upper_case_acronyms)]
 pub enum FunctionParameterAttribute {
     Zext = 0u32,
     Sext = 1u32,
@@ -1164,6 +1180,7 @@ impl core::str::FromStr for FunctionParameterAttribute {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[allow(clippy::upper_case_acronyms)]
 pub enum Decoration {
     RelaxedPrecision = 0u32,
     SpecId = 1u32,
@@ -1434,6 +1451,7 @@ impl core::str::FromStr for Decoration {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[allow(clippy::upper_case_acronyms)]
 pub enum BuiltIn {
     Position = 0u32,
     PointSize = 1u32,
@@ -1797,6 +1815,7 @@ impl core::str::FromStr for BuiltIn {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[allow(clippy::upper_case_acronyms)]
 pub enum Scope {
     CrossDevice = 0u32,
     Device = 1u32,
@@ -1849,6 +1868,7 @@ impl core::str::FromStr for Scope {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[allow(clippy::upper_case_acronyms)]
 pub enum GroupOperation {
     Reduce = 0u32,
     InclusiveScan = 1u32,
@@ -1898,6 +1918,7 @@ impl core::str::FromStr for GroupOperation {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[allow(clippy::upper_case_acronyms)]
 pub enum KernelEnqueueFlags {
     NoWait = 0u32,
     WaitKernel = 1u32,
@@ -1935,6 +1956,7 @@ impl core::str::FromStr for KernelEnqueueFlags {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[allow(clippy::upper_case_acronyms)]
 pub enum Capability {
     Matrix = 0u32,
     Shader = 1u32,
@@ -2526,6 +2548,7 @@ impl core::str::FromStr for Capability {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[allow(clippy::upper_case_acronyms)]
 pub enum RayQueryIntersection {
     RayQueryCandidateIntersectionKHR = 0u32,
     RayQueryCommittedIntersectionKHR = 1u32,
@@ -2560,6 +2583,7 @@ impl core::str::FromStr for RayQueryIntersection {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[allow(clippy::upper_case_acronyms)]
 pub enum RayQueryCommittedIntersectionType {
     RayQueryCommittedIntersectionNoneKHR = 0u32,
     RayQueryCommittedIntersectionTriangleKHR = 1u32,
@@ -2603,6 +2627,7 @@ impl core::str::FromStr for RayQueryCommittedIntersectionType {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[allow(clippy::upper_case_acronyms)]
 pub enum RayQueryCandidateIntersectionType {
     RayQueryCandidateIntersectionTriangleKHR = 0u32,
     RayQueryCandidateIntersectionAABBKHR = 1u32,
@@ -2641,6 +2666,7 @@ impl core::str::FromStr for RayQueryCandidateIntersectionType {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[allow(clippy::upper_case_acronyms)]
 pub enum Op {
     Nop = 0u32,
     Undef = 1u32,
@@ -3203,6 +3229,7 @@ pub enum Op {
     RayQueryGetIntersectionWorldToObjectKHR = 6032u32,
     AtomicFAddEXT = 6035u32,
 }
+#[allow(clippy::upper_case_acronyms)]
 #[allow(non_upper_case_globals)]
 impl Op {
     pub const ReportIntersectionKHR: Op = Op::ReportIntersectionNV;
@@ -3786,6 +3813,7 @@ impl num_traits::FromPrimitive for Op {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[allow(clippy::upper_case_acronyms)]
 pub enum GLOp {
     Round = 1u32,
     RoundEven = 2u32,
@@ -3966,6 +3994,7 @@ impl num_traits::FromPrimitive for GLOp {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[allow(clippy::upper_case_acronyms)]
 pub enum CLOp {
     acos = 0u32,
     acosh = 1u32,


### PR DESCRIPTION
```
> cargo clippy &| wc -l
16723
```

was a little too much for me to cope with

A large chunk of this change is autogen changes, thankfully, not much "real" diff. Biggest thing is slapping `#[allow(clippy::upper_case_acronyms)]` all over.