### PR TITLE
Add type_<name>_id builders

### DIFF
--- a/rspirv/dr/build/autogen_type.rs
+++ b/rspirv/dr/build/autogen_type.rs
@@ -5,15 +5,7 @@
 impl Builder {
     #[doc = "Appends an OpTypeVoid instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_void(&mut self) -> spirv::Word {
-        let mut inst = dr::Instruction::new(spirv::Op::TypeVoid, None, None, vec![]);
-        if let Some(id) = self.dedup_insert_type(&inst) {
-            id
-        } else {
-            let new_id = self.id();
-            inst.result_id = Some(new_id);
-            self.module.types_global_values.push(inst);
-            new_id
-        }
+        self.type_void_id(None)
     }
     #[doc = "Appends an OpTypeVoid instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_void_id(&mut self, result_id: Option<spirv::Word>) -> spirv::Word {
@@ -32,15 +24,7 @@ impl Builder {
     }
     #[doc = "Appends an OpTypeBool instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_bool(&mut self) -> spirv::Word {
-        let mut inst = dr::Instruction::new(spirv::Op::TypeBool, None, None, vec![]);
-        if let Some(id) = self.dedup_insert_type(&inst) {
-            id
-        } else {
-            let new_id = self.id();
-            inst.result_id = Some(new_id);
-            self.module.types_global_values.push(inst);
-            new_id
-        }
+        self.type_bool_id(None)
     }
     #[doc = "Appends an OpTypeBool instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_bool_id(&mut self, result_id: Option<spirv::Word>) -> spirv::Word {
@@ -59,23 +43,7 @@ impl Builder {
     }
     #[doc = "Appends an OpTypeInt instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_int(&mut self, width: u32, signedness: u32) -> spirv::Word {
-        let mut inst = dr::Instruction::new(
-            spirv::Op::TypeInt,
-            None,
-            None,
-            vec![
-                dr::Operand::LiteralInt32(width),
-                dr::Operand::LiteralInt32(signedness),
-            ],
-        );
-        if let Some(id) = self.dedup_insert_type(&inst) {
-            id
-        } else {
-            let new_id = self.id();
-            inst.result_id = Some(new_id);
-            self.module.types_global_values.push(inst);
-            new_id
-        }
+        self.type_int_id(None, width, signedness)
     }
     #[doc = "Appends an OpTypeInt instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_int_id(
@@ -107,20 +75,7 @@ impl Builder {
     }
     #[doc = "Appends an OpTypeFloat instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_float(&mut self, width: u32) -> spirv::Word {
-        let mut inst = dr::Instruction::new(
-            spirv::Op::TypeFloat,
-            None,
-            None,
-            vec![dr::Operand::LiteralInt32(width)],
-        );
-        if let Some(id) = self.dedup_insert_type(&inst) {
-            id
-        } else {
-            let new_id = self.id();
-            inst.result_id = Some(new_id);
-            self.module.types_global_values.push(inst);
-            new_id
-        }
+        self.type_float_id(None, width)
     }
     #[doc = "Appends an OpTypeFloat instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_float_id(&mut self, result_id: Option<spirv::Word>, width: u32) -> spirv::Word {
@@ -148,23 +103,7 @@ impl Builder {
         component_type: spirv::Word,
         component_count: u32,
     ) -> spirv::Word {
-        let mut inst = dr::Instruction::new(
-            spirv::Op::TypeVector,
-            None,
-            None,
-            vec![
-                dr::Operand::IdRef(component_type),
-                dr::Operand::LiteralInt32(component_count),
-            ],
-        );
-        if let Some(id) = self.dedup_insert_type(&inst) {
-            id
-        } else {
-            let new_id = self.id();
-            inst.result_id = Some(new_id);
-            self.module.types_global_values.push(inst);
-            new_id
-        }
+        self.type_vector_id(None, component_type, component_count)
     }
     #[doc = "Appends an OpTypeVector instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_vector_id(
@@ -196,23 +135,7 @@ impl Builder {
     }
     #[doc = "Appends an OpTypeMatrix instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_matrix(&mut self, column_type: spirv::Word, column_count: u32) -> spirv::Word {
-        let mut inst = dr::Instruction::new(
-            spirv::Op::TypeMatrix,
-            None,
-            None,
-            vec![
-                dr::Operand::IdRef(column_type),
-                dr::Operand::LiteralInt32(column_count),
-            ],
-        );
-        if let Some(id) = self.dedup_insert_type(&inst) {
-            id
-        } else {
-            let new_id = self.id();
-            inst.result_id = Some(new_id);
-            self.module.types_global_values.push(inst);
-            new_id
-        }
+        self.type_matrix_id(None, column_type, column_count)
     }
     #[doc = "Appends an OpTypeMatrix instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_matrix_id(
@@ -254,31 +177,17 @@ impl Builder {
         image_format: spirv::ImageFormat,
         access_qualifier: Option<spirv::AccessQualifier>,
     ) -> spirv::Word {
-        let mut inst = dr::Instruction::new(
-            spirv::Op::TypeImage,
+        self.type_image_id(
             None,
-            None,
-            vec![
-                dr::Operand::IdRef(sampled_type),
-                dr::Operand::Dim(dim),
-                dr::Operand::LiteralInt32(depth),
-                dr::Operand::LiteralInt32(arrayed),
-                dr::Operand::LiteralInt32(ms),
-                dr::Operand::LiteralInt32(sampled),
-                dr::Operand::ImageFormat(image_format),
-            ],
-        );
-        if let Some(v) = access_qualifier {
-            inst.operands.push(dr::Operand::AccessQualifier(v));
-        }
-        if let Some(id) = self.dedup_insert_type(&inst) {
-            id
-        } else {
-            let new_id = self.id();
-            inst.result_id = Some(new_id);
-            self.module.types_global_values.push(inst);
-            new_id
-        }
+            sampled_type,
+            dim,
+            depth,
+            arrayed,
+            ms,
+            sampled,
+            image_format,
+            access_qualifier,
+        )
     }
     #[doc = "Appends an OpTypeImage instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_image_id(
