### PR TITLE
sr: Deduplicate `match` ranges like `spirv` header

### DIFF
--- a/autogen/src/sr.rs
+++ b/autogen/src/sr.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeSet;
+
 use crate::structs;
 use crate::utils::*;
 
@@ -319,12 +321,18 @@ pub fn gen_sr_code_from_instruction_grammar(
     let mut field_types = Vec::new();
     let mut field_lifts = Vec::new();
 
+    let mut seen_discriminator = BTreeSet::new();
+
     // Compose the token stream for all instructions
     for inst in grammar_instructions
         .iter() // Loop over all instructions
         .filter(|i| i.class != Some(structs::Class::Constant))
     // Skip constants
     {
+        if !seen_discriminator.insert(inst.opcode) {
+            continue;
+        }
+
         // Get the token for its enumerant
         let inst_name = &inst.opname[2..];
 

--- a/autogen/src/sr.rs
+++ b/autogen/src/sr.rs
@@ -325,9 +325,9 @@ pub fn gen_sr_code_from_instruction_grammar(
 
     // Compose the token stream for all instructions
     for inst in grammar_instructions
-        .iter() // Loop over all instructions
+        .iter()
+        // Skip constants
         .filter(|i| i.class != Some(structs::Class::Constant))
-    // Skip constants
     {
         if !seen_discriminator.insert(inst.opcode) {
             continue;

--- a/rspirv/dr/build/autogen_norm_insts.rs
+++ b/rspirv/dr/build/autogen_norm_insts.rs
@@ -13729,45 +13729,6 @@ impl Builder {
         self.insert_into_block(insert_point, inst)?;
         Ok(())
     }
-    #[doc = "Appends an OpReportIntersectionNV instruction to the current block."]
-    pub fn report_intersection_nv(
-        &mut self,
-        result_type: spirv::Word,
-        result_id: Option<spirv::Word>,
-        hit: spirv::Word,
-        hit_kind: spirv::Word,
-    ) -> BuildResult<spirv::Word> {
-        let _id = result_id.unwrap_or_else(|| self.id());
-        #[allow(unused_mut)]
-        let mut inst = dr::Instruction::new(
-            spirv::Op::ReportIntersectionNV,
-            Some(result_type),
-            Some(_id),
-            vec![dr::Operand::IdRef(hit), dr::Operand::IdRef(hit_kind)],
-        );
-        self.insert_into_block(InsertPoint::End, inst)?;
-        Ok(_id)
-    }
-    #[doc = "Appends an OpReportIntersectionNV instruction to the current block."]
-    pub fn insert_report_intersection_nv(
-        &mut self,
-        insert_point: InsertPoint,
-        result_type: spirv::Word,
-        result_id: Option<spirv::Word>,
-        hit: spirv::Word,
-        hit_kind: spirv::Word,
-    ) -> BuildResult<spirv::Word> {
-        let _id = result_id.unwrap_or_else(|| self.id());
-        #[allow(unused_mut)]
-        let mut inst = dr::Instruction::new(
-            spirv::Op::ReportIntersectionNV,
-            Some(result_type),
-            Some(_id),
-            vec![dr::Operand::IdRef(hit), dr::Operand::IdRef(hit_kind)],
-        );
-        self.insert_into_block(insert_point, inst)?;
-        Ok(_id)
-    }
     #[doc = "Appends an OpReportIntersectionKHR instruction to the current block."]
     pub fn report_intersection_khr(
         &mut self,
@@ -13800,6 +13761,45 @@ impl Builder {
         #[allow(unused_mut)]
         let mut inst = dr::Instruction::new(
             spirv::Op::ReportIntersectionKHR,
+            Some(result_type),
+            Some(_id),
+            vec![dr::Operand::IdRef(hit), dr::Operand::IdRef(hit_kind)],
+        );
+        self.insert_into_block(insert_point, inst)?;
+        Ok(_id)
+    }
+    #[doc = "Appends an OpReportIntersectionNV instruction to the current block."]
+    pub fn report_intersection_nv(
+        &mut self,
+        result_type: spirv::Word,
+        result_id: Option<spirv::Word>,
+        hit: spirv::Word,
+        hit_kind: spirv::Word,
+    ) -> BuildResult<spirv::Word> {
+        let _id = result_id.unwrap_or_else(|| self.id());
+        #[allow(unused_mut)]
+        let mut inst = dr::Instruction::new(
+            spirv::Op::ReportIntersectionNV,
+            Some(result_type),
+            Some(_id),
+            vec![dr::Operand::IdRef(hit), dr::Operand::IdRef(hit_kind)],
+        );
+        self.insert_into_block(InsertPoint::End, inst)?;
+        Ok(_id)
+    }
+    #[doc = "Appends an OpReportIntersectionNV instruction to the current block."]
+    pub fn insert_report_intersection_nv(
+        &mut self,
+        insert_point: InsertPoint,
+        result_type: spirv::Word,
+        result_id: Option<spirv::Word>,
+        hit: spirv::Word,
+        hit_kind: spirv::Word,
+    ) -> BuildResult<spirv::Word> {
+        let _id = result_id.unwrap_or_else(|| self.id());
+        #[allow(unused_mut)]
+        let mut inst = dr::Instruction::new(
+            spirv::Op::ReportIntersectionNV,
             Some(result_type),
             Some(_id),
             vec![dr::Operand::IdRef(hit), dr::Operand::IdRef(hit_kind)],

--- a/rspirv/dr/build/autogen_type.rs
+++ b/rspirv/dr/build/autogen_type.rs
@@ -592,6 +592,33 @@ impl Builder {
             new_id
         }
     }
+    #[doc = "Appends an OpTypeAccelerationStructureNV instruction and returns the result id, or return the existing id if the instruction was already present."]
+    pub fn type_acceleration_structure_nv(&mut self) -> spirv::Word {
+        self.type_acceleration_structure_nv_id(None)
+    }
+    #[doc = "Appends an OpTypeAccelerationStructureNV instruction and returns the result id, or return the existing id if the instruction was already present."]
+    pub fn type_acceleration_structure_nv_id(
+        &mut self,
+        result_id: Option<spirv::Word>,
+    ) -> spirv::Word {
+        let mut inst = dr::Instruction::new(
+            spirv::Op::TypeAccelerationStructureNV,
+            None,
+            result_id,
+            vec![],
+        );
+        if let Some(result_id) = result_id {
+            self.module.types_global_values.push(inst);
+            result_id
+        } else if let Some(id) = self.dedup_insert_type(&inst) {
+            id
+        } else {
+            let new_id = self.id();
+            inst.result_id = Some(new_id);
+            self.module.types_global_values.push(inst);
+            new_id
+        }
+    }
     #[doc = "Appends an OpTypeCooperativeMatrixNV instruction and returns the result id, or return the existing id if the instruction was already present."]
     pub fn type_cooperative_matrix_nv(
         &mut self,

--- a/rspirv/grammar/autogen_table.rs
+++ b/rspirv/grammar/autogen_table.rs
@@ -3595,7 +3595,7 @@ static INSTRUCTION_TABLE: &[Instruction<'static>] = &[
         [(IdRef, One), (IdRef, One)]
     ),
     inst!(
-        ReportIntersectionNV,
+        ReportIntersectionKHR,
         [RayTracingNV, RayTracingKHR],
         ["SPV_NV_ray_tracing", "SPV_KHR_ray_tracing"],
         [
@@ -3606,7 +3606,7 @@ static INSTRUCTION_TABLE: &[Instruction<'static>] = &[
         ]
     ),
     inst!(
-        ReportIntersectionKHR,
+        ReportIntersectionNV,
         [RayTracingNV, RayTracingKHR],
         ["SPV_NV_ray_tracing", "SPV_KHR_ray_tracing"],
         [
@@ -3680,7 +3680,7 @@ static INSTRUCTION_TABLE: &[Instruction<'static>] = &[
         ]
     ),
     inst!(
-        TypeAccelerationStructureNV,
+        TypeAccelerationStructureKHR,
         [RayTracingNV, RayTracingKHR, RayQueryKHR],
         [
             "SPV_NV_ray_tracing",
@@ -3690,7 +3690,7 @@ static INSTRUCTION_TABLE: &[Instruction<'static>] = &[
         [(IdResult, One)]
     ),
     inst!(
-        TypeAccelerationStructureKHR,
+        TypeAccelerationStructureNV,
         [RayTracingNV, RayTracingKHR, RayQueryKHR],
         [
             "SPV_NV_ray_tracing",

--- a/rspirv/lift/autogen_context.rs
+++ b/rspirv/lift/autogen_context.rs
@@ -5849,20 +5849,6 @@ impl LiftContext {
                 })
                 .ok_or(OperandError::Missing)?,
             }),
-            5334u32 => Ok(ops::Op::ReportIntersectionKHR {
-                hit: (match operands.next() {
-                    Some(dr::Operand::IdRef(value)) => Some(*value),
-                    Some(_) => return Err(OperandError::WrongType.into()),
-                    None => None,
-                })
-                .ok_or(OperandError::Missing)?,
-                hit_kind: (match operands.next() {
-                    Some(dr::Operand::IdRef(value)) => Some(*value),
-                    Some(_) => return Err(OperandError::WrongType.into()),
-                    None => None,
-                })
-                .ok_or(OperandError::Missing)?,
-            }),
             5335u32 => Ok(ops::Op::IgnoreIntersectionNV),
             5336u32 => Ok(ops::Op::TerminateRayNV),
             5337u32 => Ok(ops::Op::TraceNV {
@@ -6768,41 +6754,7 @@ impl LiftContext {
                 })
                 .ok_or(OperandError::Missing)?,
             }),
-            5632u32 => Ok(ops::Op::DecorateStringGOOGLE {
-                target: (match operands.next() {
-                    Some(dr::Operand::IdRef(value)) => Some(*value),
-                    Some(_) => return Err(OperandError::WrongType.into()),
-                    None => None,
-                })
-                .ok_or(OperandError::Missing)?,
-                decoration: (match operands.next() {
-                    Some(dr::Operand::Decoration(value)) => Some(*value),
-                    Some(_) => return Err(OperandError::WrongType.into()),
-                    None => None,
-                })
-                .ok_or(OperandError::Missing)?,
-            }),
             5633u32 => Ok(ops::Op::MemberDecorateString {
-                struct_type: (match operands.next() {
-                    Some(dr::Operand::IdRef(value)) => Some(self.types.lookup_token(*value)),
-                    Some(_) => return Err(OperandError::WrongType.into()),
-                    None => None,
-                })
-                .ok_or(OperandError::Missing)?,
-                member: (match operands.next() {
-                    Some(dr::Operand::LiteralBit32(value)) => Some(*value),
-                    Some(_) => return Err(OperandError::WrongType.into()),
-                    None => None,
-                })
-                .ok_or(OperandError::Missing)?,
-                decoration: (match operands.next() {
-                    Some(dr::Operand::Decoration(value)) => Some(*value),
-                    Some(_) => return Err(OperandError::WrongType.into()),
-                    None => None,
-                })
-                .ok_or(OperandError::Missing)?,
-            }),
-            5633u32 => Ok(ops::Op::MemberDecorateStringGOOGLE {
                 struct_type: (match operands.next() {
                     Some(dr::Operand::IdRef(value)) => Some(self.types.lookup_token(*value)),
                     Some(_) => return Err(OperandError::WrongType.into()),
@@ -11118,7 +11070,6 @@ impl LiftContext {
             322u32 => Ok(Type::PipeStorage),
             327u32 => Ok(Type::NamedBarrier),
             4472u32 => Ok(Type::RayQueryKHR),
-            5341u32 => Ok(Type::AccelerationStructureKHR),
             5358u32 => Ok(Type::CooperativeMatrixNV {
                 component_type: (match operands.next() {
                     Some(dr::Operand::IdRef(value)) => Some(self.types.lookup_token(*value)),

--- a/rspirv/lift/autogen_context.rs
+++ b/rspirv/lift/autogen_context.rs
@@ -5835,7 +5835,7 @@ impl LiftContext {
                 })
                 .ok_or(OperandError::Missing)?,
             }),
-            5334u32 => Ok(ops::Op::ReportIntersectionNV {
+            5334u32 => Ok(ops::Op::ReportIntersectionKHR {
                 hit: (match operands.next() {
                     Some(dr::Operand::IdRef(value)) => Some(*value),
                     Some(_) => return Err(OperandError::WrongType.into()),
@@ -6067,7 +6067,6 @@ impl LiftContext {
                 })
                 .ok_or(OperandError::Missing)?,
             }),
-            5341u32 => Ok(ops::Op::TypeAccelerationStructureNV),
             5344u32 => Ok(ops::Op::ExecuteCallableNV {
                 sbt_index: (match operands.next() {
                     Some(dr::Operand::IdRef(value)) => Some(*value),
@@ -11070,6 +11069,7 @@ impl LiftContext {
             322u32 => Ok(Type::PipeStorage),
             327u32 => Ok(Type::NamedBarrier),
             4472u32 => Ok(Type::RayQueryKHR),
+            5341u32 => Ok(Type::AccelerationStructureKHR),
             5358u32 => Ok(Type::CooperativeMatrixNV {
                 component_type: (match operands.next() {
                     Some(dr::Operand::IdRef(value)) => Some(self.types.lookup_token(*value)),

--- a/rspirv/sr/autogen_ops.rs
+++ b/rspirv/sr/autogen_ops.rs
@@ -1491,7 +1491,7 @@ pub enum Op {
         index_offset: spirv::Word,
         packed_indices: spirv::Word,
     },
-    ReportIntersectionNV {
+    ReportIntersectionKHR {
         hit: spirv::Word,
         hit_kind: spirv::Word,
     },
@@ -1538,7 +1538,6 @@ pub enum Op {
         time: spirv::Word,
         payload: spirv::Word,
     },
-    TypeAccelerationStructureNV,
     ExecuteCallableNV {
         sbt_index: spirv::Word,
         callable_data_id: spirv::Word,

--- a/rspirv/sr/autogen_ops.rs
+++ b/rspirv/sr/autogen_ops.rs
@@ -1495,10 +1495,6 @@ pub enum Op {
         hit: spirv::Word,
         hit_kind: spirv::Word,
     },
-    ReportIntersectionKHR {
-        hit: spirv::Word,
-        hit_kind: spirv::Word,
-    },
     IgnoreIntersectionNV,
     TerminateRayNV,
     TraceNV {
@@ -1736,16 +1732,7 @@ pub enum Op {
         target: spirv::Word,
         decoration: spirv::Decoration,
     },
-    DecorateStringGOOGLE {
-        target: spirv::Word,
-        decoration: spirv::Decoration,
-    },
     MemberDecorateString {
-        struct_type: Token<Type>,
-        member: u32,
-        decoration: spirv::Decoration,
-    },
-    MemberDecorateStringGOOGLE {
         struct_type: Token<Type>,
         member: u32,
         decoration: spirv::Decoration,

--- a/rspirv/sr/autogen_types.rs
+++ b/rspirv/sr/autogen_types.rs
@@ -71,7 +71,6 @@ pub enum Type {
     PipeStorage,
     NamedBarrier,
     RayQueryKHR,
-    AccelerationStructureKHR,
     CooperativeMatrixNV {
         component_type: Token<Type>,
         execution: spirv::Word,

--- a/rspirv/sr/autogen_types.rs
+++ b/rspirv/sr/autogen_types.rs
@@ -71,6 +71,7 @@ pub enum Type {
     PipeStorage,
     NamedBarrier,
     RayQueryKHR,
+    AccelerationStructureKHR,
     CooperativeMatrixNV {
         component_type: Token<Type>,
         execution: spirv::Word,

--- a/spirv/autogen_spirv.rs
+++ b/spirv/autogen_spirv.rs
@@ -2859,13 +2859,13 @@ pub enum Op {
     ImageSampleFootprintNV = 5283u32,
     GroupNonUniformPartitionNV = 5296u32,
     WritePackedPrimitiveIndices4x8NV = 5299u32,
-    ReportIntersectionNV = 5334u32,
+    ReportIntersectionKHR = 5334u32,
     IgnoreIntersectionNV = 5335u32,
     TerminateRayNV = 5336u32,
     TraceNV = 5337u32,
     TraceMotionNV = 5338u32,
     TraceRayMotionNV = 5339u32,
-    TypeAccelerationStructureNV = 5341u32,
+    TypeAccelerationStructureKHR = 5341u32,
     ExecuteCallableNV = 5344u32,
     TypeCooperativeMatrixNV = 5358u32,
     CooperativeMatrixLoadNV = 5359u32,
@@ -3193,8 +3193,8 @@ impl Op {
 #[allow(clippy::upper_case_acronyms)]
 #[allow(non_upper_case_globals)]
 impl Op {
-    pub const ReportIntersectionKHR: Op = Op::ReportIntersectionNV;
-    pub const TypeAccelerationStructureKHR: Op = Op::TypeAccelerationStructureNV;
+    pub const ReportIntersectionNV: Op = Op::ReportIntersectionKHR;
+    pub const TypeAccelerationStructureNV: Op = Op::TypeAccelerationStructureKHR;
     pub const DecorateStringGOOGLE: Op = Op::DecorateString;
     pub const MemberDecorateStringGOOGLE: Op = Op::MemberDecorateString;
 }


### PR DESCRIPTION
Solve some clippy lints by getting rid of these aliases of overlapping `Op`s.  Unfortunately, just like in `spirv`, this biases towards the `NV` rather than `KHR` stabilized raytracing ops.

Note that in `spirv` the `Op`s are aliases in code rather than omitted altogether: don't think we can do that for the range match here though unless deducing whether the shader was compiled with the NV or KHR variant, even though the KHR variant is already stabilized for quite some time.
