### PR TITLE
Iterator -> IntoIterator

### DIFF
--- a/rspirv/dr/build/mod.rs
+++ b/rspirv/dr/build/mod.rs
@@ -587,7 +587,7 @@ impl Builder {
         result_id: Option<spirv::Word>,
         extension_set: spirv::Word,
         instruction: spirv::Word,
-        operands: impl Iterator<Item = dr::Operand>,
+        operands: impl IntoIterator<Item = dr::Operand>,
     ) -> BuildResult<spirv::Word> {
         let mut ops = vec![
             dr::Operand::IdRef(extension_set),


### PR DESCRIPTION
Looks like taking Iterator instead of IntoIterator was a typo.
IntoIterator allows to directly use an array of operands as argument. 
And it is the trait used by extend (currently going through impl IntoIterator for Iterator).