### PR TITLE
ci: remove dev version settings

### DIFF
--- a/rspirv/release.toml
+++ b/rspirv/release.toml
@@ -1,5 +1,4 @@
 pre-release-commit-message = "Release {{crate_name}} {{version}}"
-no-dev-version = true
 tag-message = "Release {{crate_name}} {{version}}"
 tag-name = "{{crate_name}}-{{version}}"
 sign-commit = true

--- a/spirv/release.toml
+++ b/spirv/release.toml
@@ -1,5 +1,4 @@
 pre-release-commit-message = "Release {{crate_name}} {{version}}"
-no-dev-version = true
 tag-message = "Release {{crate_name}} {{version}}"
 tag-name = "{{crate_name}}-{{version}}"
 sign-commit = true


### PR DESCRIPTION
dev-version support has been removed from `cargo-release` in https://github.com/crate-ci/cargo-release/commit/77009fdbc999669c7e3ce5ac904b4c28afd51eb4