### PR TITLE
[spirv]: Remove unused features from `serde`

### DIFF
--- a/spirv/Cargo.toml
+++ b/spirv/Cargo.toml
@@ -20,4 +20,4 @@ path = "lib.rs"
 
 [dependencies]
 bitflags = "2.0"
-serde = { version = "1", optional = true, features = ["derive"] }
+serde = { version = "1", optional = true, default-features = false, features = ["derive"] }


### PR DESCRIPTION
The `serialize` and `deserialize` features will break `no_std` compatibility due to default features. Disabling those defaults allows the features within `no_std`. This will improve [wgpu/6826](https://github.com/gfx-rs/wgpu/issues/6826).