### PR TITLE
Fix all clippy lints for Rust 1.56.1

### DIFF
--- a/autogen/src/sr.rs
+++ b/autogen/src/sr.rs
@@ -354,7 +354,7 @@ pub fn gen_sr_code_from_instruction_grammar(
             if operand.kind.starts_with("IdResult") {
                 continue;
             }
-            let tokens = OperandTokens::new(&inst.operands, index, Some(&inst));
+            let tokens = OperandTokens::new(&inst.operands, index, Some(inst));
             field_names.push(tokens.name);
             field_types.push(tokens.quantified_type);
             field_lifts.push(tokens.lift_expression);

--- a/rspirv/binary/decoder.rs
+++ b/rspirv/binary/decoder.rs
@@ -47,18 +47,16 @@ const WORD_NUM_BYTES: usize = 4;
 /// use rspirv::binary::{Decoder, DecodeError};
 /// use spirv::SourceLanguage;
 ///
-/// fn main() {
-///     let v = vec![0x12, 0x34, 0x56, 0x78,
-///                  0x90, 0xab, 0xcd, 0xef,
-///                  0x02, 0x00, 0x00, 0x00];
-///     let mut d = Decoder::new(&v);
+/// let v = vec![0x12, 0x34, 0x56, 0x78,
+///              0x90, 0xab, 0xcd, 0xef,
+///              0x02, 0x00, 0x00, 0x00];
+/// let mut d = Decoder::new(&v);
 ///
-///     assert_eq!(Ok(0x78563412), d.word());
-///     assert_eq!(Ok(0xefcdab90), d.word());
-///     assert_eq!(Ok(SourceLanguage::GLSL), d.source_language());
+/// assert_eq!(Ok(0x78563412), d.word());
+/// assert_eq!(Ok(0xefcdab90), d.word());
+/// assert_eq!(Ok(SourceLanguage::GLSL), d.source_language());
 ///
-///     assert_eq!(Err(DecodeError::StreamExpected(12)), d.word());
-/// }
+/// assert_eq!(Err(DecodeError::StreamExpected(12)), d.word());
 /// ```
 pub struct Decoder<'a> {
     /// Raw bytes to decode
@@ -358,10 +356,7 @@ mod tests {
 
     #[test]
     fn test_limit() {
-        let mut v = vec![];
-        for _ in 0..12 {
-            v.push(0xff);
-        }
+        let v = vec![0xff; 12];
         let mut d = Decoder::new(&v);
 
         assert!(!d.has_limit());

--- a/rspirv/binary/parser.rs
+++ b/rspirv/binary/parser.rs
@@ -184,32 +184,30 @@ pub fn parse_words(binary: impl AsRef<[u32]>, consumer: &mut dyn Consumer) -> Re
 /// use rspirv::binary::Parser;
 /// use rspirv::dr::{Loader, Operand};
 ///
-/// fn main() {
-///     let bin = vec![
-///         // Magic number.           Version number: 1.0.
-///         0x03, 0x02, 0x23, 0x07,    0x00, 0x00, 0x01, 0x00,
-///         // Generator number: 0.    Bound: 0.
-///         0x00, 0x00, 0x00, 0x00,    0x00, 0x00, 0x00, 0x00,
-///         // Reserved word: 0.
-///         0x00, 0x00, 0x00, 0x00,
-///         // OpMemoryModel.          Logical.
-///         0x0e, 0x00, 0x03, 0x00,    0x00, 0x00, 0x00, 0x00,
-///         // GLSL450.
-///         0x01, 0x00, 0x00, 0x00];
-///     let mut loader = Loader::new();  // You can use your own consumer here.
-///     {
-///         let p = Parser::new(&bin, &mut loader);
-///         p.parse().unwrap();
-///     }
-///     let module = loader.module();
-///
-///     assert_eq!((1, 0), module.header.unwrap().version());
-///     let m = module.memory_model.as_ref().unwrap();
-///     assert_eq!(Operand::AddressingModel(AddressingModel::Logical),
-///                m.operands[0]);
-///     assert_eq!(Operand::MemoryModel(MemoryModel::GLSL450),
-///                m.operands[1]);
+/// let bin = vec![
+///     // Magic number.           Version number: 1.0.
+///     0x03, 0x02, 0x23, 0x07,    0x00, 0x00, 0x01, 0x00,
+///     // Generator number: 0.    Bound: 0.
+///     0x00, 0x00, 0x00, 0x00,    0x00, 0x00, 0x00, 0x00,
+///     // Reserved word: 0.
+///     0x00, 0x00, 0x00, 0x00,
+///     // OpMemoryModel.          Logical.
+///     0x0e, 0x00, 0x03, 0x00,    0x00, 0x00, 0x00, 0x00,
+///     // GLSL450.
+///     0x01, 0x00, 0x00, 0x00];
+/// let mut loader = Loader::new();  // You can use your own consumer here.
+/// {
+///     let p = Parser::new(&bin, &mut loader);
+///     p.parse().unwrap();
 /// }
+/// let module = loader.module();
+///
+/// assert_eq!((1, 0), module.header.unwrap().version());
+/// let m = module.memory_model.as_ref().unwrap();
+/// assert_eq!(Operand::AddressingModel(AddressingModel::Logical),
+///            m.operands[0]);
+/// assert_eq!(Operand::MemoryModel(MemoryModel::GLSL450),
+///            m.operands[1]);
 /// ```
 pub struct Parser<'c, 'd> {
     decoder: decoder::Decoder<'d>,

--- a/rspirv/dr/build/mod.rs
+++ b/rspirv/dr/build/mod.rs
@@ -53,35 +53,33 @@ type BuildResult<T> = result::Result<T, Error>;
 /// ```
 /// use rspirv::binary::Disassemble;
 ///
-/// fn main() {
-///     let mut b = rspirv::dr::Builder::new();
-///     b.set_version(1, 0);
-///     b.memory_model(spirv::AddressingModel::Logical, spirv::MemoryModel::Simple);
-///     let void = b.type_void();
-///     let voidf = b.type_function(void, vec![void]);
-///     b.begin_function(void,
-///                      None,
-///                      (spirv::FunctionControl::DONT_INLINE |
-///                       spirv::FunctionControl::CONST),
-///                      voidf)
-///      .unwrap();
-///     b.begin_block(None).unwrap();
-///     b.ret().unwrap();
-///     b.end_function().unwrap();
+/// let mut b = rspirv::dr::Builder::new();
+/// b.set_version(1, 0);
+/// b.memory_model(spirv::AddressingModel::Logical, spirv::MemoryModel::Simple);
+/// let void = b.type_void();
+/// let voidf = b.type_function(void, vec![void]);
+/// b.begin_function(void,
+///                  None,
+///                  (spirv::FunctionControl::DONT_INLINE |
+///                   spirv::FunctionControl::CONST),
+///                  voidf)
+///  .unwrap();
+/// b.begin_block(None).unwrap();
+/// b.ret().unwrap();
+/// b.end_function().unwrap();
 ///
-///     assert_eq!(b.module().disassemble(),
-///                "; SPIR-V\n\
-///                 ; Version: 1.0\n\
-///                 ; Generator: rspirv\n\
-///                 ; Bound: 5\n\
-///                 OpMemoryModel Logical Simple\n\
-///                 %1 = OpTypeVoid\n\
-///                 %2 = OpTypeFunction %1 %1\n\
-///                 %3 = OpFunction  %1  DontInline|Const %2\n\
-///                 %4 = OpLabel\n\
-///                 OpReturn\n\
-///                 OpFunctionEnd");
-/// }
+/// assert_eq!(b.module().disassemble(),
+///            "; SPIR-V\n\
+///             ; Version: 1.0\n\
+///             ; Generator: rspirv\n\
+///             ; Bound: 5\n\
+///             OpMemoryModel Logical Simple\n\
+///             %1 = OpTypeVoid\n\
+///             %2 = OpTypeFunction %1 %1\n\
+///             %3 = OpFunction  %1  DontInline|Const %2\n\
+///             %4 = OpLabel\n\
+///             OpReturn\n\
+///             OpFunctionEnd");
 /// ```
 #[derive(Default)]
 pub struct Builder {
@@ -238,7 +236,7 @@ impl Builder {
     /// the SPIR-V rule that non-aggregate types can't be duplicates.
     pub fn dedup_insert_type(&mut self, inst: &dr::Instruction) -> Option<spirv::Word> {
         for ty in &self.module.types_global_values {
-            if ty.is_type_identical(&inst) {
+            if ty.is_type_identical(inst) {
                 if let Some(id) = ty.result_id {
                     return Some(id);
                 }
@@ -1024,7 +1022,7 @@ mod tests {
         let mut b = Builder::new();
         let float = b.type_float(32);
         // Normal numbers
-        b.constant_f32(float, 3.14);
+        b.constant_f32(float, f32::consts::PI);
         b.constant_f32(float, 2e-10);
         // Zero
         b.constant_f32(float, 0.);
@@ -1041,7 +1039,7 @@ mod tests {
         assert_eq!(spirv::Op::Constant, inst.class.opcode);
         assert_eq!(Some(1), inst.result_type);
         assert_eq!(Some(2), inst.result_id);
-        assert_eq!(dr::Operand::from(3.14f32), inst.operands[0]);
+        assert_eq!(dr::Operand::from(f32::consts::PI), inst.operands[0]);
 
         let inst = &m.types_global_values[2];
         assert_eq!(spirv::Op::Constant, inst.class.opcode);
@@ -1074,7 +1072,7 @@ mod tests {
         // NaN != NaN
         match inst.operands[0] {
             dr::Operand::LiteralFloat32(f) => assert!(f.is_nan()),
-            _ => assert!(false),
+            _ => panic!(),
         }
     }
 
@@ -1126,7 +1124,7 @@ mod tests {
         // NaN != NaN
         match inst.operands[0] {
             dr::Operand::LiteralFloat32(f) => assert!(f.is_nan()),
-            _ => assert!(false),
+            _ => panic!(),
         }
     }
 

--- a/rspirv/dr/constructs.rs
+++ b/rspirv/dr/constructs.rs
@@ -346,8 +346,8 @@ mod tests {
             dr::Operand::from(128934u64)
         );
         assert_eq!(
-            dr::Operand::LiteralFloat32(3.14f32),
-            dr::Operand::from(3.14f32)
+            dr::Operand::LiteralFloat32(std::f32::consts::PI),
+            dr::Operand::from(std::f32::consts::PI)
         );
         assert_eq!(
             dr::Operand::LiteralFloat64(10.4235f64),

--- a/rspirv/lib.rs
+++ b/rspirv/lib.rs
@@ -32,47 +32,45 @@
 //! use rspirv::binary::Assemble;
 //! use rspirv::binary::Disassemble;
 //!
-//! fn main() {
-//!     // Building
-//!     let mut b = rspirv::dr::Builder::new();
-//!     b.memory_model(spirv::AddressingModel::Logical, spirv::MemoryModel::GLSL450);
-//!     let void = b.type_void();
-//!     let voidf = b.type_function(void, vec![void]);
-//!     b.begin_function(void,
-//!                      None,
-//!                      (spirv::FunctionControl::DONT_INLINE |
-//!                       spirv::FunctionControl::CONST),
-//!                      voidf)
-//!      .unwrap();
-//!     b.begin_block(None).unwrap();
-//!     b.ret().unwrap();
-//!     b.end_function().unwrap();
-//!     let module = b.module();
+//! // Building
+//! let mut b = rspirv::dr::Builder::new();
+//! b.memory_model(spirv::AddressingModel::Logical, spirv::MemoryModel::GLSL450);
+//! let void = b.type_void();
+//! let voidf = b.type_function(void, vec![void]);
+//! b.begin_function(void,
+//!                  None,
+//!                  (spirv::FunctionControl::DONT_INLINE |
+//!                   spirv::FunctionControl::CONST),
+//!                  voidf)
+//!  .unwrap();
+//! b.begin_block(None).unwrap();
+//! b.ret().unwrap();
+//! b.end_function().unwrap();
+//! let module = b.module();
 //!
-//!     // Assembling
-//!     let code = module.assemble();
-//!     assert!(code.len() > 20);  // Module header contains 5 words
-//!     assert_eq!(spirv::MAGIC_NUMBER, code[0]);
+//! // Assembling
+//! let code = module.assemble();
+//! assert!(code.len() > 20);  // Module header contains 5 words
+//! assert_eq!(spirv::MAGIC_NUMBER, code[0]);
 //!
-//!     // Parsing
-//!     let mut loader = rspirv::dr::Loader::new();
-//!     rspirv::binary::parse_words(&code, &mut loader).unwrap();
-//!     let module = loader.module();
+//! // Parsing
+//! let mut loader = rspirv::dr::Loader::new();
+//! rspirv::binary::parse_words(&code, &mut loader).unwrap();
+//! let module = loader.module();
 //!
-//!     // Disassembling
-//!     assert_eq!(module.disassemble(),
-//!                "; SPIR-V\n\
-//!                 ; Version: 1.5\n\
-//!                 ; Generator: rspirv\n\
-//!                 ; Bound: 5\n\
-//!                 OpMemoryModel Logical GLSL450\n\
-//!                 %1 = OpTypeVoid\n\
-//!                 %2 = OpTypeFunction %1 %1\n\
-//!                 %3 = OpFunction  %1  DontInline|Const %2\n\
-//!                 %4 = OpLabel\n\
-//!                 OpReturn\n\
-//!                 OpFunctionEnd");
-//! }
+//! // Disassembling
+//! assert_eq!(module.disassemble(),
+//!            "; SPIR-V\n\
+//!             ; Version: 1.5\n\
+//!             ; Generator: rspirv\n\
+//!             ; Bound: 5\n\
+//!             OpMemoryModel Logical GLSL450\n\
+//!             %1 = OpTypeVoid\n\
+//!             %2 = OpTypeFunction %1 %1\n\
+//!             %3 = OpFunction  %1  DontInline|Const %2\n\
+//!             %4 = OpLabel\n\
+//!             OpReturn\n\
+//!             OpFunctionEnd");
 //! ```
 
 pub use spirv;

--- a/rspirv/sr/storage.rs
+++ b/rspirv/sr/storage.rs
@@ -99,6 +99,7 @@ impl<T> std::ops::Index<Token<T>> for Storage<T> {
 }
 
 #[cfg(test)]
+#[allow(clippy::float_cmp)]
 mod tests {
     use super::*;
 


### PR DESCRIPTION
These slipped in over time.  Fix them once now, while enabling clippy in the CI separately to make sure they don't end up in the codebase over time either.
