### PR TITLE
Document and automate the release process

### DIFF
--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -1,0 +1,5 @@
+# Making a new release
+
+1. If you don't have cargo-release installed run `cargo install cargo-release`
+1. For `rspirv` run `cargo release` in the `rspriv` directory, this should follow Semantic Versioning
+1. For `spirv_headers` we don't follow Semantic Versioning, instead we follow the versioning SPIR-V uses, and reserve the patch version to do our own version increments.

--- a/rspirv/README.md
+++ b/rspirv/README.md
@@ -37,12 +37,6 @@ First add to your `Cargo.toml`:
 rspirv = "0.7"
 ```
 
-Then add to your crate root:
-
-```rust
-extern crate rspirv;
-```
-
 Examples
 --------
 

--- a/rspirv/release.toml
+++ b/rspirv/release.toml
@@ -1,0 +1,10 @@
+pre-release-commit-message = "Release {{version}}"
+no-dev-version = true
+tag-message = "Release {{version}}"
+tag-name = "{{version}}"
+sign-commit = true
+sign-tag = true
+
+pre-release-replacements = [
+  {file="README.md", search="rspirv = .*", replace="{{crate_name}} = \"{{version}}\""},
+]

--- a/rspirv/release.toml
+++ b/rspirv/release.toml
@@ -1,7 +1,7 @@
-pre-release-commit-message = "Release {{version}}"
+pre-release-commit-message = "Release {{crate_name}} {{version}}"
 no-dev-version = true
-tag-message = "Release {{version}}"
-tag-name = "{{version}}"
+tag-message = "Release {{crate_name}} {{version}}"
+tag-name = "{{crate_name}}-{{version}}"
 sign-commit = true
 sign-tag = true
 

--- a/spirv/README.md
+++ b/spirv/README.md
@@ -21,12 +21,6 @@ First add to your `Cargo.toml`:
 spirv_headers = "1.5"
 ```
 
-Then add to your crate root:
-
-```rust
-extern crate spirv_headers;
-```
-
 Version
 -------
 

--- a/spirv/release.toml
+++ b/spirv/release.toml
@@ -1,0 +1,10 @@
+pre-release-commit-message = "Release {{version}}"
+no-dev-version = true
+tag-message = "Release {{version}}"
+tag-name = "{{version}}"
+sign-commit = true
+sign-tag = true
+
+pre-release-replacements = [
+  {file="README.md", search="spirv_headers = .*", replace="{{crate_name}} = \"{{version}}\""},
+]

--- a/spirv/release.toml
+++ b/spirv/release.toml
@@ -1,7 +1,7 @@
-pre-release-commit-message = "Release {{version}}"
+pre-release-commit-message = "Release {{crate_name}} {{version}}"
 no-dev-version = true
-tag-message = "Release {{version}}"
-tag-name = "{{version}}"
+tag-message = "Release {{crate_name}} {{version}}"
+tag-name = "{{crate_name}}-{{version}}"
 sign-commit = true
 sign-tag = true
 


### PR DESCRIPTION
This automates the release process through `cargo release` which should make it a bit easier to do more frequent releases.