### PR TITLE
grammar: Handle `TypeCooperativeMatrixKHR` as type

### DIFF
--- a/autogen/src/binary.rs
+++ b/autogen/src/binary.rs
@@ -152,7 +152,7 @@ fn gen_operand_param_parse_methods(grammar: &[structs::OperandKind]) -> Vec<(&st
             // For each operand kind in the BitEnum category, its
             // enumerants are bit masks. If a certain bit having associated
             // parameters is set, we also need to decode the corresponding
-            // parameters. E.g., for MemoryAccess Aigned, an additional
+            // parameters. E.g., for MemoryAccess Aligned, an additional
             // LiteralInteger, which stands for the known alignment, should
             // be decoded.
 
@@ -191,10 +191,7 @@ fn gen_operand_param_parse_methods(grammar: &[structs::OperandKind]) -> Vec<(&st
                     spirv::#kind::#symbol => vec![#(#params),*]
                 }
             });
-            // TODO: filter duplicated symbols mapping to the same discriminator to avoid
-            // unreachable patterns.
             quote! {
-                #[allow(unreachable_patterns)]
                 fn #function_name(&mut self, #lo_kind: spirv::#kind) -> Result<Vec<dr::Operand>> {
                     Ok(match #lo_kind {
                         #(#cases),*,

--- a/autogen/src/sr.rs
+++ b/autogen/src/sr.rs
@@ -533,9 +533,6 @@ pub fn gen_sr_code_from_instruction_grammar(
                         .map(ops::Terminator::Branch)
                 }
             }
-            // TODO: filter duplicated symbols mapping to the same discriminator to avoid
-            // unreachable patterns.
-            #[allow(unreachable_patterns)]
             pub fn lift_op(
                 &mut self, raw: &dr::Instruction
             ) -> Result<ops::Op, InstructionError> {

--- a/rspirv/binary/autogen_parse_operand.rs
+++ b/rspirv/binary/autogen_parse_operand.rs
@@ -322,7 +322,6 @@ impl Parser<'_, '_> {
         }
         Ok(params)
     }
-    #[allow(unreachable_patterns)]
     fn parse_execution_mode_arguments(
         &mut self,
         execution_mode: spirv::ExecutionMode,
@@ -459,7 +458,6 @@ impl Parser<'_, '_> {
             _ => vec![],
         })
     }
-    #[allow(unreachable_patterns)]
     fn parse_decoration_arguments(
         &mut self,
         decoration: spirv::Decoration,

--- a/rspirv/grammar/reflect.rs
+++ b/rspirv/grammar/reflect.rs
@@ -66,6 +66,7 @@ pub fn is_type(opcode: spirv::Op) -> bool {
             | spirv::Op::TypeAccelerationStructureKHR
             | spirv::Op::TypeRayQueryKHR
             | spirv::Op::TypeForwardPointer
+            | spirv::Op::TypeCooperativeMatrixKHR
     )
 }
 

--- a/rspirv/grammar/syntax.rs
+++ b/rspirv/grammar/syntax.rs
@@ -115,7 +115,7 @@ impl CoreInstructionTable {
     pub fn get(opcode: spirv::Op) -> &'static Instruction<'static> {
         INSTRUCTION_TABLE
             .iter()
-            .find(|inst| (inst.opcode == opcode))
+            .find(|inst| inst.opcode == opcode)
             .expect("internal error")
     }
 
@@ -145,7 +145,7 @@ impl GlslStd450InstructionTable {
     pub fn get(opcode: spirv::GLOp) -> &'static ExtendedInstruction<'static> {
         GLSL_STD_450_INSTRUCTION_TABLE
             .iter()
-            .find(|inst| (inst.opcode == opcode as spirv::Word))
+            .find(|inst| inst.opcode == opcode as spirv::Word)
             .expect("internal error")
     }
 
@@ -176,7 +176,7 @@ impl OpenCLStd100InstructionTable {
     pub fn get(opcode: spirv::CLOp) -> &'static ExtendedInstruction<'static> {
         OPENCL_STD_100_INSTRUCTION_TABLE
             .iter()
-            .find(|inst| (inst.opcode == opcode as spirv::Word))
+            .find(|inst| inst.opcode == opcode as spirv::Word)
             .expect("internal error")
     }
 

--- a/rspirv/lift/autogen_context.rs
+++ b/rspirv/lift/autogen_context.rs
@@ -203,7 +203,6 @@ impl LiftContext {
             _ => self.lift_branch(raw).map(ops::Terminator::Branch),
         }
     }
-    #[allow(unreachable_patterns)]
     pub fn lift_op(&mut self, raw: &dr::Instruction) -> Result<ops::Op, InstructionError> {
         let mut operands = raw.operands.iter();
         match raw.class.opcode as u32 {

--- a/rspirv/lift/mod.rs
+++ b/rspirv/lift/mod.rs
@@ -64,7 +64,7 @@ impl From<OperandError> for InstructionError {
     }
 }
 
-/// Error that may occur during the convesion from the data representation
+/// Error that may occur during the conversion from the data representation
 /// of a module into a structured representation.
 #[derive(Clone, Debug)]
 pub enum ConversionError {

--- a/rspirv/lift/storage.rs
+++ b/rspirv/lift/storage.rs
@@ -41,7 +41,7 @@ impl<T, L: Borrow<Token<T>>> LiftStorage<T, L> {
         &mut self,
         id: spirv::Word,
         value: T,
-    ) -> (Token<T>, VacantEntry<spirv::Word, L>) {
+    ) -> (Token<T>, VacantEntry<'_, spirv::Word, L>) {
         let token = self.values.append(value);
         match self.lookup.entry(id) {
             Entry::Occupied(_) => panic!("Id {:?} is already used", id),


### PR DESCRIPTION
Depends on #267
Fixes #265

Without this shaders with cooperative matrix types fail to parse.

Note that separately I copied my own coopmat example together with a function call that is compiled with `glslang test.comp -G -o spirv-blobs/cooperative-matrix.spv`:

```glsl
#version 450
#extension GL_KHR_cooperative_matrix : require

coopmat<float, gl_ScopeSubgroup, 16, 8, gl_MatrixUseAccumulator> m;

float f(float x) {
    return x + 2;
}

void main() {
    for (int i = 0; i < m.length(); ++i) {
        m[i] = f(m[i]);
    }
}
```

This results in a failure when lifting to the structured representation (part of the `spirv-blobs` parsing test) because `lift_op()` doesn't handle `OpFunctionCall` to call `f`, so I've hacked something in here to start handling that separately via `lift_function_call()` but not decided how to represent that further. Perhaps fold into `enum sr::ops::Op` after all?