### PR TITLE
spirv: improve documentation detailing SPIR-V specification version

### DIFF
--- a/autogen/src/header.rs
+++ b/autogen/src/header.rs
@@ -2,7 +2,7 @@ use crate::structs;
 use crate::utils::*;
 
 use heck::{ShoutySnakeCase, SnakeCase};
-use proc_macro2::TokenStream;
+use proc_macro2::{Literal, TokenStream};
 use quote::quote;
 use std::cmp::Ordering;
 use std::collections::BTreeMap;
@@ -278,9 +278,9 @@ pub fn gen_spirv_header(grammar: &structs::Grammar) -> TokenStream {
     let magic_number = format!("{:#010X}", grammar.magic_number)
         .parse::<TokenStream>()
         .unwrap();
-    let major_version = grammar.major_version;
-    let minor_version = grammar.minor_version;
-    let revision = grammar.revision;
+    let major_version = Literal::u8_unsuffixed(grammar.major_version);
+    let minor_version = Literal::u8_unsuffixed(grammar.minor_version);
+    let revision = Literal::u8_unsuffixed(grammar.revision);
 
     // Operand kinds.
     let kinds = grammar.operand_kinds.iter().filter_map(gen_operand_kind);
@@ -339,9 +339,10 @@ pub fn gen_spirv_header(grammar: &structs::Grammar) -> TokenStream {
         //pub use crate::grammar::{OperandKind, OperandQuantifier, LogicalOperand};
         pub type Word = u32;
         pub const MAGIC_NUMBER: u32 = #magic_number;
-        pub const MAJOR_VERSION: u8 = #major_version;
-        pub const MINOR_VERSION: u8 = #minor_version;
-        pub const REVISION: u8 = #revision;
+
+        macro_rules! version_major { () => { #major_version } }
+        macro_rules! version_minor { () => { #minor_version } }
+        macro_rules! version_revision { () => { #revision } }
 
         #(#kinds)*
 

--- a/spirv/autogen_spirv.rs
+++ b/spirv/autogen_spirv.rs
@@ -4,9 +4,21 @@
 
 pub type Word = u32;
 pub const MAGIC_NUMBER: u32 = 0x07230203;
-pub const MAJOR_VERSION: u8 = 1u8;
-pub const MINOR_VERSION: u8 = 6u8;
-pub const REVISION: u8 = 4u8;
+macro_rules! version_major {
+    () => {
+        1
+    };
+}
+macro_rules! version_minor {
+    () => {
+        6
+    };
+}
+macro_rules! version_revision {
+    () => {
+        4
+    };
+}
 bitflags! { # [doc = "SPIR-V operand kind: [ImageOperands](https://www.khronos.org/registry/spir-v/specs/unified1/SPIRV.html#_a_id_image_operands_a_image_operands)"] # [derive (Clone , Copy , Debug , PartialEq , Eq , Hash)] # [cfg_attr (feature = "serialize" , derive (serde :: Serialize))] # [cfg_attr (feature = "deserialize" , derive (serde :: Deserialize))] pub struct ImageOperands : u32 { const NONE = 0u32 ; const BIAS = 1u32 ; const LOD = 2u32 ; const GRAD = 4u32 ; const CONST_OFFSET = 8u32 ; const OFFSET = 16u32 ; const CONST_OFFSETS = 32u32 ; const SAMPLE = 64u32 ; const MIN_LOD = 128u32 ; const MAKE_TEXEL_AVAILABLE = 256u32 ; const MAKE_TEXEL_VISIBLE = 512u32 ; const NON_PRIVATE_TEXEL = 1024u32 ; const VOLATILE_TEXEL = 2048u32 ; const SIGN_EXTEND = 4096u32 ; const ZERO_EXTEND = 8192u32 ; const NONTEMPORAL = 16384u32 ; const OFFSETS = 65536u32 ; } }
 bitflags! { # [doc = "SPIR-V operand kind: [FPFastMathMode](https://www.khronos.org/registry/spir-v/specs/unified1/SPIRV.html#_a_id_fp_fast_math_mode_a_fp_fast_math_mode)"] # [derive (Clone , Copy , Debug , PartialEq , Eq , Hash)] # [cfg_attr (feature = "serialize" , derive (serde :: Serialize))] # [cfg_attr (feature = "deserialize" , derive (serde :: Deserialize))] pub struct FPFastMathMode : u32 { const NONE = 0u32 ; const NOT_NAN = 1u32 ; const NOT_INF = 2u32 ; const NSZ = 4u32 ; const ALLOW_RECIP = 8u32 ; const FAST = 16u32 ; const ALLOW_CONTRACT = 65536u32 ; const ALLOW_REASSOC = 131072u32 ; const ALLOW_TRANSFORM = 262144u32 ; } }
 bitflags! { # [doc = "SPIR-V operand kind: [SelectionControl](https://www.khronos.org/registry/spir-v/specs/unified1/SPIRV.html#_a_id_selection_control_a_selection_control)"] # [derive (Clone , Copy , Debug , PartialEq , Eq , Hash)] # [cfg_attr (feature = "serialize" , derive (serde :: Serialize))] # [cfg_attr (feature = "deserialize" , derive (serde :: Deserialize))] pub struct SelectionControl : u32 { const NONE = 0u32 ; const FLATTEN = 1u32 ; const DONT_FLATTEN = 2u32 ; } }

--- a/spirv/lib.rs
+++ b/spirv/lib.rs
@@ -3,7 +3,12 @@
 //! This crate contains Rust definitions of all SPIR-V structs, enums,
 //! and constants.
 //!
-//! The version of this crate is the version of SPIR-V it contains.
+//! The version-metadata of this crate specifies the [SPIRV-Headers] git-tag
+//! it is generated from. The corresponding SPIR-V specification is
+#![doc = concat!("Version ", version_major!(), ".", version_minor!())]
+#![doc = concat!("Revision ", version_revision!(), ".")]
+//!
+//! [SPIRV-Headers]: https://github.com/KhronosGroup/SPIRV-Headers
 
 #![no_std]
 #![allow(non_camel_case_types)]
@@ -12,7 +17,12 @@
 
 use bitflags::bitflags;
 
+pub const MAJOR_VERSION: u8 = version_major!();
+pub const MINOR_VERSION: u8 = version_minor!();
+pub const REVISION: u8 = version_revision!();
+
 include!("autogen_spirv.rs");
+pub(crate) use {version_major, version_minor, version_revision};
 
 impl From<Op> for Word {
     // Exists because of repr()


### PR DESCRIPTION
I was a little bit confused when trying to understand what version of the spir-v specification the `spirv` crates corresponds to. 

This patch includes the SPIR-V specification version in the `spirv` crate documentation explicitly, and further clarifies that the version-metadata corresponds to the git tag of the SPIRV-HEADERS repository.