@@ -324,15 +233,7 @@ impl Builder {
     }
     #[doc = "Appends an OpTypeSampler instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_sampler(&mut self) -> spirv::Word {
-        let mut inst = dr::Instruction::new(spirv::Op::TypeSampler, None, None, vec![]);
-        if let Some(id) = self.dedup_insert_type(&inst) {
-            id
-        } else {
-            let new_id = self.id();
-            inst.result_id = Some(new_id);
-            self.module.types_global_values.push(inst);
-            new_id
-        }
+        self.type_sampler_id(None)
     }
     #[doc = "Appends an OpTypeSampler instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_sampler_id(&mut self, result_id: Option<spirv::Word>) -> spirv::Word {
@@ -351,20 +252,7 @@ impl Builder {
     }
     #[doc = "Appends an OpTypeSampledImage instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_sampled_image(&mut self, image_type: spirv::Word) -> spirv::Word {
-        let mut inst = dr::Instruction::new(
-            spirv::Op::TypeSampledImage,
-            None,
-            None,
-            vec![dr::Operand::IdRef(image_type)],
-        );
-        if let Some(id) = self.dedup_insert_type(&inst) {
-            id
-        } else {
-            let new_id = self.id();
-            inst.result_id = Some(new_id);
-            self.module.types_global_values.push(inst);
-            new_id
-        }
+        self.type_sampled_image_id(None, image_type)
     }
     #[doc = "Appends an OpTypeSampledImage instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_sampled_image_id(
@@ -392,20 +280,7 @@ impl Builder {
     }
     #[doc = "Appends an OpTypeArray instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_array(&mut self, element_type: spirv::Word, length: spirv::Word) -> spirv::Word {
-        let mut inst = dr::Instruction::new(
-            spirv::Op::TypeArray,
-            None,
-            None,
-            vec![dr::Operand::IdRef(element_type), dr::Operand::IdRef(length)],
-        );
-        if let Some(id) = self.dedup_insert_type(&inst) {
-            id
-        } else {
-            let new_id = self.id();
-            inst.result_id = Some(new_id);
-            self.module.types_global_values.push(inst);
-            new_id
-        }
+        self.type_array_id(None, element_type, length)
     }
     #[doc = "Appends an OpTypeArray instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_array_id(
@@ -434,20 +309,7 @@ impl Builder {
     }
     #[doc = "Appends an OpTypeRuntimeArray instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_runtime_array(&mut self, element_type: spirv::Word) -> spirv::Word {
-        let mut inst = dr::Instruction::new(
-            spirv::Op::TypeRuntimeArray,
-            None,
-            None,
-            vec![dr::Operand::IdRef(element_type)],
-        );
-        if let Some(id) = self.dedup_insert_type(&inst) {
-            id
-        } else {
-            let new_id = self.id();
-            inst.result_id = Some(new_id);
-            self.module.types_global_values.push(inst);
-            new_id
-        }
+        self.type_runtime_array_id(None, element_type)
     }
     #[doc = "Appends an OpTypeRuntimeArray instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_runtime_array_id(
@@ -478,20 +340,7 @@ impl Builder {
         &mut self,
         member_0_type_member_1_type: impl IntoIterator<Item = spirv::Word>,
     ) -> spirv::Word {
-        let mut inst = dr::Instruction::new(spirv::Op::TypeStruct, None, None, vec![]);
-        inst.operands.extend(
-            member_0_type_member_1_type
-                .into_iter()
-                .map(dr::Operand::IdRef),
-        );
-        if let Some(id) = self.dedup_insert_type(&inst) {
-            id
-        } else {
-            let new_id = self.id();
-            inst.result_id = Some(new_id);
-            self.module.types_global_values.push(inst);
-            new_id
-        }
+        self.type_struct_id(None, member_0_type_member_1_type)
     }
     #[doc = "Appends an OpTypeStruct instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_struct_id(
@@ -523,25 +372,7 @@ impl Builder {
         return_type: spirv::Word,
         parameter_0_type_parameter_1_type: impl IntoIterator<Item = spirv::Word>,
     ) -> spirv::Word {
-        let mut inst = dr::Instruction::new(
-            spirv::Op::TypeFunction,
-            None,
-            None,
-            vec![dr::Operand::IdRef(return_type)],
-        );
-        inst.operands.extend(
-            parameter_0_type_parameter_1_type
-                .into_iter()
-                .map(dr::Operand::IdRef),
-        );
-        if let Some(id) = self.dedup_insert_type(&inst) {
-            id
-        } else {
-            let new_id = self.id();
-            inst.result_id = Some(new_id);
-            self.module.types_global_values.push(inst);
-            new_id
-        }
+        self.type_function_id(None, return_type, parameter_0_type_parameter_1_type)
     }
     #[doc = "Appends an OpTypeFunction instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_function_id(
@@ -575,15 +406,7 @@ impl Builder {
     }
     #[doc = "Appends an OpTypeEvent instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_event(&mut self) -> spirv::Word {
