### PR TITLE
binary: Only parse parameters for overlapping operands once

### DIFF
--- a/autogen/src/binary.rs
+++ b/autogen/src/binary.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use crate::structs;
 use crate::utils::*;
 
@@ -130,8 +132,9 @@ fn gen_operand_param_parse_methods(grammar: &[structs::OperandKind]) -> Vec<(&st
         !element.enumerants.is_empty()
     }).filter_map(|element| {
         // Get the symbol and all the parameters for each enumerant.
-        let pairs: Vec<(&str, Vec<&str>)> =
-            element.enumerants.iter().filter_map(|e| {
+        let pairs: Vec<(&str, Vec<&str>)> = element.enumerants.iter()
+            .scan(HashSet::new(), |seen_values, e| Some(if seen_values.insert(e.value) { Some(e) } else { None })).flatten()
+            .filter_map(|e| {
                 let params: Vec<&str> = e.parameters.iter().map(
                     |p| { p.kind.as_str() }
                 ).collect();

--- a/rspirv/binary/autogen_parse_operand.rs
+++ b/rspirv/binary/autogen_parse_operand.rs
@@ -169,13 +169,7 @@ impl<'c, 'd> Parser<'c, 'd> {
         if image_operands.contains(spirv::ImageOperands::MAKE_TEXEL_AVAILABLE) {
             params.append(&mut vec![dr::Operand::IdScope(self.decoder.id()?)]);
         }
-        if image_operands.contains(spirv::ImageOperands::MAKE_TEXEL_AVAILABLE_KHR) {
-            params.append(&mut vec![dr::Operand::IdScope(self.decoder.id()?)]);
-        }
         if image_operands.contains(spirv::ImageOperands::MAKE_TEXEL_VISIBLE) {
-            params.append(&mut vec![dr::Operand::IdScope(self.decoder.id()?)]);
-        }
-        if image_operands.contains(spirv::ImageOperands::MAKE_TEXEL_VISIBLE_KHR) {
             params.append(&mut vec![dr::Operand::IdScope(self.decoder.id()?)]);
         }
         Ok(params)
@@ -237,13 +231,7 @@ impl<'c, 'd> Parser<'c, 'd> {
         if memory_access.contains(spirv::MemoryAccess::MAKE_POINTER_AVAILABLE) {
             params.append(&mut vec![dr::Operand::IdScope(self.decoder.id()?)]);
         }
-        if memory_access.contains(spirv::MemoryAccess::MAKE_POINTER_AVAILABLE_KHR) {
-            params.append(&mut vec![dr::Operand::IdScope(self.decoder.id()?)]);
-        }
         if memory_access.contains(spirv::MemoryAccess::MAKE_POINTER_VISIBLE) {
-            params.append(&mut vec![dr::Operand::IdScope(self.decoder.id()?)]);
-        }
-        if memory_access.contains(spirv::MemoryAccess::MAKE_POINTER_VISIBLE_KHR) {
             params.append(&mut vec![dr::Operand::IdScope(self.decoder.id()?)]);
         }
         Ok(params)
@@ -372,13 +360,7 @@ impl<'c, 'd> Parser<'c, 'd> {
                 vec![dr::Operand::LiteralInt32(self.decoder.int32()?)]
             }
             spirv::Decoration::CounterBuffer => vec![dr::Operand::IdRef(self.decoder.id()?)],
-            spirv::Decoration::HlslCounterBufferGOOGLE => {
-                vec![dr::Operand::IdRef(self.decoder.id()?)]
-            }
             spirv::Decoration::UserSemantic => {
-                vec![dr::Operand::LiteralString(self.decoder.string()?)]
-            }
-            spirv::Decoration::HlslSemanticGOOGLE => {
                 vec![dr::Operand::LiteralString(self.decoder.string()?)]
             }
             spirv::Decoration::UserTypeGOOGLE => {


### PR DESCRIPTION
If an operand has two distinct variants with the same value a SPIR-V
word would be consumed and decoded into an operand more than once,
breaking the remaining parsing code.  This happens for example with
MAKE_POINTER_AVAILABLE and MAKE_POINTER_AVAILABLE_KHR which have the
same value and would call the parameter parsing code twice.
