### PR TITLE
spirv: Allow crate to remain `no_std` when `(de)serialize` features are enabled

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,7 +48,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --all --all-targets -- -Dwarnings
+          args: --workspace --all-features --all-targets -- -Dwarnings
   test:
     name: Cargo check and test
     strategy:
@@ -67,8 +67,8 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: check
-          args: --workspace --all-targets --verbose
+          args: --workspace --all-features --all-targets --verbose
       - uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --workspace --verbose
+          args: --workspace --all-features --verbose

--- a/rspirv/Cargo.toml
+++ b/rspirv/Cargo.toml
@@ -18,7 +18,6 @@ path = "lib.rs"
 travis-ci = { repository = "gfx-rs/rspirv" }
 
 [dependencies]
-clippy = { version = "0.0", optional = true }
 rustc-hash = "1.1.0"
 spirv = { version = "0.3.0", path = "../spirv" }
 

--- a/rspirv/binary/decoder.rs
+++ b/rspirv/binary/decoder.rs
@@ -35,9 +35,9 @@ const WORD_NUM_BYTES: usize = 4;
 ///
 /// * `DecodeError::LimitReached(offset)` if the most recent limit has reached.
 /// * `DecodeError::StreamExpected(offset)` if more bytes are needed to decode
-///    the next word.
+///   the next word.
 /// * `DecodeError::<spirv-enum>Unknown(offset, value)` if failed to decode the
-///    next word as the given `<spirv-enum>`.
+///   next word as the given `<spirv-enum>`.
 ///
 /// All errors contain the byte offset of the word failed decoding.
 ///

--- a/rspirv/sr/constants.rs
+++ b/rspirv/sr/constants.rs
@@ -50,7 +50,7 @@ impl Constant {
     }
 
     pub fn is_null_constant(&self) -> bool {
-        matches!(self, Constant::Null { .. })
+        matches!(self, Constant::Null)
     }
 
     pub fn is_sampler_constant(&self) -> bool {

--- a/spirv/Cargo.toml
+++ b/spirv/Cargo.toml
@@ -20,4 +20,4 @@ path = "lib.rs"
 
 [dependencies]
 bitflags = "2.0"
-serde = { version = "1", optional = true, features = ["derive"] }
+serde = { version = "1", optional = true, default-features = false, features = ["derive"] }

--- a/spirv/lib.rs
+++ b/spirv/lib.rs
@@ -7,6 +7,7 @@
 
 #![no_std]
 #![allow(non_camel_case_types)]
+#![deny(clippy::std_instead_of_core, clippy::alloc_instead_of_core)]
 #![cfg_attr(rustfmt, rustfmt_skip)]
 
 use bitflags::bitflags;


### PR DESCRIPTION
Despite `spirv` crate being `no_std`, it pulls in serde's `std` feature by accident. This fixes that, so it can be used safely in no_std crates