### PR TITLE
Generate `reflect::is_xxx()` helpers directly in the `spirv` header

### DIFF
--- a/autogen/src/header.rs
+++ b/autogen/src/header.rs
@@ -291,16 +291,42 @@ pub fn gen_spirv_header(grammar: &structs::Grammar) -> TokenStream {
     // Use associated constants for these aliases.
     let mut aliases = vec![];
     let mut variants = vec![];
+    let mut types = vec![];
+    let mut constants = vec![];
+    let mut annotations = vec![];
+    let mut debugs = vec![];
+    let mut control_flows = vec![];
 
     // Get the instruction table.
     for inst in &grammar.instructions {
         let opname = as_ident(inst.opname.strip_prefix("Op").unwrap());
         let opcode = inst.opcode;
+        variants.push((opcode, opname.clone()));
+
+        let opname = quote!(Self::#opname);
         for alias in &inst.aliases {
             let alias = as_ident(alias.strip_prefix("Op").unwrap());
-            aliases.push(quote! { pub const #alias: Op = Op::#opname; });
+            aliases.push(quote! { pub const #alias: Self = #opname; });
         }
-        variants.push((opcode, opname.clone()));
+
+        match inst.class {
+            Some(structs::Class::Type) => {
+                types.push(opname);
+            }
+            Some(structs::Class::Constant) => {
+                constants.push(opname);
+            }
+            Some(structs::Class::Annotation) => {
+                annotations.push(opname);
+            }
+            Some(structs::Class::Debug) => {
+                debugs.push(opname);
+            }
+            Some(structs::Class::Branch) => {
+                control_flows.push(opname);
+            }
+            _ => {}
+        }
     }
 
     let the_enum = generate_enum(
@@ -325,6 +351,37 @@ pub fn gen_spirv_header(grammar: &structs::Grammar) -> TokenStream {
         #[allow(non_upper_case_globals)]
         impl Op {
             #(#aliases)*
+
+            /// Returns [`true`] if the given opcode is a type-declaring instruction.
+            ///
+            /// <https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#_type_declaration_instructions>
+            pub fn is_type(self) -> bool {
+                matches!(self, #(#types)|*)
+            }
+            /// Returns [`true`] if the given opcode is a constant-defining instruction.
+            ///
+            /// <https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#_constant_creation_instructions>
+            pub fn is_constant(self) -> bool {
+                matches!(self, #(#constants)|*)
+            }
+            /// Returns [`true`] if the given opcode is an annotation instruction.
+            ///
+            /// <https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#Annotation>
+            pub fn is_annotation(self) -> bool {
+                matches!(self, #(#annotations)|*)
+            }
+            /// Returns [`true`] if the given opcode is a debug instruction.
+            ///
+            /// <https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#_debug_instructions>
+            pub fn is_debug(self) -> bool {
+                matches!(self, #(#debugs)|*)
+            }
+            /// Returns [`true`] if the given opcode is a control-flow instruction.
+            ///
+            /// <https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#_control_flow_instructions>
+            pub fn is_control_flow(self) -> bool {
+                matches!(self, #(#control_flows)|*)
+            }
         }
     }
 }

--- a/autogen/src/structs.rs
+++ b/autogen/src/structs.rs
@@ -122,7 +122,6 @@ pub enum Class {
     #[serde(rename = "Constant-Creation")]
     Constant,
     Debug,
-    DebugLine,
     #[serde(rename = "Extension")]
     ExtensionDecl,
     #[serde(rename = "Function")]

--- a/rspirv/binary/tracker.rs
+++ b/rspirv/binary/tracker.rs
@@ -38,7 +38,7 @@ impl TypeTracker {
 
     pub fn track(&mut self, inst: &dr::Instruction) {
         if let Some(rid) = inst.result_id {
-            if grammar::reflect::is_type(inst.class.opcode) {
+            if inst.class.opcode.is_type() {
                 match inst.class.opcode {
                     spirv::Op::TypeInt => {
                         if let (

--- a/rspirv/dr/loader.rs
+++ b/rspirv/dr/loader.rs
@@ -150,10 +150,8 @@ impl binary::Consumer for Loader {
                     None => self.module.types_global_values.push(inst),
                 }
             }
-            opcode if grammar::reflect::is_annotation(opcode) => self.module.annotations.push(inst),
-            opcode
-                if grammar::reflect::is_type(opcode) || grammar::reflect::is_constant(opcode) =>
-            {
+            opcode if opcode.is_annotation() => self.module.annotations.push(inst),
+            opcode if opcode.is_type() || opcode.is_constant() => {
                 self.module.types_global_values.push(inst)
             }
             spirv::Op::Variable if self.function.is_none() => {

--- a/rspirv/grammar/reflect.rs
+++ b/rspirv/grammar/reflect.rs
@@ -2,105 +2,22 @@
 
 use crate::spirv;
 
-/// Returns true if the given opcode is for a location debug instruction.
+/// Returns [`true`] if the given opcode is for a location debug instruction.
 pub fn is_location_debug(opcode: spirv::Op) -> bool {
     matches!(opcode, spirv::Op::Line | spirv::Op::NoLine)
 }
 
-/// Returns true if the given opcode is for a non-location debug instruction.
-pub fn is_nonlocation_debug(opcode: spirv::Op) -> bool {
-    matches!(
-        opcode,
-        spirv::Op::SourceContinued
-            | spirv::Op::Source
-            | spirv::Op::SourceExtension
-            | spirv::Op::Name
-            | spirv::Op::MemberName
-            | spirv::Op::String
-    )
-}
-
-/// Returns true if the given opcode is for a debug instruction.
-pub fn is_debug(opcode: spirv::Op) -> bool {
-    is_location_debug(opcode) || is_nonlocation_debug(opcode)
-}
-
-/// Returns true if the given opcode is for an annotation instruction.
-pub fn is_annotation(opcode: spirv::Op) -> bool {
-    matches!(
-        opcode,
-        spirv::Op::Decorate
-            | spirv::Op::MemberDecorate
-            | spirv::Op::DecorationGroup
-            | spirv::Op::GroupDecorate
-            | spirv::Op::GroupMemberDecorate
-            | spirv::Op::DecorateString
-            | spirv::Op::MemberDecorateStringGOOGLE
-    )
-}
-
-/// Returns true if the given opcode is for a type-declaring instruction.
-pub fn is_type(opcode: spirv::Op) -> bool {
-    matches!(
-        opcode,
-        spirv::Op::TypeVoid
-            | spirv::Op::TypeBool
-            | spirv::Op::TypeInt
-            | spirv::Op::TypeFloat
-            | spirv::Op::TypeVector
-            | spirv::Op::TypeMatrix
-            | spirv::Op::TypeImage
-            | spirv::Op::TypeSampler
-            | spirv::Op::TypeSampledImage
-            | spirv::Op::TypeArray
-            | spirv::Op::TypeRuntimeArray
-            | spirv::Op::TypeStruct
-            | spirv::Op::TypeOpaque
-            | spirv::Op::TypePointer
-            | spirv::Op::TypeFunction
-            | spirv::Op::TypeEvent
-            | spirv::Op::TypeDeviceEvent
-            | spirv::Op::TypeReserveId
-            | spirv::Op::TypeQueue
-            | spirv::Op::TypePipe
-            | spirv::Op::TypeAccelerationStructureKHR
-            | spirv::Op::TypeRayQueryKHR
-            | spirv::Op::TypeForwardPointer
-            | spirv::Op::TypeCooperativeMatrixKHR
-    )
-}
-
-/// Returns true if the given opcode is for a constant-defining instruction.
-pub fn is_constant(opcode: spirv::Op) -> bool {
-    matches!(
-        opcode,
-        spirv::Op::ConstantTrue
-            | spirv::Op::ConstantFalse
-            | spirv::Op::Constant
-            | spirv::Op::ConstantComposite
-            | spirv::Op::ConstantSampler
-            | spirv::Op::ConstantNull
-            | spirv::Op::SpecConstantTrue
-            | spirv::Op::SpecConstantFalse
-            | spirv::Op::SpecConstant
-            | spirv::Op::SpecConstantComposite
-            | spirv::Op::SpecConstantOp
-            | spirv::Op::ConstantCompositeContinuedINTEL
-            | spirv::Op::SpecConstantCompositeContinuedINTEL
-    )
-}
-
-/// Returns true if the given opcode is for a variable-defining instruction.
+/// Returns [`true`] if the given opcode is for a variable-defining instruction.
 pub fn is_variable(opcode: spirv::Op) -> bool {
     opcode == spirv::Op::Variable
 }
 
-/// Returns true if the given opcode is a return instruction.
+/// Returns [`true`] if the given opcode is a return instruction.
 pub fn is_return(opcode: spirv::Op) -> bool {
     matches!(opcode, spirv::Op::Return | spirv::Op::ReturnValue)
 }
 
-/// Returns true if the given opcode aborts execution.
+/// Returns [`true`] if the given opcode aborts execution.
 pub fn is_abort(opcode: spirv::Op) -> bool {
     matches!(
         opcode,
@@ -113,13 +30,16 @@ pub fn is_abort(opcode: spirv::Op) -> bool {
     )
 }
 
-/// Returns true if the given opcode is a return instruction or it aborts
-/// execution.
+/// Returns [`true`] if the given opcode is a return instruction or it aborts execution.
+///
+/// <https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#FunctionTermination>
 pub fn is_return_or_abort(opcode: spirv::Op) -> bool {
     is_return(opcode) || is_abort(opcode)
 }
 
-/// Returns true if the given opcode is a branch instruction.
+/// Returns [`true`] if the given opcode is a branch instruction.
+///
+/// <https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#Branch> and <https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#ConditionalBranch>
 pub fn is_branch(opcode: spirv::Op) -> bool {
     matches!(
         opcode,
@@ -127,7 +47,9 @@ pub fn is_branch(opcode: spirv::Op) -> bool {
     )
 }
 
-/// Returns true if the given opcode is for a terminator instruction.
+/// Returns [`true`] if the given opcode is for a terminator instruction.
+///
+/// <https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#Termination>
 pub fn is_block_terminator(opcode: spirv::Op) -> bool {
     is_branch(opcode) || is_return_or_abort(opcode)
 }

--- a/spirv/autogen_spirv.rs
+++ b/spirv/autogen_spirv.rs
@@ -4199,17 +4199,139 @@ impl Op {
 #[allow(clippy::upper_case_acronyms)]
 #[allow(non_upper_case_globals)]
 impl Op {
-    pub const SDotKHR: Op = Op::SDot;
-    pub const UDotKHR: Op = Op::UDot;
-    pub const SUDotKHR: Op = Op::SUDot;
-    pub const SDotAccSatKHR: Op = Op::SDotAccSat;
-    pub const UDotAccSatKHR: Op = Op::UDotAccSat;
-    pub const SUDotAccSatKHR: Op = Op::SUDotAccSat;
-    pub const ReportIntersectionNV: Op = Op::ReportIntersectionKHR;
-    pub const TypeAccelerationStructureNV: Op = Op::TypeAccelerationStructureKHR;
-    pub const DemoteToHelperInvocationEXT: Op = Op::DemoteToHelperInvocation;
-    pub const DecorateStringGOOGLE: Op = Op::DecorateString;
-    pub const MemberDecorateStringGOOGLE: Op = Op::MemberDecorateString;
+    pub const SDotKHR: Self = Self::SDot;
+    pub const UDotKHR: Self = Self::UDot;
+    pub const SUDotKHR: Self = Self::SUDot;
+    pub const SDotAccSatKHR: Self = Self::SDotAccSat;
+    pub const UDotAccSatKHR: Self = Self::UDotAccSat;
+    pub const SUDotAccSatKHR: Self = Self::SUDotAccSat;
+    pub const ReportIntersectionNV: Self = Self::ReportIntersectionKHR;
+    pub const TypeAccelerationStructureNV: Self = Self::TypeAccelerationStructureKHR;
+    pub const DemoteToHelperInvocationEXT: Self = Self::DemoteToHelperInvocation;
+    pub const DecorateStringGOOGLE: Self = Self::DecorateString;
+    pub const MemberDecorateStringGOOGLE: Self = Self::MemberDecorateString;
+    #[doc = r" Returns [`true`] if the given opcode is a type-declaring instruction."]
+    #[doc = r""]
+    #[doc = r" <https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#_type_declaration_instructions>"]
+    pub fn is_type(self) -> bool {
+        matches!(
+            self,
+            Self::TypeVoid
+                | Self::TypeBool
+                | Self::TypeInt
+                | Self::TypeFloat
+                | Self::TypeVector
+                | Self::TypeMatrix
+                | Self::TypeImage
+                | Self::TypeSampler
+                | Self::TypeSampledImage
+                | Self::TypeArray
+                | Self::TypeRuntimeArray
+                | Self::TypeStruct
+                | Self::TypeOpaque
+                | Self::TypePointer
+                | Self::TypeFunction
+                | Self::TypeEvent
+                | Self::TypeDeviceEvent
+                | Self::TypeReserveId
+                | Self::TypeQueue
+                | Self::TypePipe
+                | Self::TypeForwardPointer
+                | Self::TypePipeStorage
+                | Self::TypeNamedBarrier
+                | Self::TypeUntypedPointerKHR
+                | Self::TypeCooperativeMatrixKHR
+                | Self::TypeRayQueryKHR
+                | Self::TypeNodePayloadArrayAMDX
+                | Self::TypeHitObjectNV
+                | Self::TypeCooperativeVectorNV
+                | Self::TypeAccelerationStructureKHR
+                | Self::TypeCooperativeMatrixNV
+                | Self::TypeTensorLayoutNV
+                | Self::TypeTensorViewNV
+                | Self::TypeBufferSurfaceINTEL
+                | Self::TypeStructContinuedINTEL
+        )
+    }
+    #[doc = r" Returns [`true`] if the given opcode is a constant-defining instruction."]
+    #[doc = r""]
+    #[doc = r" <https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#_constant_creation_instructions>"]
+    pub fn is_constant(self) -> bool {
+        matches!(
+            self,
+            Self::ConstantTrue
+                | Self::ConstantFalse
+                | Self::Constant
+                | Self::ConstantComposite
+                | Self::ConstantSampler
+                | Self::ConstantNull
+                | Self::SpecConstantTrue
+                | Self::SpecConstantFalse
+                | Self::SpecConstant
+                | Self::SpecConstantComposite
+                | Self::SpecConstantOp
+                | Self::ConstantCompositeReplicateEXT
+                | Self::SpecConstantCompositeReplicateEXT
+                | Self::ConstantCompositeContinuedINTEL
+                | Self::SpecConstantCompositeContinuedINTEL
+        )
+    }
+    #[doc = r" Returns [`true`] if the given opcode is an annotation instruction."]
+    #[doc = r""]
+    #[doc = r" <https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#Annotation>"]
+    pub fn is_annotation(self) -> bool {
+        matches!(
+            self,
+            Self::Decorate
+                | Self::MemberDecorate
+                | Self::DecorationGroup
+                | Self::GroupDecorate
+                | Self::GroupMemberDecorate
+                | Self::DecorateId
+                | Self::DecorateString
+                | Self::MemberDecorateString
+        )
+    }
+    #[doc = r" Returns [`true`] if the given opcode is a debug instruction."]
+    #[doc = r""]
+    #[doc = r" <https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#_debug_instructions>"]
+    pub fn is_debug(self) -> bool {
+        matches!(
+            self,
+            Self::SourceContinued
+                | Self::Source
+                | Self::SourceExtension
+                | Self::Name
+                | Self::MemberName
+                | Self::String
+                | Self::Line
+                | Self::NoLine
+                | Self::ModuleProcessed
+        )
+    }
+    #[doc = r" Returns [`true`] if the given opcode is a control-flow instruction."]
+    #[doc = r""]
+    #[doc = r" <https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#_control_flow_instructions>"]
+    pub fn is_control_flow(self) -> bool {
+        matches!(
+            self,
+            Self::Phi
+                | Self::LoopMerge
+                | Self::SelectionMerge
+                | Self::Label
+                | Self::Branch
+                | Self::BranchConditional
+                | Self::Switch
+                | Self::Kill
+                | Self::Return
+                | Self::ReturnValue
+                | Self::Unreachable
+                | Self::LifetimeStart
+                | Self::LifetimeStop
+                | Self::TerminateInvocation
+                | Self::DemoteToHelperInvocation
+        )
+    }
 }
 #[doc = "[GLSL.std.450](https://www.khronos.org/registry/spir-v/specs/unified1/GLSL.std.450.html) extended instruction opcode"]
 #[repr(u32)]


### PR DESCRIPTION
We've had a *lot* of bugs surfacing from the fact that the manual `rspirv::grammar::reflect` module required hand-adding various `spirv` ops to `match` statements to let the code behave, despite being able to very trivially autogenerate this based on the SPIR-V grammar.  By doing so we find quite a few instructions that weren't handled by the hand-written table.  For `is_type()` those are:

- `OpTypePipeStorage`
- `OpTypeNamedBarrier`
- `OpTypeUntypedPointerKHR`
- `OpTypeNodePayloadArrayAMDX`
- `OpTypeHitObjectNV`
- `OpTypeCooperativeVectorNV`
- `OpTypeCooperativeMatrixNV`
- `OpTypeTensorLayoutNV`
- `OpTypeTensorViewNV`
- `OpTypeBufferSurfaceINTEL`
- `OpTypeStructContinuedINTEL`

For `is_constant()`:

- `OpConstantCompositeReplicateEXT`
- `OpSpecConstantCompositeReplicateEXT`

For `is_annotation()`:

- `OpDecorateId`

For `is_debug()` (via `is_nonlocation_debug()`):

- `OpModuleProcessed`

Unfortunately classes only convey the `Control-Flow` marker which doesn't provide enough detail to distinguish between returns, aborts or branches (or anything not specified).  Even if our crates only ever call `is_block_terminator()` which is a composite of all those checks, not all `Control-Flow` opcodes are supposed to be treated as a terminator.