### PR TITLE
Fix latest clippy lints

### DIFF
--- a/rspirv/binary/assemble.rs
+++ b/rspirv/binary/assemble.rs
@@ -17,7 +17,7 @@ pub trait Assemble {
 
 impl Assemble for dr::ModuleHeader {
     fn assemble_into(&self, result: &mut Vec<u32>) {
-        result.extend(&[
+        result.extend([
             self.magic_number,
             self.version,
             self.generator,
@@ -74,10 +74,10 @@ impl Assemble for dr::Operand {
             | Self::IdRef(v)
             | Self::LiteralInt32(v)
             | Self::LiteralExtInstInteger(v) => result.push(v),
-            Self::LiteralInt64(v) => result.extend(&[v as u32, (v >> 32) as u32]),
+            Self::LiteralInt64(v) => result.extend([v as u32, (v >> 32) as u32]),
             Self::LiteralFloat32(v) => result.push(v.to_bits()),
             Self::LiteralFloat64(v) => {
-                result.extend(&[v.to_bits() as u32, (v.to_bits() >> 32) as u32])
+                result.extend([v.to_bits() as u32, (v.to_bits() >> 32) as u32])
             }
             Self::LiteralSpecConstantOpInteger(v) => result.push(v as u32),
             Self::LiteralString(ref v) => assemble_str(v, result),

--- a/rspirv/binary/autogen_error.rs
+++ b/rspirv/binary/autogen_error.rs
@@ -4,7 +4,7 @@
 
 use std::{error, fmt};
 #[doc = "Decoder Error"]
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 #[allow(clippy::upper_case_acronyms)]
 pub enum Error {
     StreamExpected(usize),

--- a/rspirv/dr/build/autogen_norm_insts.rs
+++ b/rspirv/dr/build/autogen_norm_insts.rs
@@ -2,7 +2,7 @@
 //   external/spirv.core.grammar.json.
 // DO NOT MODIFY!
 
-#[allow(clippy::identity_conversion, clippy::too_many_arguments)]
+#[allow(clippy::useless_conversion, clippy::too_many_arguments)]
 impl Builder {
     #[doc = "Appends an OpNop instruction to the current block."]
     pub fn nop(&mut self) -> BuildResult<()> {

--- a/rspirv/dr/build/mod.rs
+++ b/rspirv/dr/build/mod.rs
@@ -938,7 +938,7 @@ mod tests {
             + module.debug_names.len()
             + module.debug_module_processed.len()
             + module.annotations.len())
-            + (if module.memory_model.is_some() { 1 } else { 0 })
+            + (usize::from(module.memory_model.is_some()))
             == 1
     }
 

--- a/rspirv/dr/constructs.rs
+++ b/rspirv/dr/constructs.rs
@@ -50,7 +50,7 @@ pub struct Module {
 }
 
 /// Data representation of a SPIR-V module header.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ModuleHeader {
     pub magic_number: Word,
     pub version: Word,

--- a/rspirv/dr/loader.rs
+++ b/rspirv/dr/loader.rs
@@ -34,7 +34,7 @@ impl Error {
     /// This method is intended to be used by fmt::Display and error::Error to
     /// avoid duplication in implementation. So it's private.
     fn describe(&self) -> Cow<'static, str> {
-        match &*self {
+        match self {
             Error::NestedFunction => Cow::Borrowed("found nested function"),
             Error::UnclosedFunction => Cow::Borrowed("found unclosed function"),
             Error::MismatchedFunctionEnd => Cow::Borrowed("found mismatched OpFunctionEnd"),


### PR DESCRIPTION
As usual the latest version of Rust detects more "bad" patterns, run `clippy --fix` to address them so that they don't clutter up feature PRs.