-        let mut inst = dr::Instruction::new(spirv::Op::TypeEvent, None, None, vec![]);
-        if let Some(id) = self.dedup_insert_type(&inst) {
-            id
-        } else {
-            let new_id = self.id();
-            inst.result_id = Some(new_id);
-            self.module.types_global_values.push(inst);
-            new_id
-        }
+        self.type_event_id(None)
     }
     #[doc = "Appends an OpTypeEvent instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_event_id(&mut self, result_id: Option<spirv::Word>) -> spirv::Word {
@@ -602,15 +425,7 @@ impl Builder {
     }
     #[doc = "Appends an OpTypeDeviceEvent instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_device_event(&mut self) -> spirv::Word {
-        let mut inst = dr::Instruction::new(spirv::Op::TypeDeviceEvent, None, None, vec![]);
-        if let Some(id) = self.dedup_insert_type(&inst) {
-            id
-        } else {
-            let new_id = self.id();
-            inst.result_id = Some(new_id);
-            self.module.types_global_values.push(inst);
-            new_id
-        }
+        self.type_device_event_id(None)
     }
     #[doc = "Appends an OpTypeDeviceEvent instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_device_event_id(&mut self, result_id: Option<spirv::Word>) -> spirv::Word {
@@ -629,15 +444,7 @@ impl Builder {
     }
     #[doc = "Appends an OpTypeReserveId instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_reserve_id(&mut self) -> spirv::Word {
-        let mut inst = dr::Instruction::new(spirv::Op::TypeReserveId, None, None, vec![]);
-        if let Some(id) = self.dedup_insert_type(&inst) {
-            id
-        } else {
-            let new_id = self.id();
-            inst.result_id = Some(new_id);
-            self.module.types_global_values.push(inst);
-            new_id
-        }
+        self.type_reserve_id_id(None)
     }
     #[doc = "Appends an OpTypeReserveId instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_reserve_id_id(&mut self, result_id: Option<spirv::Word>) -> spirv::Word {
@@ -656,15 +463,7 @@ impl Builder {
     }
     #[doc = "Appends an OpTypeQueue instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_queue(&mut self) -> spirv::Word {
-        let mut inst = dr::Instruction::new(spirv::Op::TypeQueue, None, None, vec![]);
-        if let Some(id) = self.dedup_insert_type(&inst) {
-            id
-        } else {
-            let new_id = self.id();
-            inst.result_id = Some(new_id);
-            self.module.types_global_values.push(inst);
-            new_id
-        }
+        self.type_queue_id(None)
     }
     #[doc = "Appends an OpTypeQueue instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_queue_id(&mut self, result_id: Option<spirv::Word>) -> spirv::Word {
@@ -683,20 +482,7 @@ impl Builder {
     }
     #[doc = "Appends an OpTypePipe instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_pipe(&mut self, qualifier: spirv::AccessQualifier) -> spirv::Word {
-        let mut inst = dr::Instruction::new(
-            spirv::Op::TypePipe,
-            None,
-            None,
-            vec![dr::Operand::AccessQualifier(qualifier)],
-        );
-        if let Some(id) = self.dedup_insert_type(&inst) {
-            id
-        } else {
-            let new_id = self.id();
-            inst.result_id = Some(new_id);
-            self.module.types_global_values.push(inst);
-            new_id
-        }
+        self.type_pipe_id(None, qualifier)
     }
     #[doc = "Appends an OpTypePipe instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_pipe_id(
@@ -724,15 +510,7 @@ impl Builder {
     }
     #[doc = "Appends an OpTypePipeStorage instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_pipe_storage(&mut self) -> spirv::Word {
-        let mut inst = dr::Instruction::new(spirv::Op::TypePipeStorage, None, None, vec![]);
-        if let Some(id) = self.dedup_insert_type(&inst) {
-            id
-        } else {
-            let new_id = self.id();
-            inst.result_id = Some(new_id);
-            self.module.types_global_values.push(inst);
-            new_id
-        }
+        self.type_pipe_storage_id(None)
     }
     #[doc = "Appends an OpTypePipeStorage instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_pipe_storage_id(&mut self, result_id: Option<spirv::Word>) -> spirv::Word {
@@ -751,15 +529,7 @@ impl Builder {
     }
     #[doc = "Appends an OpTypeNamedBarrier instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_named_barrier(&mut self) -> spirv::Word {
-        let mut inst = dr::Instruction::new(spirv::Op::TypeNamedBarrier, None, None, vec![]);
-        if let Some(id) = self.dedup_insert_type(&inst) {
-            id
-        } else {
-            let new_id = self.id();
-            inst.result_id = Some(new_id);
-            self.module.types_global_values.push(inst);
-            new_id
-        }
+        self.type_named_barrier_id(None)
     }
     #[doc = "Appends an OpTypeNamedBarrier instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_named_barrier_id(&mut self, result_id: Option<spirv::Word>) -> spirv::Word {
@@ -778,15 +548,7 @@ impl Builder {
     }
     #[doc = "Appends an OpTypeRayQueryKHR instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_ray_query_khr(&mut self) -> spirv::Word {
-        let mut inst = dr::Instruction::new(spirv::Op::TypeRayQueryKHR, None, None, vec![]);
-        if let Some(id) = self.dedup_insert_type(&inst) {
-            id
-        } else {
-            let new_id = self.id();
-            inst.result_id = Some(new_id);
-            self.module.types_global_values.push(inst);
-            new_id
-        }
+        self.type_ray_query_khr_id(None)
     }
     #[doc = "Appends an OpTypeRayQueryKHR instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_ray_query_khr_id(&mut self, result_id: Option<spirv::Word>) -> spirv::Word {
