### PR TITLE
Add `Sync` trait bound to make compatible with anyhow

### DIFF
--- a/rspirv/Cargo.toml
+++ b/rspirv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rspirv"
-version = "0.11.0+sdk-1.2.198"
+version = "0.11.1+sdk-1.2.198"
 authors = ["Lei Zhang <antiagainst@gmail.com>"]
 edition = "2018"
 

--- a/rspirv/Cargo.toml
+++ b/rspirv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rspirv"
-version = "0.11.1+sdk-1.2.198"
+version = "0.11.0+sdk-1.2.198"
 authors = ["Lei Zhang <antiagainst@gmail.com>"]
 edition = "2018"
 

--- a/rspirv/binary/parser.rs
+++ b/rspirv/binary/parser.rs
@@ -30,7 +30,7 @@ pub enum State {
     /// Consumer requested to stop parse
     ConsumerStopRequested,
     /// Consumer errored out with the given error
-    ConsumerError(Box<dyn error::Error + Send>),
+    ConsumerError(Box<dyn error::Error + Send + Sync>),
     /// Incomplete module header
     HeaderIncomplete(DecodeError),
     /// Incorrect module header
@@ -117,7 +117,7 @@ pub enum Action {
     /// Normally stop the parsing
     Stop,
     /// Error out with the given error
-    Error(Box<dyn error::Error + Send>),
+    Error(Box<dyn error::Error + Send + Sync>),
 }
 
 impl Action {


### PR DESCRIPTION
Hey, I had a problem with `rspirv-reflect`, where I couldn't use `anyhow::Result` in the following example:

```Rust
use std::fs::File;
use std::io::Read;
use anyhow::Result;
use rspirv_reflect::Reflection;

fn main() -> Result<()> {
    let mut file = File::open("test.vert.spv")?;

    let mut buffer = Vec::new();
    file.read_to_end(&mut buffer)?;

    let reflection = Reflection::new_from_spirv(&buffer)?;
    let descriptor_sets = reflection.get_descriptor_sets()?;

    println!("{:#?}", descriptor_sets);

    Ok(())
}
```

The reason this does not work is because `rspirv::binary::ParseState` does not implement `Sync`. So I changed from `Box<dyn error::Error + Send` to `Box<dyn error::Error + Send + Sync`, and and it keeps compiling so I think that's ok.

