### PR TITLE
ci: Drop --all-targets from `test` to include doctest

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,4 +54,4 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --workspace --all-targets --verbose
+          args: --workspace --verbose


### PR DESCRIPTION
https://doc.rust-lang.org/cargo/commands/cargo-test.html: Surprisingly enough `--all-targets` includes less targets than when calling `cargo test` without any target selection, except benches.  We don't have any, and prefer inline docs to be tested either way.