@@ -805,16 +567,7 @@ impl Builder {
     }
     #[doc = "Appends an OpTypeAccelerationStructureKHR instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_acceleration_structure_khr(&mut self) -> spirv::Word {
-        let mut inst =
-            dr::Instruction::new(spirv::Op::TypeAccelerationStructureKHR, None, None, vec![]);
-        if let Some(id) = self.dedup_insert_type(&inst) {
-            id
-        } else {
-            let new_id = self.id();
-            inst.result_id = Some(new_id);
-            self.module.types_global_values.push(inst);
-            new_id
-        }
+        self.type_acceleration_structure_khr_id(None)
     }
     #[doc = "Appends an OpTypeAccelerationStructureKHR instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_acceleration_structure_khr_id(
@@ -847,25 +600,7 @@ impl Builder {
         rows: spirv::Word,
         columns: spirv::Word,
     ) -> spirv::Word {
-        let mut inst = dr::Instruction::new(
-            spirv::Op::TypeCooperativeMatrixNV,
-            None,
-            None,
-            vec![
-                dr::Operand::IdRef(component_type),
-                dr::Operand::IdScope(execution),
-                dr::Operand::IdRef(rows),
-                dr::Operand::IdRef(columns),
-            ],
-        );
-        if let Some(id) = self.dedup_insert_type(&inst) {
-            id
-        } else {
-            let new_id = self.id();
-            inst.result_id = Some(new_id);
-            self.module.types_global_values.push(inst);
-            new_id
-        }
+        self.type_cooperative_matrix_nv_id(None, component_type, execution, rows, columns)
     }
     #[doc = "Appends an OpTypeCooperativeMatrixNV instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_cooperative_matrix_nv_id(

--- a/rspirv/dr/build/autogen_type.rs
+++ b/rspirv/dr/build/autogen_type.rs
@@ -15,10 +15,40 @@ impl Builder {
             new_id
         }
     }
