### PR TITLE
Switch to rustc-hash

### DIFF
--- a/rspirv/Cargo.toml
+++ b/rspirv/Cargo.toml
@@ -19,7 +19,7 @@ travis-ci = { repository = "gfx-rs/rspirv" }
 
 [dependencies]
 clippy = { version = "0.0", optional = true }
-fxhash = "0.2"
+rustc-hash = "1.1.0"
 spirv = { version = "0.2.0", path = "../spirv" }
 
 [dev-dependencies]

--- a/rspirv/lift/storage.rs
+++ b/rspirv/lift/storage.rs
@@ -6,7 +6,7 @@ use std::{
     hash::BuildHasherDefault,
 };
 
-use fxhash::FxHasher;
+use rustc_hash::FxHasher;
 
 /// A wrapper around `Storage` that tracks associated SPIR-V <id>
 /// with the elements, allowing the lookup of `Token<T>` by <id>.


### PR DESCRIPTION
The last fxhash version is 4 years old while the last rustc-hash version is 2 years old. Rustc-hash is an official rust project unlike fxhash. Rustc-hash doesn't have any dependencies, while fxhash has a dependency on byteorder. Finally rustc-hash takes ~0.7s to compile while fxhash including it's byteorder dependency takes ~1.0s to compile.