### PR TITLE
spirv: Drop stale "tracking SPIR-V major/minor version" from README

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,6 +3,7 @@ name: Publish
 on:
   push:
     tags:
+       - '**'
     paths: "**/Cargo.toml"
 
 concurrency:

--- a/autogen/Cargo.toml
+++ b/autogen/Cargo.toml
@@ -6,7 +6,6 @@ authors = [
 	"Lei Zhang <antiagainst@gmail.com>",
 ]
 edition = "2018"
-rust-version = "1.58"
 
 publish = false
 

--- a/autogen/src/binary.rs
+++ b/autogen/src/binary.rs
@@ -111,7 +111,7 @@ pub fn gen_operand_decode_methods(grammar: &[structs::OperandKind]) -> TokenStre
     });
 
     quote! {
-        impl<'a> Decoder<'a> {
+        impl Decoder<'_> {
             #(#methods)*
         }
     }
@@ -288,7 +288,7 @@ pub fn gen_operand_parse_methods(grammar: &[structs::OperandKind]) -> TokenStrea
     });
 
     quote! {
-        impl<'c, 'd> Parser<'c, 'd> {
+        impl Parser<'_, '_> {
             fn parse_operand(&mut self, kind: GOpKind) -> Result<Vec<dr::Operand>> {
                 Ok(match kind {
                     #(#normal_cases),*,

--- a/autogen/src/dr.rs
+++ b/autogen/src/dr.rs
@@ -24,7 +24,7 @@ pub fn operand_has_additional_params(
     kinds
         .iter()
         .find(|kind| kind.kind == operand.kind)
-        .map_or(false, has_additional_params)
+        .is_some_and(has_additional_params)
 }
 
 fn get_param_or_arg_list(
@@ -391,7 +391,7 @@ pub fn gen_dr_operand_kinds(grammar: &[structs::OperandKind]) -> TokenStream {
                 let mut seen_discriminator = BTreeMap::new();
 
                 for e in enumerators {
-                    if seen_discriminator.get(&e.value).is_none() {
+                    if let std::collections::btree_map::Entry::Vacant(seen_entry) = seen_discriminator.entry(e.value) {
                         let name = match category {
                             structs::Category::BitEnum => {
                                 use heck::ShoutySnakeCase;
@@ -412,7 +412,7 @@ pub fn gen_dr_operand_kinds(grammar: &[structs::OperandKind]) -> TokenStream {
                             _ => panic!("Unexpected operand type"),
                         };
 
-                        seen_discriminator.insert(e.value, name.clone());
+                        seen_entry.insert(name.clone());
 
                         capability_clauses
                             .entry(&e.capabilities)

--- a/autogen/src/structs.rs
+++ b/autogen/src/structs.rs
@@ -1,4 +1,6 @@
-/// Rust structs for deserializing the SPIR-V JSON grammar.
+//! Rust structs for deserializing the SPIR-V JSON grammar.
+#![allow(dead_code)] // Parsed but unread fields
+
 use serde::de;
 use serde_derive::*;
 use std::{convert::TryInto, fmt, result, str};
@@ -74,7 +76,7 @@ pub struct ExtInstSetGrammar {
 fn num_or_hex<'de, D: de::Deserializer<'de>>(d: D) -> result::Result<u32, D::Error> {
     struct NumOrStr;
 
-    impl<'de> de::Visitor<'de> for NumOrStr {
+    impl de::Visitor<'_> for NumOrStr {
         type Value = u32;
 
         fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
@@ -93,20 +95,15 @@ fn num_or_hex<'de, D: de::Deserializer<'de>>(d: D) -> result::Result<u32, D::Err
     d.deserialize_any(NumOrStr)
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize, Ord, PartialOrd)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Deserialize, Ord, PartialOrd)]
 pub enum Quantifier {
     #[serde(rename = "")]
+    #[default]
     One,
     #[serde(rename = "?")]
     ZeroOrOne,
     #[serde(rename = "*")]
     ZeroOrMore,
-}
-
-impl Default for Quantifier {
-    fn default() -> Self {
-        Quantifier::One
-    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize)]

--- a/rspirv/binary/autogen_decode_operand.rs
+++ b/rspirv/binary/autogen_decode_operand.rs
@@ -2,7 +2,7 @@
 //   external/spirv.core.grammar.json.
 // DO NOT MODIFY!
 
-impl<'a> Decoder<'a> {
+impl Decoder<'_> {
     #[doc = "Decodes and returns the next SPIR-V word as\na SPIR-V ImageOperands value."]
     pub fn image_operands(&mut self) -> Result<spirv::ImageOperands> {
         if let Ok(word) = self.word() {

--- a/rspirv/binary/autogen_parse_operand.rs
+++ b/rspirv/binary/autogen_parse_operand.rs
@@ -2,7 +2,7 @@
 //   external/spirv.core.grammar.json.
 // DO NOT MODIFY!
 
-impl<'c, 'd> Parser<'c, 'd> {
+impl Parser<'_, '_> {
     fn parse_operand(&mut self, kind: GOpKind) -> Result<Vec<dr::Operand>> {
         Ok(match kind {
             GOpKind::FPFastMathMode => vec![dr::Operand::FPFastMathMode(

--- a/rspirv/binary/decoder.rs
+++ b/rspirv/binary/decoder.rs
@@ -112,7 +112,7 @@ impl<'a> Decoder<'a> {
     }
 }
 
-impl<'a> Decoder<'a> {
+impl Decoder<'_> {
     /// Sets the limit to `num_words` words.
     ///
     /// The decoder will return [`State::LimitReached`](enum.ParseState.html)
@@ -144,7 +144,7 @@ impl<'a> Decoder<'a> {
     }
 }
 
-impl<'a> Decoder<'a> {
+impl Decoder<'_> {
     /// Decodes and returns the next SPIR-V word as an id.
     pub fn id(&mut self) -> Result<spirv::Word> {
         self.word()

--- a/rspirv/binary/tracker.rs
+++ b/rspirv/binary/tracker.rs
@@ -116,7 +116,7 @@ impl ExtInstSetTracker {
     /// Returns true if the given extended instruction `set` has been
     /// recognized thus tracked.
     pub fn have(&self, set: spirv::Word) -> bool {
-        self.sets.get(&set).is_some()
+        self.sets.contains_key(&set)
     }
 
     /// Resolves the extended instruction with `opcode` in set `set`.

--- a/rspirv/sr/storage.rs
+++ b/rspirv/sr/storage.rs
@@ -112,8 +112,8 @@ mod tests {
     #[test]
     fn append_unique() {
         let mut storage: Storage<f64> = Storage::new();
-        let t1 = storage.append(std::f64::NAN);
-        let t2 = storage.append(std::f64::NAN);
+        let t1 = storage.append(f64::NAN);
+        let t2 = storage.append(f64::NAN);
         assert!(t1 != t2);
         assert!(storage[t1] != storage[t2]);
     }
@@ -130,8 +130,8 @@ mod tests {
     #[test]
     fn fetch_or_append_unique() {
         let mut storage: Storage<f64> = Storage::new();
-        let t1 = storage.fetch_or_append(std::f64::NAN);
-        let t2 = storage.fetch_or_append(std::f64::NAN);
+        let t1 = storage.fetch_or_append(f64::NAN);
+        let t2 = storage.fetch_or_append(f64::NAN);
         assert!(t1 != t2);
         assert!(storage[t1] != storage[t2]);
     }

--- a/spirv/README.md
+++ b/spirv/README.md
@@ -21,15 +21,6 @@ First add to your `Cargo.toml`:
 spirv = "0.3.0"
 ```
 
-Version
--------
-
-Note that the major and minor version of this create is tracking the SPIR-V spec,
-while the patch number is used for bugfixes for the crate itself. So version
-`1.4.2` is tracking SPIR-V 1.4 but not necessarily revision 2. Major client APIs
-like Vulkan/OpenCL pin to a specific major and minor version, regardless of the
-revision.
-
 Examples
 --------
 


### PR DESCRIPTION
For #252, CC @tareksander

Since inheriting the `spirv` crate and dropping the `spirv_headers` crate in #204, and following up on a choice in #197 to no longer have the SPIR-V major/minor version in our crate version which disallows us from making any breaking changes to the crate, we reset the version to `0.1.0` and embedded the SPIR-V version via _version metadata_ instead. This stale comment in the README was still indicating as such though, confusing users in e.g. #252 that our `spirv` crate was somehow exposing SPIR-V 1.3 (should have been 0.3 by that logic which is the current latest version).  Remove it entirely.

Note also that since #225 / #226 our version metadata is no longer the SPIR-V version/revision but the Vulkan SDK tag that it was released with.  The SPIR-V version isn't bumped often enough to match extensions in new SDK releases, making the SDK tag more indicative of the included API surface instead.