+    #[doc = "Appends an OpTypeVoid instruction and returns the result id, or return the existing id if the instruction was already present."]
+    pub fn type_void_id(&mut self, result_id: Option<spirv::Word>) -> spirv::Word {
+        let mut inst = dr::Instruction::new(spirv::Op::TypeVoid, None, result_id, vec![]);
+        if let Some(result_id) = result_id {
+            self.module.types_global_values.push(inst);
+            result_id
+        } else if let Some(id) = self.dedup_insert_type(&inst) {
+            id
+        } else {
+            let new_id = self.id();
+            inst.result_id = Some(new_id);
+            self.module.types_global_values.push(inst);
+            new_id
+        }
+    }
     #[doc = "Appends an OpTypeBool instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_bool(&mut self) -> spirv::Word {
         let mut inst = dr::Instruction::new(spirv::Op::TypeBool, None, None, vec![]);
         if let Some(id) = self.dedup_insert_type(&inst) {
+            id
+        } else {
+            let new_id = self.id();
+            inst.result_id = Some(new_id);
+            self.module.types_global_values.push(inst);
+            new_id
+        }
+    }
+    #[doc = "Appends an OpTypeBool instruction and returns the result id, or return the existing id if the instruction was already present."]
+    pub fn type_bool_id(&mut self, result_id: Option<spirv::Word>) -> spirv::Word {
+        let mut inst = dr::Instruction::new(spirv::Op::TypeBool, None, result_id, vec![]);
+        if let Some(result_id) = result_id {
+            self.module.types_global_values.push(inst);
+            result_id
+        } else if let Some(id) = self.dedup_insert_type(&inst) {
             id
         } else {
             let new_id = self.id();
@@ -47,6 +77,34 @@ impl Builder {
             new_id
         }
     }
+    #[doc = "Appends an OpTypeInt instruction and returns the result id, or return the existing id if the instruction was already present."]
+    pub fn type_int_id(
+        &mut self,
+        result_id: Option<spirv::Word>,
+        width: u32,
+        signedness: u32,
+    ) -> spirv::Word {
+        let mut inst = dr::Instruction::new(
+            spirv::Op::TypeInt,
+            None,
+            result_id,
+            vec![
+                dr::Operand::LiteralInt32(width),
+                dr::Operand::LiteralInt32(signedness),
+            ],
+        );
+        if let Some(result_id) = result_id {
+            self.module.types_global_values.push(inst);
+            result_id
+        } else if let Some(id) = self.dedup_insert_type(&inst) {
+            id
+        } else {
+            let new_id = self.id();
+            inst.result_id = Some(new_id);
+            self.module.types_global_values.push(inst);
+            new_id
+        }
+    }
     #[doc = "Appends an OpTypeFloat instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_float(&mut self, width: u32) -> spirv::Word {
         let mut inst = dr::Instruction::new(
@@ -56,6 +114,26 @@ impl Builder {
             vec![dr::Operand::LiteralInt32(width)],
         );
         if let Some(id) = self.dedup_insert_type(&inst) {
+            id
+        } else {
+            let new_id = self.id();
+            inst.result_id = Some(new_id);
+            self.module.types_global_values.push(inst);
+            new_id
+        }
+    }
+    #[doc = "Appends an OpTypeFloat instruction and returns the result id, or return the existing id if the instruction was already present."]
+    pub fn type_float_id(&mut self, result_id: Option<spirv::Word>, width: u32) -> spirv::Word {
+        let mut inst = dr::Instruction::new(
+            spirv::Op::TypeFloat,
+            None,
+            result_id,
+            vec![dr::Operand::LiteralInt32(width)],
+        );
+        if let Some(result_id) = result_id {
+            self.module.types_global_values.push(inst);
+            result_id
+        } else if let Some(id) = self.dedup_insert_type(&inst) {
             id
         } else {
             let new_id = self.id();
@@ -88,6 +166,34 @@ impl Builder {
             new_id
         }
     }
+    #[doc = "Appends an OpTypeVector instruction and returns the result id, or return the existing id if the instruction was already present."]
+    pub fn type_vector_id(
+        &mut self,
+        result_id: Option<spirv::Word>,
+        component_type: spirv::Word,
+        component_count: u32,
+    ) -> spirv::Word {
+        let mut inst = dr::Instruction::new(
+            spirv::Op::TypeVector,
+            None,
+            result_id,
+            vec![
+                dr::Operand::IdRef(component_type),
+                dr::Operand::LiteralInt32(component_count),
+            ],
+        );
+        if let Some(result_id) = result_id {
+            self.module.types_global_values.push(inst);
+            result_id
+        } else if let Some(id) = self.dedup_insert_type(&inst) {
+            id
+        } else {
+            let new_id = self.id();
+            inst.result_id = Some(new_id);
+            self.module.types_global_values.push(inst);
+            new_id
+        }
+    }
     #[doc = "Appends an OpTypeMatrix instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_matrix(&mut self, column_type: spirv::Word, column_count: u32) -> spirv::Word {
         let mut inst = dr::Instruction::new(
@@ -100,6 +206,34 @@ impl Builder {
             ],
         );
         if let Some(id) = self.dedup_insert_type(&inst) {
+            id
+        } else {
+            let new_id = self.id();
+            inst.result_id = Some(new_id);
+            self.module.types_global_values.push(inst);
+            new_id
+        }
+    }
+    #[doc = "Appends an OpTypeMatrix instruction and returns the result id, or return the existing id if the instruction was already present."]
+    pub fn type_matrix_id(
+        &mut self,
+        result_id: Option<spirv::Word>,
+        column_type: spirv::Word,
+        column_count: u32,
+    ) -> spirv::Word {
+        let mut inst = dr::Instruction::new(
+            spirv::Op::TypeMatrix,
+            None,
+            result_id,
+            vec![
+                dr::Operand::IdRef(column_type),
+                dr::Operand::LiteralInt32(column_count),
+            ],
+        );
+        if let Some(result_id) = result_id {
+            self.module.types_global_values.push(inst);
+            result_id
+        } else if let Some(id) = self.dedup_insert_type(&inst) {
             id
         } else {
             let new_id = self.id();
@@ -146,10 +280,67 @@ impl Builder {
             new_id
         }
     }
+    #[doc = "Appends an OpTypeImage instruction and returns the result id, or return the existing id if the instruction was already present."]
+    pub fn type_image_id(
+        &mut self,
+        result_id: Option<spirv::Word>,
+        sampled_type: spirv::Word,
+        dim: spirv::Dim,
+        depth: u32,
+        arrayed: u32,
+        ms: u32,
+        sampled: u32,
+        image_format: spirv::ImageFormat,
+        access_qualifier: Option<spirv::AccessQualifier>,
+    ) -> spirv::Word {
+        let mut inst = dr::Instruction::new(
+            spirv::Op::TypeImage,
+            None,
+            result_id,
+            vec![
+                dr::Operand::IdRef(sampled_type),
+                dr::Operand::Dim(dim),
+                dr::Operand::LiteralInt32(depth),
+                dr::Operand::LiteralInt32(arrayed),
+                dr::Operand::LiteralInt32(ms),
+                dr::Operand::LiteralInt32(sampled),
+                dr::Operand::ImageFormat(image_format),
+            ],
+        );
+        if let Some(v) = access_qualifier {
+            inst.operands.push(dr::Operand::AccessQualifier(v));
+        }
+        if let Some(result_id) = result_id {
+            self.module.types_global_values.push(inst);
+            result_id
+        } else if let Some(id) = self.dedup_insert_type(&inst) {
+            id
+        } else {
+            let new_id = self.id();
+            inst.result_id = Some(new_id);
+            self.module.types_global_values.push(inst);
+            new_id
+        }
+    }
     #[doc = "Appends an OpTypeSampler instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_sampler(&mut self) -> spirv::Word {
         let mut inst = dr::Instruction::new(spirv::Op::TypeSampler, None, None, vec![]);
         if let Some(id) = self.dedup_insert_type(&inst) {
+            id
+        } else {
+            let new_id = self.id();
+            inst.result_id = Some(new_id);
+            self.module.types_global_values.push(inst);
+            new_id
+        }
+    }
+    #[doc = "Appends an OpTypeSampler instruction and returns the result id, or return the existing id if the instruction was already present."]
+    pub fn type_sampler_id(&mut self, result_id: Option<spirv::Word>) -> spirv::Word {
+        let mut inst = dr::Instruction::new(spirv::Op::TypeSampler, None, result_id, vec![]);
+        if let Some(result_id) = result_id {
+            self.module.types_global_values.push(inst);
+            result_id
+        } else if let Some(id) = self.dedup_insert_type(&inst) {
             id
         } else {
             let new_id = self.id();
@@ -175,6 +366,30 @@ impl Builder {
             new_id
         }
     }
+    #[doc = "Appends an OpTypeSampledImage instruction and returns the result id, or return the existing id if the instruction was already present."]
+    pub fn type_sampled_image_id(
+        &mut self,
+        result_id: Option<spirv::Word>,
+        image_type: spirv::Word,
+    ) -> spirv::Word {
+        let mut inst = dr::Instruction::new(
+            spirv::Op::TypeSampledImage,
+            None,
+            result_id,
+            vec![dr::Operand::IdRef(image_type)],
+        );
+        if let Some(result_id) = result_id {
+            self.module.types_global_values.push(inst);
+            result_id
+        } else if let Some(id) = self.dedup_insert_type(&inst) {
+            id
+        } else {
+            let new_id = self.id();
+            inst.result_id = Some(new_id);
+            self.module.types_global_values.push(inst);
+            new_id
+        }
+    }
     #[doc = "Appends an OpTypeArray instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_array(&mut self, element_type: spirv::Word, length: spirv::Word) -> spirv::Word {
         let mut inst = dr::Instruction::new(
@@ -184,6 +399,31 @@ impl Builder {
             vec![dr::Operand::IdRef(element_type), dr::Operand::IdRef(length)],
         );
         if let Some(id) = self.dedup_insert_type(&inst) {
+            id
+        } else {
+            let new_id = self.id();
+            inst.result_id = Some(new_id);
+            self.module.types_global_values.push(inst);
+            new_id
+        }
+    }
+    #[doc = "Appends an OpTypeArray instruction and returns the result id, or return the existing id if the instruction was already present."]
+    pub fn type_array_id(
+        &mut self,
+        result_id: Option<spirv::Word>,
+        element_type: spirv::Word,
+        length: spirv::Word,
+    ) -> spirv::Word {
+        let mut inst = dr::Instruction::new(
+            spirv::Op::TypeArray,
+            None,
+            result_id,
+            vec![dr::Operand::IdRef(element_type), dr::Operand::IdRef(length)],
+        );
+        if let Some(result_id) = result_id {
+            self.module.types_global_values.push(inst);
+            result_id
+        } else if let Some(id) = self.dedup_insert_type(&inst) {
             id
         } else {
             let new_id = self.id();
@@ -209,6 +449,30 @@ impl Builder {
             new_id
         }
     }
+    #[doc = "Appends an OpTypeRuntimeArray instruction and returns the result id, or return the existing id if the instruction was already present."]
+    pub fn type_runtime_array_id(
+        &mut self,
+        result_id: Option<spirv::Word>,
+        element_type: spirv::Word,
+    ) -> spirv::Word {
+        let mut inst = dr::Instruction::new(
+            spirv::Op::TypeRuntimeArray,
+            None,
+            result_id,
+            vec![dr::Operand::IdRef(element_type)],
+        );
+        if let Some(result_id) = result_id {
+            self.module.types_global_values.push(inst);
+            result_id
+        } else if let Some(id) = self.dedup_insert_type(&inst) {
+            id
+        } else {
+            let new_id = self.id();
+            inst.result_id = Some(new_id);
+            self.module.types_global_values.push(inst);
+            new_id
+        }
+    }
     #[doc = "Appends an OpTypeStruct instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_struct(
         &mut self,
@@ -221,6 +485,30 @@ impl Builder {
                 .map(dr::Operand::IdRef),
         );
         if let Some(id) = self.dedup_insert_type(&inst) {
+            id
+        } else {
+            let new_id = self.id();
+            inst.result_id = Some(new_id);
+            self.module.types_global_values.push(inst);
+            new_id
+        }
+    }
+    #[doc = "Appends an OpTypeStruct instruction and returns the result id, or return the existing id if the instruction was already present."]
+    pub fn type_struct_id(
+        &mut self,
+        result_id: Option<spirv::Word>,
+        member_0_type_member_1_type: impl IntoIterator<Item = spirv::Word>,
+    ) -> spirv::Word {
+        let mut inst = dr::Instruction::new(spirv::Op::TypeStruct, None, result_id, vec![]);
+        inst.operands.extend(
+            member_0_type_member_1_type
+                .into_iter()
+                .map(dr::Operand::IdRef),
+        );
+        if let Some(result_id) = result_id {
+            self.module.types_global_values.push(inst);
+            result_id
+        } else if let Some(id) = self.dedup_insert_type(&inst) {
             id
         } else {
             let new_id = self.id();
@@ -255,10 +543,55 @@ impl Builder {
             new_id
         }
     }
+    #[doc = "Appends an OpTypeFunction instruction and returns the result id, or return the existing id if the instruction was already present."]
+    pub fn type_function_id(
+        &mut self,
+        result_id: Option<spirv::Word>,
+        return_type: spirv::Word,
+        parameter_0_type_parameter_1_type: impl IntoIterator<Item = spirv::Word>,
+    ) -> spirv::Word {
+        let mut inst = dr::Instruction::new(
+            spirv::Op::TypeFunction,
+            None,
+            result_id,
+            vec![dr::Operand::IdRef(return_type)],
+        );
+        inst.operands.extend(
+            parameter_0_type_parameter_1_type
+                .into_iter()
+                .map(dr::Operand::IdRef),
+        );
+        if let Some(result_id) = result_id {
+            self.module.types_global_values.push(inst);
+            result_id
+        } else if let Some(id) = self.dedup_insert_type(&inst) {
+            id
+        } else {
+            let new_id = self.id();
+            inst.result_id = Some(new_id);
+            self.module.types_global_values.push(inst);
+            new_id
+        }
+    }
     #[doc = "Appends an OpTypeEvent instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_event(&mut self) -> spirv::Word {
         let mut inst = dr::Instruction::new(spirv::Op::TypeEvent, None, None, vec![]);
         if let Some(id) = self.dedup_insert_type(&inst) {
+            id
+        } else {
+            let new_id = self.id();
+            inst.result_id = Some(new_id);
+            self.module.types_global_values.push(inst);
+            new_id
+        }
+    }
+    #[doc = "Appends an OpTypeEvent instruction and returns the result id, or return the existing id if the instruction was already present."]
+    pub fn type_event_id(&mut self, result_id: Option<spirv::Word>) -> spirv::Word {
+        let mut inst = dr::Instruction::new(spirv::Op::TypeEvent, None, result_id, vec![]);
+        if let Some(result_id) = result_id {
+            self.module.types_global_values.push(inst);
+            result_id
+        } else if let Some(id) = self.dedup_insert_type(&inst) {
             id
         } else {
             let new_id = self.id();
@@ -279,6 +612,21 @@ impl Builder {
             new_id
         }
     }
+    #[doc = "Appends an OpTypeDeviceEvent instruction and returns the result id, or return the existing id if the instruction was already present."]
+    pub fn type_device_event_id(&mut self, result_id: Option<spirv::Word>) -> spirv::Word {
+        let mut inst = dr::Instruction::new(spirv::Op::TypeDeviceEvent, None, result_id, vec![]);
+        if let Some(result_id) = result_id {
+            self.module.types_global_values.push(inst);
+            result_id
+        } else if let Some(id) = self.dedup_insert_type(&inst) {
+            id
+        } else {
+            let new_id = self.id();
+            inst.result_id = Some(new_id);
+            self.module.types_global_values.push(inst);
+            new_id
+        }
+    }
     #[doc = "Appends an OpTypeReserveId instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_reserve_id(&mut self) -> spirv::Word {
         let mut inst = dr::Instruction::new(spirv::Op::TypeReserveId, None, None, vec![]);
@@ -291,10 +639,40 @@ impl Builder {
             new_id
         }
     }
+    #[doc = "Appends an OpTypeReserveId instruction and returns the result id, or return the existing id if the instruction was already present."]
+    pub fn type_reserve_id_id(&mut self, result_id: Option<spirv::Word>) -> spirv::Word {
+        let mut inst = dr::Instruction::new(spirv::Op::TypeReserveId, None, result_id, vec![]);
+        if let Some(result_id) = result_id {
+            self.module.types_global_values.push(inst);
+            result_id
+        } else if let Some(id) = self.dedup_insert_type(&inst) {
+            id
+        } else {
+            let new_id = self.id();
+            inst.result_id = Some(new_id);
+            self.module.types_global_values.push(inst);
+            new_id
+        }
+    }
     #[doc = "Appends an OpTypeQueue instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_queue(&mut self) -> spirv::Word {
         let mut inst = dr::Instruction::new(spirv::Op::TypeQueue, None, None, vec![]);
         if let Some(id) = self.dedup_insert_type(&inst) {
+            id
+        } else {
+            let new_id = self.id();
+            inst.result_id = Some(new_id);
+            self.module.types_global_values.push(inst);
+            new_id
+        }
+    }
+    #[doc = "Appends an OpTypeQueue instruction and returns the result id, or return the existing id if the instruction was already present."]
+    pub fn type_queue_id(&mut self, result_id: Option<spirv::Word>) -> spirv::Word {
+        let mut inst = dr::Instruction::new(spirv::Op::TypeQueue, None, result_id, vec![]);
+        if let Some(result_id) = result_id {
+            self.module.types_global_values.push(inst);
+            result_id
+        } else if let Some(id) = self.dedup_insert_type(&inst) {
             id
         } else {
             let new_id = self.id();
@@ -320,10 +698,49 @@ impl Builder {
             new_id
         }
     }
+    #[doc = "Appends an OpTypePipe instruction and returns the result id, or return the existing id if the instruction was already present."]
+    pub fn type_pipe_id(
+        &mut self,
+        result_id: Option<spirv::Word>,
+        qualifier: spirv::AccessQualifier,
+    ) -> spirv::Word {
+        let mut inst = dr::Instruction::new(
+            spirv::Op::TypePipe,
+            None,
+            result_id,
+            vec![dr::Operand::AccessQualifier(qualifier)],
+        );
+        if let Some(result_id) = result_id {
+            self.module.types_global_values.push(inst);
+            result_id
+        } else if let Some(id) = self.dedup_insert_type(&inst) {
+            id
+        } else {
+            let new_id = self.id();
+            inst.result_id = Some(new_id);
+            self.module.types_global_values.push(inst);
+            new_id
+        }
+    }
     #[doc = "Appends an OpTypePipeStorage instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_pipe_storage(&mut self) -> spirv::Word {
         let mut inst = dr::Instruction::new(spirv::Op::TypePipeStorage, None, None, vec![]);
         if let Some(id) = self.dedup_insert_type(&inst) {
+            id
+        } else {
+            let new_id = self.id();
+            inst.result_id = Some(new_id);
+            self.module.types_global_values.push(inst);
+            new_id
+        }
+    }
+    #[doc = "Appends an OpTypePipeStorage instruction and returns the result id, or return the existing id if the instruction was already present."]
+    pub fn type_pipe_storage_id(&mut self, result_id: Option<spirv::Word>) -> spirv::Word {
+        let mut inst = dr::Instruction::new(spirv::Op::TypePipeStorage, None, result_id, vec![]);
+        if let Some(result_id) = result_id {
+            self.module.types_global_values.push(inst);
+            result_id
+        } else if let Some(id) = self.dedup_insert_type(&inst) {
             id
         } else {
             let new_id = self.id();
@@ -344,10 +761,40 @@ impl Builder {
             new_id
         }
     }
+    #[doc = "Appends an OpTypeNamedBarrier instruction and returns the result id, or return the existing id if the instruction was already present."]
+    pub fn type_named_barrier_id(&mut self, result_id: Option<spirv::Word>) -> spirv::Word {
+        let mut inst = dr::Instruction::new(spirv::Op::TypeNamedBarrier, None, result_id, vec![]);
+        if let Some(result_id) = result_id {
+            self.module.types_global_values.push(inst);
+            result_id
+        } else if let Some(id) = self.dedup_insert_type(&inst) {
+            id
+        } else {
+            let new_id = self.id();
+            inst.result_id = Some(new_id);
+            self.module.types_global_values.push(inst);
+            new_id
+        }
+    }
     #[doc = "Appends an OpTypeRayQueryKHR instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_ray_query_khr(&mut self) -> spirv::Word {
         let mut inst = dr::Instruction::new(spirv::Op::TypeRayQueryKHR, None, None, vec![]);
         if let Some(id) = self.dedup_insert_type(&inst) {
+            id
+        } else {
+            let new_id = self.id();
+            inst.result_id = Some(new_id);
+            self.module.types_global_values.push(inst);
+            new_id
+        }
+    }
+    #[doc = "Appends an OpTypeRayQueryKHR instruction and returns the result id, or return the existing id if the instruction was already present."]
+    pub fn type_ray_query_khr_id(&mut self, result_id: Option<spirv::Word>) -> spirv::Word {
+        let mut inst = dr::Instruction::new(spirv::Op::TypeRayQueryKHR, None, result_id, vec![]);
+        if let Some(result_id) = result_id {
+            self.module.types_global_values.push(inst);
+            result_id
+        } else if let Some(id) = self.dedup_insert_type(&inst) {
             id
         } else {
             let new_id = self.id();
@@ -361,6 +808,29 @@ impl Builder {
         let mut inst =
             dr::Instruction::new(spirv::Op::TypeAccelerationStructureKHR, None, None, vec![]);
         if let Some(id) = self.dedup_insert_type(&inst) {
+            id
+        } else {
+            let new_id = self.id();
+            inst.result_id = Some(new_id);
+            self.module.types_global_values.push(inst);
+            new_id
+        }
+    }
+    #[doc = "Appends an OpTypeAccelerationStructureKHR instruction and returns the result id, or return the existing id if the instruction was already present."]
+    pub fn type_acceleration_structure_khr_id(
+        &mut self,
+        result_id: Option<spirv::Word>,
+    ) -> spirv::Word {
+        let mut inst = dr::Instruction::new(
+            spirv::Op::TypeAccelerationStructureKHR,
+            None,
+            result_id,
+            vec![],
+        );
+        if let Some(result_id) = result_id {
+            self.module.types_global_values.push(inst);
+            result_id
+        } else if let Some(id) = self.dedup_insert_type(&inst) {
             id
         } else {
             let new_id = self.id();
@@ -389,6 +859,38 @@ impl Builder {
             ],
         );
         if let Some(id) = self.dedup_insert_type(&inst) {
+            id
+        } else {
+            let new_id = self.id();
+            inst.result_id = Some(new_id);
+            self.module.types_global_values.push(inst);
+            new_id
+        }
+    }
+    #[doc = "Appends an OpTypeCooperativeMatrixNV instruction and returns the result id, or return the existing id if the instruction was already present."]
+    pub fn type_cooperative_matrix_nv_id(
+        &mut self,
+        result_id: Option<spirv::Word>,
+        component_type: spirv::Word,
+        execution: spirv::Word,
+        rows: spirv::Word,
+        columns: spirv::Word,
+    ) -> spirv::Word {
+        let mut inst = dr::Instruction::new(
+            spirv::Op::TypeCooperativeMatrixNV,
+            None,
+            result_id,
+            vec![
+                dr::Operand::IdRef(component_type),
+                dr::Operand::IdScope(execution),
+                dr::Operand::IdRef(rows),
+                dr::Operand::IdRef(columns),
+            ],
+        );
+        if let Some(result_id) = result_id {
+            self.module.types_global_values.push(inst);
+            result_id
+        } else if let Some(id) = self.dedup_insert_type(&inst) {
             id
         } else {
             let new_id = self.id();

--- a/rspirv/dr/build/mod.rs
+++ b/rspirv/dr/build/mod.rs
@@ -735,37 +735,6 @@ impl Builder {
         id
     }
 
-    /// Appends an OpTypeStruct instruction and returns the result id, or return the existing id if the instruction was already present.
-    pub fn type_struct_id(
-        &mut self,
-        result_id: Option<spirv::Word>,
-        member_0_type_member_1_type: impl IntoIterator<Item = spirv::Word>,
-    ) -> spirv::Word {
-        let mut inst = dr::Instruction::new(
-            spirv::Op::TypeStruct,
-            None,
-            result_id,
-            member_0_type_member_1_type
-                .into_iter()
-                .map(dr::Operand::IdRef)
-                .collect(),
-        );
-        if let Some(result_id) = result_id {
-            // An explicit ID was provided, emit it no matter what.
-            self.module.types_global_values.push(inst);
-            result_id
-        } else if let Some(id) = self.dedup_insert_type(&inst) {
-            // No ID was provided, and the type has already been declared.
-            id
-        } else {
-            // No ID was provided, it didn't already exist, so generate a new ID and emit it.
-            let new_id = self.id();
-            inst.result_id = Some(new_id);
-            self.module.types_global_values.push(inst);
-            new_id
-        }
-    }
-
     /// Appends an OpConstant instruction with the given 32-bit float `value`.
     /// or the module if no block is under construction.
     pub fn constant_f32(&mut self, result_type: spirv::Word, value: f32) -> spirv::Word {


### PR DESCRIPTION
`type_struct_id` already existed, and these methods do the same thing as that, but for everything else too. This is useful when the user of rspirv does not want to invoke the (`O(n^2)`) `dedup_insert_type` method - they can pass in `Some(builder.id())` themselves and that case will be skipped.