### PR TITLE
ci: add publishing workflow (triggered by tags)

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -5,6 +5,10 @@ on:
     tags:
     paths: "**/Cargo.toml"
 
+concurrency:
+  group: ${{ github.sha }}
+  cancel-in-progress: true
+
 jobs:
   Publish:
     if: github.repository_owner == 'gfx-rs'

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,7 +3,7 @@ name: Publish
 on:
   push:
     tags:
-      - '*'
+    paths: "**/Cargo.toml"
 
 jobs:
   Publish:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,17 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  Publish:
+    if: github.repository_owner == 'gfx-rs'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Publish spirv
+        run: cargo publish --manifest-path spirv/Cargo.toml --token ${{ secrets.cratesio_token }}
+      - name: Publish rspirv
+        run: cargo publish --manifest-path rspirv/Cargo.toml --token ${{ secrets.cratesio_token }}

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -1,5 +1,9 @@
+# Prerequisites
+
+`rspirv` uses `cargo-release` for release management. If you don't have `cargo-release` installed run `cargo install cargo-release`. Publishing to crates.io is handled by a github workflow.
+
 # Making a new release
 
-1. If you don't have cargo-release installed run `cargo install cargo-release`
-1. To prevent breakage, one should release `spirv` before releasing a new `rspirv` because it has an obvious dependency.
-1. For `rspirv` run `cargo release` in the `rspirv` directory, this should follow Semantic Versioning
+Order of releases crates is important to prevent breakage. `spirv` should released before `rspirv` because it has an obvious dependency.
+
+In the corresponding crate directory execute `cargo release <version> -x`.

--- a/rspirv/release.toml
+++ b/rspirv/release.toml
@@ -4,6 +4,7 @@ tag-message = "Release {{crate_name}} {{version}}"
 tag-name = "{{crate_name}}-{{version}}"
 sign-commit = true
 sign-tag = true
+publish = false
 
 pre-release-replacements = [
   {file="README.md", search="rspirv = .*", replace="{{crate_name}} = \"{{version}}\""},

--- a/spirv/release.toml
+++ b/spirv/release.toml
@@ -4,10 +4,9 @@ tag-message = "Release {{crate_name}} {{version}}"
 tag-name = "{{crate_name}}-{{version}}"
 sign-commit = true
 sign-tag = true
+publish = false
 
 pre-release-replacements = [
   {file="README.md", search="spirv = .*", replace="{{crate_name}} = \"{{version}}\""},
   {file="../rspirv/Cargo.toml", search="spirv = \\{ version = \".*\", path = \"../spirv\" \\}", replace="{{crate_name}} = { version = \"{{version}}\", path = \"../spirv\" }" },
 ]
-
-


### PR DESCRIPTION
Add a github workflow for publishing the crates semi-automatically. Currently went for tag based trigger due to metadata changes to `Cargo.toml` but open to switch to the 'normal' `Cargo.toml` trigger.

Secret already added in the settings.