### PR TITLE
Use new {{version_without_metadata}} tag in release.toml

### DIFF
--- a/spirv/release.toml
+++ b/spirv/release.toml
@@ -6,8 +6,8 @@ sign-commit = true
 sign-tag = true
 
 pre-release-replacements = [
-  {file="README.md", search="spirv = .*", replace="{{crate_name}} = \"{{version}}\""},
-  {file="../rspirv/Cargo.toml", search="spirv = \\{ version = \".*\", path = \"../spirv\" \\}", replace="{{crate_name}} = { version = \"{{version}}\", path = \"../spirv\" }" },
+  {file="README.md", search="spirv = .*", replace="{{crate_name}} = \"{{version_without_metadata}}\""},
+  {file="../rspirv/Cargo.toml", search="spirv = \\{ version = \".*\", path = \"../spirv\" \\}", replace="{{crate_name}} = { version = \"{{version_without_metadata}}\", path = \"../spirv\" }" },
 ]
 
 


### PR DESCRIPTION
Waiting on https://github.com/crate-ci/cargo-release/issues/312

This removes a small manual step that was needed when publishing releases to clean up the version metadata after `cargo release` was run on the `spirv` crate. This is needed because Cargo.toml dependencies can't have metadata in the version field.