### PR TITLE
DRAFT: Support lifting `OpFunctionCall` to Structured Representation

### DIFF
--- a/rspirv/lift/mod.rs
+++ b/rspirv/lift/mod.rs
@@ -154,6 +154,11 @@ impl LiftContext {
                                 };
                             }
                         }
+                        spirv::Op::FunctionCall => {
+                            let op = context.lift_function_call(inst)?;
+                            dbg!(&op);
+                            // TODO: Add as function call?
+                        }
                         _ => {
                             if let Some(id) = inst.result_id {
                                 let op = context.lift_op(inst)?;


### PR DESCRIPTION
Haven't decided whether this should go to a new `ops::Op::FunctionCall` or a separate structure. `lift_op()` currently doesn't support `OpFunctionCall`, but it feels like adding it to `ops::Op` should be paired with supporting it in `lift_op()`.